### PR TITLE
Require the gettext php extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
         "twitter/bootstrap": "3.0.0",
         "twitter/typeahead.js": "v0.10.2",
         "willdurand/negotiation": "1.3.1",
-        "ml/json-ld": "1.*"
+        "ml/json-ld": "1.*",
+        "ext-gettext": "*"
     },
     "require-dev": {
         "umpirsky/twig-gettext-extractor": "1.1.*",


### PR DESCRIPTION
Used by e.g. the bindtextdomain() function
