### PR TITLE
Simplify/fix parsing of 'type' in REST API search

### DIFF
--- a/controller/RestController.php
+++ b/controller/RestController.php
@@ -169,11 +169,7 @@ class RestController extends Controller
     $vocid = isset($_GET['vocab']) ? $_GET['vocab'] : $vocab; # optional
     $lang = isset($_GET['lang']) ? $_GET['lang'] : null; # optional
     $labellang = isset($_GET['labellang']) ? $_GET['labellang'] : null; # optional
-    $type = isset($_GET['type']) ? $_GET['type'] : array('skos:Concept');
-    if ($type && strpos($type, '+'))
-      $type = explode('+',$type);
-    else if ($type && !is_array($type)) // if only one type param given place it into an array regardless
-      $type = array($type);
+    $types = isset($_GET['type']) ? explode(' ', $_GET['type']) : array('skos:Concept');
     $parent = isset($_GET['parent']) ? $_GET['parent'] : null;
     $group = isset($_GET['group']) ? $_GET['group'] : null;
     $fields = isset($_GET['fields']) ? explode(' ', $_GET['fields']) : null;
@@ -183,7 +179,7 @@ class RestController extends Controller
 
     $maxhits = isset($_GET['maxhits']) ? ($_GET['maxhits']) : null; # optional
     $offset = isset($_GET['offset']) ? ($_GET['offset']) : 0; # optional
-    $results = $this->model->searchConcepts($term, $vocids, $labellang, $lang, $type, $parent, $group, $offset, $maxhits, true, $fields);
+    $results = $this->model->searchConcepts($term, $vocids, $labellang, $lang, $types, $parent, $group, $offset, $maxhits, true, $fields);
     // before serializing to JSON, get rid of the Vocabulary object that came with each resource
     foreach ($results as &$res) {
       unset($res['voc']);


### PR DESCRIPTION
- `strpos()` expects a string and throws a warning when given
  an array.
- For consistency with the other fields, assume $_GET['type'] isn't
  an array already, and split by ' '.
- Rename from `type` to `types` to make it explicit that it's an array

I think this should be fine unless you expect urls like `type[]=someType&type[]=someOtherType`, but it seems a bit inconsistent to allow two different ways of encoding the same information.
