### PR TITLE
Fall back on localName if vocabulary hasn't any labels

### DIFF
--- a/model/VocabularyCategory.php
+++ b/model/VocabularyCategory.php
@@ -23,7 +23,8 @@ class VocabularyCategory extends DataObject
    */
   public function getTitle()
   {
-    return $this->resource->label($this->lang)->getValue();
+    $label = $this->resource->label($this->lang);
+    return is_null($label) ? $this->resource->localName() : $label->getValue();
   }
 
 }


### PR DESCRIPTION
I got a fatal error when I forgot to add a prefLabel to vocabularies.ttl for one of my vocabularies