### PR TITLE
Add support for RDF collections

### DIFF
--- a/model/Model.php
+++ b/model/Model.php
@@ -12,6 +12,7 @@ EasyRdf_Namespace::set('skosmos', 'http://purl.org/net/skosmos#');
 EasyRdf_Namespace::set('void', 'http://rdfs.org/ns/void#');
 EasyRdf_Namespace::set('skosext', 'http://purl.org/finnonto/schema/skosext#');
 EasyRdf_Namespace::set('isothes', 'http://purl.org/iso25964/skos-thes#');
+EasyRdf_Namespace::set('mads', 'http://www.loc.gov/mads/rdf/v1#');
 
 /**
  * Model provides access to the data.

--- a/model/sparql/GenericSparql.php
+++ b/model/sparql/GenericSparql.php
@@ -288,6 +288,10 @@ CONSTRUCT {
  ?directgroup skos:member ?uri .
  ?parent skos:member ?group .
  ?group skos:prefLabel ?grouplabel .
+ ?b1 rdf:first ?item .
+ ?b1 rdf:rest ?b2 .
+ ?item rdf:type ?it .
+ ?item skos:prefLabel ?il .
  ?group rdf:type ?grouptype . $construct
 } WHERE {
  $gc {
@@ -305,6 +309,13 @@ CONSTRUCT {
   UNION
   {
    ?uri ?p ?o .
+   OPTIONAL {
+     ?o rdf:rest* ?b1 .
+     ?b1 rdf:first ?item .
+     ?b1 rdf:rest ?b2 .
+     OPTIONAL { ?item rdf:type ?it . }
+     OPTIONAL { ?item skos:prefLabel ?il . }
+   }
    OPTIONAL {
      { ?p rdfs:label ?proplabel . }
      UNION

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -452,7 +452,44 @@ test:ta116
     $expectedGraph->parse($expected, "rdfxml");
     $this->assertTrue(EasyRdf_Isomorphic::isomorphic($resultGraph, $expectedGraph));
   }
-  
+
+  /**
+   * @covers Model::getRDF
+   * @depends testConstructorWithConfig
+   */
+  public function testGetRDFShouldIncludeLists() {
+    $model = new Model();
+    $result = $model->getRDF('test', 'http://www.skosmos.skos/test/ta124', 'text/turtle');
+    $resultGraph = new EasyRdf_Graph();
+    $resultGraph->parse($result, "turtle");
+
+    $expected = '@prefix test: <http://www.skosmos.skos/test/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix mads: <http://www.loc.gov/mads/rdf/v1#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+skos:prefLabel rdfs:label "preferred label"@en .
+
+test:ta124
+  a mads:ComplexSubject, skos:Concept ;
+  skos:prefLabel "Vadefugler : Europa"@nb ;
+  mads:componentList ( test:ta125 test:ta126 ) .
+
+test:ta125
+  a mads:Topic, skos:Concept ;
+  skos:prefLabel "Vadefugler"@nb .
+
+test:ta126
+  a mads:Geographic, skos:Concept ;
+  skos:prefLabel "Europa"@nb .
+
+';
+
+    $expectedGraph = new EasyRdf_Graph();
+    $expectedGraph->parse($expected, "turtle");
+    $this->assertTrue(EasyRdf_Isomorphic::isomorphic($resultGraph, $expectedGraph));
+  }
+
   /**
    * @covers Model::getLanguages
    * @depends testConstructorWithConfig

--- a/tests/test-vocab-data/test.ttl
+++ b/tests/test-vocab-data/test.ttl
@@ -10,6 +10,7 @@
 @prefix skosmos: <http://www.skosmos.skos/> .
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix mads: <http://www.loc.gov/mads/rdf/v1#> .
 
 meta:TestClass a owl:Class ;
     rdfs:subClassOf skos:Concept ;
@@ -107,6 +108,19 @@ test:ta123 a skos:Concept, meta:TestClass ;
     skos:broader test:ta118, test:ta119 ;
     skos:inScheme test:conceptscheme ;
     skos:prefLabel "multiple broaders"@en .
+
+test:ta124
+  a mads:ComplexSubject, skos:Concept ;
+  skos:prefLabel "Vadefugler : Europa"@nb ;
+  mads:componentList ( test:ta125 test:ta126 ) .
+
+test:ta125
+  a mads:Topic, skos:Concept ;
+  skos:prefLabel "Vadefugler"@nb .
+
+test:ta126
+  a mads:Geographic, skos:Concept ;
+  skos:prefLabel "Europa"@nb .
 
 test:ta1 a skos:Concept, meta:TestClass ;
     skos:inScheme test:conceptscheme ;


### PR DESCRIPTION
## Background

Our vocabulary is postcoordinated, so we have concepts like `Vadefugler : Europa` made up from (any number of) other concepts (`Vadefugler` and `Europa`) having their own URIs. When modelling the complex concepts as RDF, we need to express the relationship to the components in some way. And the component list has to be *ordered*… So I turned to RDF collections – feeling a bit uneasy about it since it involves bnodes, but the nice Turtle syntax calmed me down a bit. I also found that MADS already had a property ready for me to use (`mads:componentList`).

## The issue

Given the following data:

```turtle
realfagstermer:c015805
  mads:componentList ( realfagstermer:c005287 realfagstermer:c030200 ) ;
  skos:prefLabel "Vadefugler : Europa"@nb ;
  a mads:ComplexSubject, skos:Concept .
```

, the Skosmos `/data` method returns:

```turtle
realfagstermer:c015805
  mads:componentList [ ] ;
  skos:prefLabel "Vadefugler : Europa"@nb ;
  a mads:ComplexSubject, skos:Concept .
```

not including the collection, just the head blank node from the list. So I've tried to put together a fix for this. Let me know what you think.

Test: https://skosmos.biblionaut.net/rest/v1/realfagstermer/data?uri=http%3A%2F%2Fdata.ub.uio.no%2Frealfagstermer%2Fc018315&format=text/turtle
