### PR TITLE
Filter out blank nodes as subject

### DIFF
--- a/model/sparql/GenericSparql.php
+++ b/model/sparql/GenericSparql.php
@@ -298,7 +298,10 @@ CONSTRUCT {
  ?group a ?grouptype . $construct
 } WHERE {
  $gc {
-  { ?s ?p ?uri . }
+  {
+    ?s ?p ?uri .
+    FILTER(!isBlank(?s))
+  }
   UNION
   { ?sp ?uri ?op . }
   UNION

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -495,6 +495,34 @@ test:ta126
   }
 
   /**
+   * @covers Model::getRDF
+   * @depends testConstructorWithConfig
+   * Issue: https://github.com/NatLibFi/Skosmos/pull/419
+   */
+  public function testGetRDFShouldNotIncludeExtraBlankNodesFromLists() {
+    $model = new Model(new GlobalConfig('/../tests/testconfig.inc'));
+    $result = $model->getRDF('test', 'http://www.skosmos.skos/test/ta125', 'text/turtle');
+    $resultGraph = new EasyRdf_Graph();
+    $resultGraph->parse($result, "turtle");
+
+    $expected = '@prefix test: <http://www.skosmos.skos/test/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix mads: <http://www.loc.gov/mads/rdf/v1#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+skos:prefLabel rdfs:label "preferred label"@en .
+
+test:ta125
+  a mads:Topic, skos:Concept ;
+  skos:prefLabel "Vadefugler"@nb .
+';
+
+    $expectedGraph = new EasyRdf_Graph();
+    $expectedGraph->parse($expected, "turtle");
+    $this->assertTrue(EasyRdf_Isomorphic::isomorphic($resultGraph, $expectedGraph));
+  }
+
+  /**
    * @covers Model::getLanguages
    * @depends testConstructorWithConfig
    */


### PR DESCRIPTION
Fixes a side effect of #369 . 

Given

    test:ta124 mads:componentList ( test:ta125 test:ta126 ) .

, when querying for info about `test:ta125` or `test:ta126`, the result would include a blank node `rdf:first` statement:

```
test:ta125
  a mads:Topic, skos:Concept ;
  skos:prefLabel "Vadefugler"@nb .

[] rdf:first test:ta125 .
````
