### PR TITLE
Use lastIndexOf instead of indexOf

### DIFF
--- a/resource/js/scripts.js
+++ b/resource/js/scripts.js
@@ -250,7 +250,7 @@ function makeCallbacks(data, pageType) {
 
   var variables = data ? data.substring(data.indexOf('var uri ='), data.indexOf('var uriSpace =')).split('\n') : '';
   var newUri = data ? variables[0].substring(variables[0].indexOf('"')+1, variables[0].indexOf(';')-1) : window.uri;
-  var newPrefs = data ? JSON.parse(variables[1].substring(variables[1].indexOf('['), variables[1].indexOf(']')+1)) : window.prefLabels;
+  var newPrefs = data ? JSON.parse(variables[1].substring(variables[1].indexOf('['), variables[1].lastIndexOf(']')+1)) : window.prefLabels;
   var params = {'uri': newUri, 'prefLabels': newPrefs, 'page': pageType};
 
   if (window.pluginCallbacks) {


### PR DESCRIPTION
For issue #597, use lastIndexOf instead of indexOf.

The issue reported had the following in console:

    JSON.parse(variables[1].substring(variables[1].indexOf('['), variables[1].indexOf(']')+1))

Where variables[1] = "var prefLabels = [{"lang": "fi","label": "[cadency 5] annulet (en)"}];"

Due to another "]" character in the string, JSON parser would fail to parse just "[{"lang": "fi","label": "[cadency 5".