### PR TITLE
issue #594 add a honeypot

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,9 @@
     "phpunit/phpunit": "4.8 - 5.1",
     "umpirsky/twig-gettext-extractor": "1.1.*",
     "phpdocumentor/phpdocumentor": "2.*",
-    "codeclimate/php-test-reporter": "0.3.2"
+    "codeclimate/php-test-reporter": "0.3.2",
+    "symfony/dom-crawler": "3.2.6",
+    "mockery/mockery": "1.0.0-alpha1"
   },
   "autoload": {
     "classmap": ["controller/", "model/", "model/sparql/"]

--- a/config.inc.dist
+++ b/config.inc.dist
@@ -60,3 +60,9 @@ define("CUSTOM_CSS", "resource/css/stylesheet.css");
 
 // whether to display the ui language selection as a dropdown (useful for cases where there are more than 3 languages) 
 define("UI_LANGUAGE_DROPDOWN", FALSE);
+
+// whether to enable the spam honey pot or not
+define("UI_HONEYPOT_ENABLED", TRUE);
+
+// default time a user must wait before submitting a form
+define("UI_HONEYPOT_TIME", 5);

--- a/controller/Honeypot.php
+++ b/controller/Honeypot.php
@@ -1,0 +1,94 @@
+<?php
+
+/**
+ * Original class from msurguy/Honeypot. Licensed under the MIT License. Instead of using Laravel Crypt class,
+ * this implementation simply returns the decrypted value base64-encoded, as the encoded value.
+ * @see https://github.com/msurguy/Honeypot
+ */
+class Honeypot
+{
+    protected $disabled = false;
+    /**
+     * Enable the Honeypot validation
+     */
+    public function enable()
+    {
+        $this->disabled = false;
+    }
+    /**
+     * Disable the Honeypot validation
+     */
+    public function disable()
+    {
+        $this->disabled = true;
+    }
+    /**
+     * Generate a new honeypot and return the form HTML
+     * @param  string $honey_name
+     * @param  string $honey_time
+     * @return string
+     */
+    public function generate($honey_name, $honey_time)
+    {
+        // Encrypt the current time
+        $honey_time_encrypted = $this->getEncryptedTime();
+        $html = '<div id="' . $honey_name . '_wrap" style="display:none;">' . "\r\n" .
+                    '<input name="' . $honey_name . '" type="text" value="" id="' . $honey_name . '"/>' . "\r\n" .
+                    '<input name="' . $honey_time . '" type="text" value="' . $honey_time_encrypted . '"/>' . "\r\n" .
+                '</div>';
+        return $html;
+    }
+    /**
+    * Validate honeypot is empty
+    *
+    * @param  mixed $value
+    * @return boolean
+    */
+    public function validateHoneypot($value)
+    {
+        if ($this->disabled) {
+            return true;
+        }
+        return $value == '';
+    }
+    /**
+     * Validate honey time was within the time limit
+     *
+     * @param  mixed $value
+     * @param  array $parameters
+     * @return boolean
+     */
+    public function validateHoneytime($value, $parameters)
+    {
+        if ($this->disabled) {
+            return true;
+        }
+        
+        // Get the decrypted time
+        $value = $this->decryptTime($value);
+        // The current time should be greater than the time the form was built + the speed option
+        return ( is_numeric($value) && time() > ($value + $parameters[0]) );
+    }
+    /**
+     * Get encrypted time
+     * @return string
+     */
+    public function getEncryptedTime()
+    {
+        return base64_encode(time());
+    }
+    /**
+     * Decrypt the given time
+     *
+     * @param  mixed $time
+     * @return string|null
+     */
+    public function decryptTime($time)
+    {
+        try {
+            return base64_decode($time);
+        } catch (\Exception $exception) {
+            return null;
+        }
+    }
+}

--- a/model/GlobalConfig.php
+++ b/model/GlobalConfig.php
@@ -224,4 +224,20 @@ class GlobalConfig {
         return explode(' ', $this->getConstant('GLOBAL_PLUGINS', null));
     }
     
+    /**
+     * @return boolean
+     */
+    public function getHoneypotEnabled()
+    {
+        return $this->getConstant('UI_HONEYPOT_ENABLED', TRUE);
+    }
+
+    /**
+     * @return integer
+     */
+    public function getHoneypotTime()
+    {
+        return $this->getConstant('UI_HONEYPOT_TIME', 5);
+    }
+    
 }

--- a/resource/css/styles.css
+++ b/resource/css/styles.css
@@ -658,10 +658,6 @@ ul.dropdown-menu > li:last-child > input {
   height: 150px;
 }
 
-#feedback-fields > input:last-of-type {
-  display: none;
-}
-
 #feedback-fields > .dropdown {
   margin-bottom: 10px;
 }

--- a/tests/FeedbackTest.php
+++ b/tests/FeedbackTest.php
@@ -1,0 +1,203 @@
+<?php
+
+use Symfony\Component\DomCrawler\Crawler;
+
+class FeedbackTest extends PHPUnit_Framework_TestCase
+{
+  private $model;
+  private $request;
+
+  protected function setUp() {
+    $config = new GlobalConfig('/../tests/testconfig.inc');
+    $this->model = new Model($config);
+    $this->request = \Mockery::mock('Request', array($this->model))->makePartial();
+    $this->request->setLang('en');
+    $this->controller = \Mockery::mock('WebController[sendFeedback]', array($this->model))->makePartial();
+  }
+
+  /**
+   * @covers Honeypot::decryptTime
+   * @covers Honeypot::generate
+   * @covers Honeypot::getEncryptedTime
+   */
+  public function testHoneypotFieldsGenerated() {
+    $initialTime = time();
+    ob_start();
+    $this->controller->invokeFeedbackForm($this->request);
+    $html = ob_get_contents();
+    ob_end_clean();
+
+    $crawler = new Crawler($html);
+    $mustBeEmptyHoneypot = $crawler->filterXPath("//input[@name='item-description']");
+    $value = $mustBeEmptyHoneypot->attr('value');
+    $this->assertEquals('', $value);
+
+    // the encrypted time will be at least equal, if not greater, than the initial time recorded
+    $timeBaseHoneypot = $crawler->filterXPath("//input[@name='user-captcha']");
+    $encryptedTime = $timeBaseHoneypot->attr('value');
+    $decryptedTime = intval($this->controller->honeypot->decryptTime($encryptedTime));
+    $this->assertTrue($decryptedTime >= $initialTime);
+  }
+
+  /**
+   * @covers Honeypot::validateHoneypot
+   * @covers Honeypot::validateHoneytime
+   */
+  public function testHoneypotAndHoneypot() {
+    $this->request
+        ->shouldReceive('getQueryParamPOST')
+        ->with('message')
+        ->andReturn('Test message');
+    $this->request
+        ->shouldReceive('getQueryParamPOST')
+        ->with('name')
+        ->andReturn('Test name');
+    $this->request
+        ->shouldReceive('getQueryParamPOST')
+        ->with('email')
+        ->andReturn('test@example.com');
+    $this->request
+        ->shouldReceive('getQueryParamPOST')
+        ->with('vocab')
+        ->andReturn('Test vocab');
+    $this->request
+        ->shouldReceive('getQueryParamPOST')
+        ->with('item-description')
+        ->andReturn('');
+    $this->request
+        ->shouldReceive('getQueryParamPOST')
+        ->with('user-captcha')
+        ->andReturn(base64_encode(time() - 5 * 60));
+    $this->controller
+        ->shouldReceive('sendFeedback')
+        ->withAnyArgs()
+        ->once()
+        ->andReturn(true);
+    ob_start();
+    $this->controller->invokeFeedbackForm($this->request);
+    ob_end_clean();
+    \Mockery::close();
+  }
+
+  /**
+   * @covers Honeypot::validateHoneypot
+   * @covers Honeypot::validateHoneytime
+   */
+  public function testHoneypotAndHoneypotDisabled() {
+    $this->controller->honeypot->disable();
+    $this->request
+        ->shouldReceive('getQueryParamPOST')
+        ->with('message')
+        ->andReturn('Test message');
+    $this->request
+        ->shouldReceive('getQueryParamPOST')
+        ->with('name')
+        ->andReturn('Test name');
+    $this->request
+        ->shouldReceive('getQueryParamPOST')
+        ->with('email')
+        ->andReturn('test@example.com');
+    $this->request
+        ->shouldReceive('getQueryParamPOST')
+        ->with('vocab')
+        ->andReturn('Test vocab');
+    $this->request
+        ->shouldReceive('getQueryParamPOST')
+        ->with('item-description')
+        // supposed to be empty
+        ->andReturn('Test item description');
+    $this->request
+        ->shouldReceive('getQueryParamPOST')
+        ->with('user-captcha')
+        // 0 seconds ago is less than the default 5 seconds
+        ->andReturn(base64_encode(time() - 0 * 60));
+    $this->controller
+        ->shouldReceive('sendFeedback')
+        ->withAnyArgs()
+        ->once()
+        ->andReturn(true);
+    ob_start();
+    $this->controller->invokeFeedbackForm($this->request);
+    ob_end_clean();
+    \Mockery::close();
+  }
+
+  /**
+   * @covers Honeypot::validateHoneytime
+   */
+  public function testHoneytimeTooFast() {
+    $this->request
+        ->shouldReceive('getQueryParamPOST')
+        ->with('message')
+        ->andReturn('Test message');
+    $this->request
+        ->shouldReceive('getQueryParamPOST')
+        ->with('name')
+        ->andReturn('Test name');
+    $this->request
+        ->shouldReceive('getQueryParamPOST')
+        ->with('email')
+        ->andReturn('test@example.com');
+    $this->request
+        ->shouldReceive('getQueryParamPOST')
+        ->with('vocab')
+        ->andReturn('Test vocab');
+    $this->request
+        ->shouldReceive('getQueryParamPOST')
+        ->with('item-description')
+        ->andReturn('');
+    $this->request
+        ->shouldReceive('getQueryParamPOST')
+        ->with('user-captcha')
+        // 0 seconds ago is less than the default 5 seconds
+        ->andReturn(base64_encode(time() - 0 * 60));
+    $this->controller
+        ->shouldReceive('sendFeedback')
+        ->withAnyArgs()
+        ->never();
+    ob_start();
+    $this->controller->invokeFeedbackForm($this->request);
+    ob_end_clean();
+    \Mockery::close();
+  }
+
+  /**
+   * @covers Honeypot::validateHoneypot
+   */
+  public function testHoneypotNotEmpty() {
+    $this->request
+        ->shouldReceive('getQueryParamPOST')
+        ->with('message')
+        ->andReturn('Test message');
+    $this->request
+        ->shouldReceive('getQueryParamPOST')
+        ->with('name')
+        ->andReturn('Test name');
+    $this->request
+        ->shouldReceive('getQueryParamPOST')
+        ->with('email')
+        ->andReturn('test@example.com');
+    $this->request
+        ->shouldReceive('getQueryParamPOST')
+        ->with('vocab')
+        ->andReturn('Test vocab');
+    $this->request
+        ->shouldReceive('getQueryParamPOST')
+        ->with('item-description')
+        // supposed to be empty
+        ->andReturn('Test item description');
+    $this->request
+        ->shouldReceive('getQueryParamPOST')
+        ->with('user-captcha')
+        ->andReturn(base64_encode(time() - 5 * 60));
+    $this->controller
+        ->shouldReceive('sendFeedback')
+        ->withAnyArgs()
+        ->never();
+    ob_start();
+    $this->controller->invokeFeedbackForm($this->request);
+    ob_end_clean();
+    \Mockery::close();
+  }
+
+}

--- a/view/feedback.twig
+++ b/view/feedback.twig
@@ -36,7 +36,7 @@
         <input id="email" class="form-control" type ="text" size="40" name="email" placeholder="{% trans %}Enter your e-mail address{% endtrans %}">
         <p>{% trans %}Message:{% endtrans %} *</p>
         <textarea id="message" class="form-control" name="message"></textarea>
-        <input name="trap" type ="text" size="40" placeholder="{% trans %}Leave this field blank{% endtrans %}">
+        {{ honeypot.generate('item-description', 'user-captcha')|raw }}
         <button type="submit" class="btn btn-primary" id="send-feedback">{% trans %}Send feedback{% endtrans %}</button>
       </form>
     {% endif %}


### PR DESCRIPTION
This pull request adds a honey pot to Skosmos. See issue #594 for more. It adds two configurations too. Would be useful for users to later add a section in the web site about these new parameters, and instruct them to tweak the values (adding more parameters, or changing the default time threshold).

The honey pot is based on [msurguy/Honeypot](https://github.com/msurguy/Honeypot) module for Laravel, also licensed under the MIT Licence. The main difference being that instead of using Laravel's Crypt class, it simply base64 the server's current time.

There are two types of honey pots. In the first honey pot, a certain value must be empty. Otherwise the request is considered invalid. The user will receive a message of OK, but no e-mail will be sent (as with the previous trap field).

The second honey pot, called also a honey time, is based on time. This field contains the server base64 encoded time. The default threshold is 5 seconds. If any feedback form is submitted in less than 5 seconds, the request is then discarded.

The reason for using base64 was for simplicity. I think we could also use mcrypt, or some other hash algorithm, but preferred to keep the pull request simple, but it can be changed later (feel free to update this pull request, I'm checking "Allow edits from maintainers").

Simple unit test included. I could not find another test for a controller, so had to include a few libraries under Composer's require-dev entry. One for mocking certain methods (like sendFeedback), and another library for parsing HTML. The feedback page's HTML contain a `footer` tag that PHP's default DOMDocument fails to parse.

Hope that helps.

Cheers
Bruno