### PR TITLE
[WIP] Add options to query Jena Text endpoints with a collation function

### DIFF
--- a/config.inc.dist
+++ b/config.inc.dist
@@ -66,3 +66,6 @@ define("UI_HONEYPOT_ENABLED", TRUE);
 
 // default time a user must wait before submitting a form
 define("UI_HONEYPOT_TIME", 5);
+
+// whether to enable collation in sparql queries
+define("SPARQL_COLLATION_ENABLED", FALSE);

--- a/model/GlobalConfig.php
+++ b/model/GlobalConfig.php
@@ -239,5 +239,12 @@ class GlobalConfig {
     {
         return $this->getConstant('UI_HONEYPOT_TIME', 5);
     }
-    
+
+    /**
+     * @return boolean
+     */
+    public function getCollationEnabled()
+    {
+        return $this->getConstant('SPARQL_COLLATION_ENABLED', FALSE);
+    }
 }

--- a/tests/GlobalConfigTest.php
+++ b/tests/GlobalConfigTest.php
@@ -162,5 +162,13 @@ class GlobalConfigTest extends PHPUnit_Framework_TestCase
     $actual = $this->config->getVocabularyConfigFile();
     $this->assertEquals('tests/testvocabularies.ttl', $actual);
   }
+
+  /**
+   * @covers GlobalConfig::getCollationEnabled
+   */
+  public function testGetCollationEnabled() {
+    $actual = $this->config->getCollationEnabled();
+    $this->assertFalse($actual);
+  }
 }
 

--- a/tests/JenaTextSparqlTest.php
+++ b/tests/JenaTextSparqlTest.php
@@ -174,4 +174,29 @@ class JenaTextSparqlTest extends PHPUnit_Framework_TestCase
     $this->assertEquals('Bass', $actual[0]['prefLabel']);
   }
 
+  /**
+   * @covers JenaTextSparql::formatOrderBy
+   */
+  public function testQueryConceptsAlphabeticalOrderBy() {
+    $vocab = $this->model->getVocabulary('collation');
+    $graph = $vocab->getGraph();
+    $sparql = new JenaTextSparql('http://localhost:3030/ds/sparql', $graph, $this->model);
+    $actual = $sparql->queryConceptsAlphabetical('t', 'fi');
+    $expected = array (
+      0 => array (
+        'uri' => 'http://www.skosmos.skos/collation/val1',
+        'localname' => 'val1',
+        'prefLabel' => 'tšekin kieli',
+        'lang' => 'fi',
+      ),
+      1 => array (
+        'uri' => 'http://www.skosmos.skos/collation/val2',
+        'localname' => 'val2',
+        'prefLabel' => 'töyhtöhyyppä',
+        'lang' => 'fi',
+      )
+    );
+    $this->assertEquals($expected, $actual);
+  }
+
 }

--- a/tests/jenatestconfig.inc
+++ b/tests/jenatestconfig.inc
@@ -2,3 +2,4 @@
 
 define("VOCABULARIES_FILE", "tests/testvocabularies.ttl");
 define("DEFAULT_SPARQL_DIALECT", "JenaText");
+define("SPARQL_COLLATION_ENABLED", TRUE);

--- a/tests/test-vocab-data/collation.ttl
+++ b/tests/test-vocab-data/collation.ttl
@@ -1,0 +1,34 @@
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix dc11: <http://purl.org/dc/elements/1.1/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix collation: <http://www.skosmos.skos/collation/> .
+@prefix meta: <http://www.skosmos.skos/test-meta/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix skosmos: <http://www.skosmos.skos/> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix mads: <http://www.loc.gov/mads/rdf/v1#> .
+
+skos:prefLabel a rdf:Property ;
+    rdfs:label "preferred label"@en .
+
+skos:altLabel a rdf:Property ;
+    rdfs:label "alternative label"@en .
+
+skos:scopeNote a rdf:Property ;
+    rdfs:label "scope note"@en .
+
+skos:broader a rdf:Property ;
+    rdfs:label "has broader"@en .
+
+skos:narrower a rdf:Property ;
+    rdfs:label "has narrower"@en .
+
+collation:val1 a skos:Concept ;
+    skos:prefLabel "tšekin kieli"@fi .
+
+collation:val2 a skos:Concept ;
+    skos:prefLabel "töyhtöhyyppä"@fi .

--- a/tests/testvocabularies.ttl
+++ b/tests/testvocabularies.ttl
@@ -143,6 +143,14 @@
 	skosmos:sparqlGraph <http://www.skosmos.skos/subtag/> ;
 	skosmos:sparqlDialect "JenaText" .
 
+:collation a skosmos:Vocabulary, void:Dataset ;
+    dc11:title "A vocabulary for test SPARQL with collation"@en ;
+    dc:subject :cat_general ;
+    void:uriSpace "http://www.skosmos.skos/collation/";
+    void:sparqlEndpoint <http://localhost:3030/ds/sparql> ;
+    skosmos:language "fi";
+    skosmos:sparqlGraph <http://www.skosmos.skos/collation/> .
+
 
 <http://skosmos.skos/dump/test/groups> dc:format "application/rdf+xml" .
 


### PR DESCRIPTION
We need to wait until the new version of Jena is released for testing and publishing a new version of Skosmos with this feature.

But for now we can start reviewing the code :-) I have 2 tests failing, one regarding time in UTC, and which I assume works fine  in Travis-CI.

The other test that fails, is the new test added in this PR for the order of elements returned using a collation. However, this test passes when I run with `phpunit --filter ...`. Only when executed with the other tests it fail.

I couldn't find the reason tonight, but will revisit this later. Will be necessary to update the shell script that downloads fuseki1, or maybe use the new embedded server instead.