### PR TITLE
Fix ShellCheck issues, and use Jena 3.4.0 for tests

### DIFF
--- a/tests/init_fuseki.sh
+++ b/tests/init_fuseki.sh
@@ -1,33 +1,34 @@
+#!/bin/bash
 # Note: This script must be sourced from within bash, e.g. ". init_fuseki.sh"
 
-FUSEKI_VERSION=${FUSEKI_VERSION:-1.3.0}
+FUSEKI_VERSION=${FUSEKI_VERSION:-3.4.0}
 
 if [ "$FUSEKI_VERSION" = "SNAPSHOT" ]; then
 	# find out the latest snapshot version and its download URL by parsing Apache directory listings
 	snapshotdir="https://repository.apache.org/content/repositories/snapshots/org/apache/jena/jena-fuseki1/"
-	latestdir=`wget -q -O- "$snapshotdir" | grep 'a href=' | cut -d '"' -f 2 | grep SNAPSHOT | tail -n 1`
-	FUSEKI_VERSION=`basename $latestdir`
-	fusekiurl=`wget -q -O- "$latestdir" | grep 'a href=' | cut -d '"' -f 2 | grep 'distribution\.tar\.gz$' | tail -n 1`
+	latestdir=$(wget -q -O- "$snapshotdir" | grep 'a href=' | cut -d '"' -f 2 | grep SNAPSHOT | tail -n 1)
+	FUSEKI_VERSION=$(basename "$latestdir")
+	fusekiurl=$(wget -q -O- "$latestdir" | grep 'a href=' | cut -d '"' -f 2 | grep 'distribution\.tar\.gz$' | tail -n 1)
 else
-	fusekiurl="http://archive.apache.org/dist/jena/binaries/jena-fuseki1-$FUSEKI_VERSION-distribution.tar.gz"
+	fusekiurl="https://repository.apache.org/content/repositories/releases/org/apache/jena/jena-fuseki1/$FUSEKI_VERSION/jena-fuseki1-$FUSEKI_VERSION-distribution.tar.gz"
 fi
 
-if [ ! -f jena-fuseki1-$FUSEKI_VERSION/fuseki-server ]; then
+if [ ! -f "jena-fuseki1-$FUSEKI_VERSION/fuseki-server" ]; then
   echo "fuseki server file not found - downloading it"
   wget --output-document=fuseki-dist.tar.gz "$fusekiurl"
   tar -zxvf fuseki-dist.tar.gz
 fi
 
-cd jena-fuseki1-$FUSEKI_VERSION
+cd "jena-fuseki1-$FUSEKI_VERSION"
 ./fuseki-server --config ../fuseki-assembler.ttl &
-until $(curl --output /dev/null --silent --head --fail http://localhost:3030); do
+until curl --output /dev/null --silent --head --fail http://localhost:3030; do
   printf '.'
   sleep 2
 done
 
 for fn in ../test-vocab-data/*.ttl; do
-  name=`basename $fn .ttl`
-  ./s-put http://localhost:3030/ds/data http://www.skosmos.skos/$name/ $fn
+  name=$(basename "${fn}" .ttl)
+  $(./s-put http://localhost:3030/ds/data "http://www.skosmos.skos/$name/" "$fn")
 done
 
 cd ..


### PR DESCRIPTION
Hello,

This pull request addresses all issues found with `shellcheck` in `init_fuseki.sh`.

Also updates Fuseki1 to Jena 3.4.0 version. Fuseki1 is not being distributed with Jena any more. However, it is still being uploaded to Maven central repository.

Hence this change that grabs the `-distribution.zip` from Maven instead of Apache archives.

Ideally, the best approach would - I guess- update the tests to use Fuseki2, however, I am not sure what would be necessary for that. And I suspect we can address it later.

Cheers
Bruno