### PR TITLE
adding concept data as jsonld to page source, related to #673

### DIFF
--- a/view/scripts.twig
+++ b/view/scripts.twig
@@ -27,6 +27,11 @@ var uriSpace = "{{ request.vocab.uriSpace }}";
 var showNotation = {% if request.vocab and request.vocab.config.showNotation == false %}false{% else %}true{% endif %};
 </script>
 
+{% if request.page == 'page' and search_results and search_results|length == 1 %}
+<script type="application/ld+json">
+{{ search_results|first.dumpJsonLd|raw }}
+</script>
+{% endif %}
 <script type="text/javascript" src="vendor/components/jquery/jquery.min.js"></script>
 <script type="text/javascript" src="vendor/components/jqueryui/jquery-ui.min.js"></script>
 <script type="text/javascript" src="vendor/components/handlebars.js/handlebars.min.js"></script>


### PR DESCRIPTION
Fixes issue #673 by serializing the concept data via EasyRDF. Additionally, the data for external resources obtained from external sources is combined to the concept graph. Concept data for a single concept is added on every response (as json-ld). 