### PR TITLE
Remove SERVICE_LOGO old constant and related code

### DIFF
--- a/config.inc.dist
+++ b/config.inc.dist
@@ -49,9 +49,6 @@ define ("LOG_FILE_NAME", NULL);
 # customize the service name
 define("SERVICE_NAME", "Skosmos");
 
-// customize the service logo by pointing to your logo here. 
-define("SERVICE_LOGO", "./resource/pics/logo.png");
-
 // customize the css by adding your own stylesheet
 define("CUSTOM_CSS", "resource/css/stylesheet.css");
 

--- a/controller/WebController.php
+++ b/controller/WebController.php
@@ -43,10 +43,6 @@ class WebController extends Controller
         $this->twig->addGlobal("BaseHref", $this->getBaseHref());
         // setting the service name string from the config.inc
         $this->twig->addGlobal("ServiceName", $this->model->getConfig()->getServiceName());
-        // setting the service logo location from the config.inc
-        if ($this->model->getConfig()->getServiceLogo() !== null) {
-            $this->twig->addGlobal("ServiceLogo", $this->model->getConfig()->getServiceLogo());
-        }
 
         // setting the service custom css file from the config.inc
         if ($this->model->getConfig()->getCustomCss() !== null) {

--- a/model/GlobalConfig.php
+++ b/model/GlobalConfig.php
@@ -187,14 +187,6 @@ class GlobalConfig {
     /**
      * @return string
      */
-    public function getServiceLogo() 
-    {
-        return $this->getConstant('SERVICE_LOGO', null);
-    }
-    
-    /**
-     * @return string
-     */
     public function getCustomCss() 
     {
         return $this->getConstant('CUSTOM_CSS', null);

--- a/tests/GlobalConfigTest.php
+++ b/tests/GlobalConfigTest.php
@@ -119,15 +119,6 @@ class GlobalConfigTest extends PHPUnit_Framework_TestCase
   }
 
   /**
-   * @covers GlobalConfig::getServiceLogo
-   * @covers GlobalConfig::getConstant
-   */
-  public function testServiceLogoDefaultValue() {
-    $actual = $this->config->getServiceLogo();
-    $this->assertEquals(null, $actual);
-  }
-
-  /**
    * @covers GlobalConfig::getCustomCss
    * @covers GlobalConfig::getConstant
    */


### PR DESCRIPTION
Fix for issue Issue #665.

Looks like the WebController was even setting the variable in the twig template, but it was just never used.

Removed the constant, tests, and the code in the controller. phpunit tests passing fine in my local computer.

Cheers
Bruno