### PR TITLE
Add Jena Fuseki to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ report
 components
 composer.phar
 composer.lock
+tests/jena-fuseki*


### PR DESCRIPTION
Just to avoid someone (probably me :-) )including the Apache Jena Fuseki used for tests in a commit.

(actually did that, then removed from the staged changes)

Cheers
B