### PR TITLE
Fix hard crash on missng skosxl:literalForm

### DIFF
--- a/model/Concept.php
+++ b/model/Concept.php
@@ -151,7 +151,7 @@ class Concept extends VocabularyDataObject
         $labels = $this->resource->allResources('skosxl:prefLabel');
         foreach($labels as $labres) {
             $label = $labres->getLiteral('skosxl:literalForm');
-            if ($label->getLang() == $this->clang) {
+            if ($label !== null && $label->getLang() == $this->clang) {
                 return new LabelSkosXL($this->model, $labres);
             }
         }


### PR DESCRIPTION
If skosxl:literalForm is missing on a label resource the $label variable remains uninitialzed and causes a hard crash
related to #686 