### PR TITLE
Add Dockerfile and a docker-compose to run Skosmos with Fuseki

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM php:7.0-apache
+
+RUN apt-get update
+
+RUN apt-get install locales
+RUN echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen
+RUN echo "fr_FR.UTF-8 UTF-8" >> /etc/locale.gen
+RUN echo "en_GB.UTF-8 UTF-8" >> /etc/locale.gen
+RUN echo "fi_FI.UTF-8 UTF-8" >> /etc/locale.gen
+RUN echo "sv_SE.UTF-8 UTF-8" >> /etc/locale.gen
+RUN locale-gen
+
+RUN a2enmod rewrite
+RUN docker-php-ext-install gettext

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
   # volumes:
   #  - ${PWD}/fuseki:/fuseki
   web:
-    container_name: skosmos-web
+    container_name: skosmos
     build: .
     volumes:
       - .:/var/www/html

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,10 @@ services:
       - JVM_ARGS=-Xmx2g
     ports:
      - 3030:3030
+  # You can uncomment the line below to have a local volume bound onto the container, or
+  # visit https://hub.docker.com/r/stain/jena-fuseki/ for other alternatives
+  # volumes:
+  #  - ${PWD}/fuseki:/fuseki
   web:
     container_name: skosmos-web
     build: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3'
 
 services:
   fuseki:
+    container_name: skosmos-fuseki
     image: stain/jena-fuseki
     environment:
       - ADMIN_PASSWORD=admin
@@ -9,6 +10,7 @@ services:
     ports:
      - 3030:3030
   web:
+    container_name: skosmos-web
     build: .
     volumes:
       - .:/var/www/html

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '3'
+
+services:
+  fuseki:
+    image: stain/jena-fuseki
+    environment:
+      - ADMIN_PASSWORD=admin
+      - JVM_ARGS=-Xmx2g
+    ports:
+     - 3030:3030
+  web:
+    build: .
+    volumes:
+      - .:/var/www/html
+    ports:
+      - 8000:80
+    depends_on:
+      - fuseki
+
+# once the environment has been created:
+# 1. create dataset
+# >curl -I -u admin:admin -XPOST --data "dbName=skosmos&dbType=tdb" -G http://localhost:3030/$/datasets/
+# 2. load example vocabulary
+# >curl -I -X POST -H Content-Type:text/turtle -T vocabularies.ttl -G http://localhost:3030/skosmos/data


### PR DESCRIPTION
Not sure if others would be interested. I started a simple Docker environment as I am on a new notebook and didn't want to install PHP + Apache + Fuseki etc just for developing SKOSMOS again.

To get everything up and running, once in the project folder:

```
$ docker-compose up
$ curl -I -u admin:admin -XPOST --data "dbName=skosmos&dbType=tdb" -G http://localhost:3030/$/datasets/
$ curl -I -X POST -H Content-Type:text/turtle -T vocabularies.ttl -G http://localhost:3030/skosmos/data
```

And with that SKOSMOS should be running on http://localhost:8000.

Feel free to close if that's not interesting at this point :-) just in case someone else was thinking about doing something along these lines. It can be easily modified to also support nginx.