### PR TITLE
WIP Issue #712: display the concepts of the first letter available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,13 +19,12 @@ before_script:
 after_script:
   - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
   - pkill -f 'java -Xmx1200M -jar'
-addons:
-  code_climate:
-    repo_token: fb98170a5c7ea9cc2bbab19ff26268335e6a11a4f8267ca935e5e8ff4624886c
 env:
-  - FUSEKI_VERSION=3.6.0
-  - FUSEKI_VERSION=SNAPSHOT
-  - CC_TEST_REPORTER_ID=fb98170a5c7ea9cc2bbab19ff26268335e6a11a4f8267ca935e5e8ff4624886c
+  global:
+    - CC_TEST_REPORTER_ID=fb98170a5c7ea9cc2bbab19ff26268335e6a11a4f8267ca935e5e8ff4624886c
+  matrix:
+    - FUSEKI_VERSION=3.6.0
+    - FUSEKI_VERSION=SNAPSHOT
 matrix:
   allow_failures:
   - env: FUSEKI_VERSION=SNAPSHOT

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ addons:
   code_climate:
     repo_token: fb98170a5c7ea9cc2bbab19ff26268335e6a11a4f8267ca935e5e8ff4624886c
 env:
-  - FUSEKI_VERSION=3.4.0
+  - FUSEKI_VERSION=3.6.0
   - FUSEKI_VERSION=SNAPSHOT
   - CC_TEST_REPORTER_ID=fb98170a5c7ea9cc2bbab19ff26268335e6a11a4f8267ca935e5e8ff4624886c
 matrix:

--- a/controller/WebController.php
+++ b/controller/WebController.php
@@ -148,7 +148,8 @@ class WebController extends Controller
         header('Vary: Accept-Language'); // inform caches that a decision was made based on Accept header
         $this->negotiator = new \Negotiation\LanguageNegotiator();
         $langcodes = array_keys($this->languages);
-        $acceptLanguage = filter_input(INPUT_SERVER, 'HTTP_ACCEPT_LANGUAGE', FILTER_SANITIZE_STRING) ? filter_input(INPUT_SERVER, 'HTTP_ACCEPT_LANGUAGE', FILTER_SANITIZE_STRING) : '';
+        // using a random language from the configured UI languages when there is no accept language header set
+        $acceptLanguage = filter_input(INPUT_SERVER, 'HTTP_ACCEPT_LANGUAGE', FILTER_SANITIZE_STRING) ? filter_input(INPUT_SERVER, 'HTTP_ACCEPT_LANGUAGE', FILTER_SANITIZE_STRING) : $langcodes[0];
         $bestLang = $this->negotiator->getBest($acceptLanguage, $langcodes);
         if (isset($bestLang) && in_array($bestLang, $langcodes)) {
             return $bestLang->getValue();

--- a/controller/WebController.php
+++ b/controller/WebController.php
@@ -489,11 +489,15 @@ class WebController extends Controller
 
         $allAtOnce = $vocab->getConfig()->getAlphabeticalFull();
         if (!$allAtOnce) {
-            $searchResults = $vocab->searchConceptsAlphabetical($request->getLetter(), $count, $offset, $contentLang);
             $letters = $vocab->getAlphabet($contentLang);
+            $letter = $request->getLetter();
+            if ($letter === '') {
+                $letter = $letters[0];
+            }
+            $searchResults = $vocab->searchConceptsAlphabetical($letter, $count, $offset, $contentLang);
         } else {
-            $searchResults = $vocab->searchConceptsAlphabetical('*', null, null, $contentLang);
             $letters = null;
+            $searchResults = $vocab->searchConceptsAlphabetical('*', null, null, $contentLang);
         }
 
         $request->setContentLang($contentLang);

--- a/model/Cache.php
+++ b/model/Cache.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Wrapper class for key-value caching. Currently supports APC and APCu.
+ * Wrapper class for key-value caching. Currently supports only APCu.
  */
 class Cache
 {
@@ -10,9 +10,6 @@ class Cache
      * Wraps apc_fetch() & apcu_fetch()
      */
     public function fetch($key) {
-        if (function_exists('apc_fetch')) {
-            return apc_fetch($key);
-        }
         if (function_exists('apcu_fetch')) {
             return apcu_fetch($key);
         }
@@ -23,15 +20,12 @@ class Cache
      * Wraps apc_store() and apcu_store()
      */
     public function store($key, $value, $ttl=3600) {
-        if (function_exists('apc_store')) {
-            return apc_store($key, $value);
-        }
-        else if (function_exists('apcu_store')) {
+        if (function_exists('apcu_store')) {
             return apcu_store($key, $value, $ttl);
         }
     }
 
     public function isAvailable() {
-        return ((function_exists('apc_store') && function_exists('apc_fetch')) || (function_exists('apcu_store') && function_exists('apcu_fetch')));
+        return (function_exists('apcu_store') && function_exists('apcu_fetch'));
     }
 }

--- a/model/Request.php
+++ b/model/Request.php
@@ -136,7 +136,7 @@ class Request
 
     public function getLetter()
     {
-        return (isset($this->letter)) ? $this->letter : 'A';
+        return (isset($this->letter)) ? $this->letter : '';
     }
 
     /**

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -134,7 +134,7 @@ class RequestTest extends PHPUnit\Framework\TestCase
    */
   public function testGetLetterWhenNotSet() {
     $this->request->setVocab('test');
-    $this->assertEquals('A', $this->request->getLetter());
+    $this->assertEquals('', $this->request->getLetter());
   }
 
   /**


### PR DESCRIPTION
For issue #712. If no concepts exist with letter `'A'`, then Skosmos will list the letters, but the concept tree will be empty.

This happens cause the `Request` by default assumes the informed letter is `A` when none given.

Instead, we can assume it is empty. Initial tests indicate everything worked with no issues. I still have to confirm the queries are not working by accident, more specifically in `Vocabulary#searchConceptsAlphabetical`.

But happy to take some reviews before digging deeper into this.

Cheers
Bruno