### PR TITLE
fix constructor call due to previously done refactoring(?)

### DIFF
--- a/model/ConceptPropertyValue.php
+++ b/model/ConceptPropertyValue.php
@@ -140,8 +140,8 @@ class ConceptPropertyValue extends VocabularyDataObject
         foreach($props as $prop) {
             $prop = (EasyRdf\RdfNamespace::shorten($prop) !== null) ? EasyRdf\RdfNamespace::shorten($prop) : $prop;
             foreach ($this->resource->allLiterals($prop) as $val) {
-                if ($prop !== 'rdf:value' && $this->resource->get($prop)) { // shown elsewhere
-                    $ret[gettext($prop)] = new ConceptPropertyValueLiteral($this->resource->get($prop), $prop);
+                if ($prop !== 'rdf:value') { // shown elsewhere
+                    $ret[gettext($prop)] = new ConceptPropertyValueLiteral($this->model, $this->vocab, $this->resource, $val, $prop);
                 }
             }
             foreach ($this->resource->allResources($prop) as $val) {


### PR DESCRIPTION
Whilst trying to access **/agrovoc/en/page/c_1fde0617** with the up-to-date AGROVOC vocabulary, a 500 return code is given. 

Stack trace: 
PHP Fatal error:  Uncaught ArgumentCountError: Too few arguments to function ConceptPropertyValueLiteral::__construct(), 2 passed in /var/www/skosmos.dev.finto.fi/model/ConceptPropertyValue.php on line 144 and exactly 5 expected in /var/www/skosmos.dev.finto.fi/model/ConceptPropertyValueLiteral.php:13\nStack trace:\n#0 /var/www/skosmos.dev.finto.fi/model/ConceptPropertyValue.php(144): ConceptPropertyValueLiteral->__construct(Object(EasyRdf\\Literal\\DateTime), 'dc:created')\n#1 /var/www/skosmos.dev.finto.fi/vendor/twig/twig/lib/Twig/Extension/Core.php(1605): ConceptPropertyValue->getReifiedPropertyValues()\n#2 /tmp/skosmos-demo-template-cache/45/45a8fbb6c92affef933c2cec85addda5042b429667039b888bec20947a35b8f1.php(439): twig_get_attribute(Object(Twig_Environment), Object(Twig_Source), Object(ConceptPropertyValue), 'reifiedProperty...', Array)\n#3 /var/www/skosmos.dev.finto.fi/vendor/twig/twig/lib/Twig/Template.php(390): __TwigTemplate_1f3fe43857c3e15645535dabbed0c8f187ff9ea04dd98ab1e144711ee1af1896->doDisplay(Array, Array)\n#4 /var/www in /var/www/skosmos.dev.finto.fi/model/ConceptPropertyValueLiteral.php on line 13

This PR fixes this issue by modifying the part from which this stack trace originates. 