### PR TITLE
Fix search with double quotes

### DIFF
--- a/model/sparql/GenericSparql.php
+++ b/model/sparql/GenericSparql.php
@@ -890,8 +890,8 @@ EOF;
     {
         $valuesProp = $this->formatValues('?prop', $props);
         $textcond = $this->generateConceptSearchQueryCondition($term, $searchLang);
-        $rawterm = str_replace('\\', '\\\\', str_replace('*', '', $term));
-        
+
+        $rawterm = str_replace(array('\\', '*', '"'), array('\\\\', '', '\"'), $term);
         // graph clause, if necessary
         $graphClause = $filterGraph != '' ? 'GRAPH ?graph' : '';
 

--- a/tests/GenericSparqlTest.php
+++ b/tests/GenericSparqlTest.php
@@ -598,6 +598,23 @@ class GenericSparqlTest extends PHPUnit\Framework\TestCase
   }
 
   /**
+   * @covers GenericSparql::queryConcepts
+   * @covers GenericSparql::generateConceptSearchQueryCondition
+   * @covers GenericSparql::generateConceptSearchQueryInner
+   * @covers GenericSparql::generateConceptSearchQuery
+   * @covers GenericSparql::transformConceptSearchResults
+   * @covers GenericSparql::transformConceptSearchResult
+   * @covers GenericSparql::shortenUri
+   */
+  public function testQueryConceptsDoubleQuotesTerm()
+  {
+    $voc = $this->model->getVocabulary('test');
+    $this->params->method('getSearchTerm')->will($this->returnValue('"'));
+    $actual = $this->sparql->queryConcepts(array($voc), null, null, $this->params);
+    $this->assertEquals(0, sizeof($actual));
+  }
+
+  /**
    * @covers GenericSparql::queryLabel
    * @covers GenericSparql::generateLabelQuery
    */


### PR DESCRIPTION
I saw the issue #763, and tried in finto.fi the search for `"`. That returned the following result.

![screenshot_2018-04-27_22-04-09](https://user-images.githubusercontent.com/304786/39359229-46a95456-4a6d-11e8-9a93-eb84b66dacd8.png)

Then looked at the query generated, and it had a part with the string `"""`, i.e. simply put `"` around double quotes. Which resulted in an invalid query.

This pull request probably doesn't fix #763, but solves the error message, and instead now escapes the `"`, replacing by `\"`. Used `str_replace` with two arrays with same length (`from` and `to`) to simplify it.

Also added a test. Without the fix, the test results in:

```
$ ./vendor/phpunit/phpunit/phpunit --filter testQueryConceptsDoubleQuotesTerm


PHPUnit 6.5.5 by Sebastian Bergmann and contributors.

22:30:31 INFO  [556] POST http://localhost:13030/ds/sparql
22:30:31 INFO  [556] Query = PREFIX owl: <http://www.w3.org/2002/07/owl#> PREFIX skos: <http://www.w3.org/2004/02/skos/core#> SELECT DISTINCT ?s ?label ?plabel ?alabel ?hlabel ?graph ?notation (GROUP_CONCAT(DISTINCT STR(?type);separator=' ') as ?types)    WHERE {  GRAPH <http://www.skosmos.skos/test/> {   {      SELECT DISTINCT ?s ?label ?notation (?matchstr AS ?hit)    WHERE {      {      {       VALUES (?prop) { (skos:prefLabel) (skos:altLabel) }      VALUES (?prop ?pri) { (skos:prefLabel 1) (skos:altLabel 3) (skos:hiddenLabel 5)}      ?s ?prop ?match . FILTER (LCASE(STR(?match)) = '"' )      ?s ?prop ?match }      UNION      { ?s skos:notation """ }      OPTIONAL {       ?s skos:prefLabel ?label .       FILTER (lang(?match) = '' || LANGMATCHES(lang(?label), lang(?match)))      }       BIND(IF(langMatches(LANG(?match),''), ?pri, ?pri+1) AS ?npri)      BIND(CONCAT(STR(?npri), LANG(?match), '@', STR(?match)) AS ?matchstr)      OPTIONAL { ?s skos:notation ?notation }     }         }       }     FILTER(BOUND(?s))   BIND(STR(SUBSTR(?hit,1,1)) AS ?pri)   BIND(IF((SUBSTR(STRBEFORE(?hit, '@'),1) != ?pri), STRLANG(STRAFTER(?hit, '@'), SUBSTR(STRBEFORE(?hit, '@'),2)), STRAFTER(?hit, '@')) AS ?match)   BIND(IF((?pri = "1" || ?pri = "2") && ?match != ?label, ?match, ?unbound) as ?plabel)   BIND(IF((?pri = "3" || ?pri = "4"), ?match, ?unbound) as ?alabel)   BIND(IF((?pri = "5" || ?pri = "6"), ?match, ?unbound) as ?hlabel)      {      ?s a ?type .        }   FILTER NOT EXISTS { ?s owl:deprecated true }  }   } GROUP BY ?s ?match ?label ?plabel ?alabel ?hlabel ?notation ?graph ORDER BY LCASE(STR(?match)) LANG(?match) 
22:30:31 INFO  [556] 400 Parse error: 
PREFIX owl: <http://www.w3.org/2002/07/owl#>
PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
SELECT DISTINCT ?s ?label ?plabel ?alabel ?hlabel ?graph ?notation (GROUP_CONCAT(DISTINCT STR(?type);separator=' ') as ?types)  

WHERE {
 GRAPH <http://www.skosmos.skos/test/> {
  {
     SELECT DISTINCT ?s ?label ?notation (?matchstr AS ?hit)
   WHERE {
     {
     { 
     VALUES (?prop) { (skos:prefLabel) (skos:altLabel) }
     VALUES (?prop ?pri) { (skos:prefLabel 1) (skos:altLabel 3) (skos:hiddenLabel 5)}
     ?s ?prop ?match . FILTER (LCASE(STR(?match)) = '"' )
     ?s ?prop ?match }
     UNION
     { ?s skos:notation """ }
     OPTIONAL {
      ?s skos:prefLabel ?label .
      FILTER (lang(?match) = '' || LANGMATCHES(lang(?label), lang(?match)))
     } 
     BIND(IF(langMatches(LANG(?match),''), ?pri, ?pri+1) AS ?npri)
     BIND(CONCAT(STR(?npri), LANG(?match), '@', STR(?match)) AS ?matchstr)
     OPTIONAL { ?s skos:notation ?notation }
    }
    
   }
   
  }
    FILTER(BOUND(?s))
  BIND(STR(SUBSTR(?hit,1,1)) AS ?pri)
  BIND(IF((SUBSTR(STRBEFORE(?hit, '@'),1) != ?pri), STRLANG(STRAFTER(?hit, '@'), SUBSTR(STRBEFORE(?hit, '@'),2)), STRAFTER(?hit, '@')) AS ?match)
  BIND(IF((?pri = "1" || ?pri = "2") && ?match != ?label, ?match, ?unbound) as ?plabel)
  BIND(IF((?pri = "3" || ?pri = "4"), ?match, ?unbound) as ?alabel)
  BIND(IF((?pri = "5" || ?pri = "6"), ?match, ?unbound) as ?hlabel)
  
  {  
   ?s a ?type .
    
  }
  FILTER NOT EXISTS { ?s owl:deprecated true }
 }
 
}
GROUP BY ?s ?match ?label ?plabel ?alabel ?hlabel ?notation ?graph
ORDER BY LCASE(STR(?match)) LANG(?match) 
Lexical error at line 17, column 30.  Encountered: "\n" (10), after : "\" }" (2 ms) 
E                                                                   1 / 1 (100%)

Time: 1.36 seconds, Memory: 8.00MB

There was 1 error:

1) GenericSparqlTest::testQueryConceptsDoubleQuotesTerm
EasyRdf\Http\Exception: HTTP request for SPARQL query failed

/home/kinow/Development/php/workspace/Skosmos/vendor/easyrdf/easyrdf/lib/Sparql/Client.php:247
/home/kinow/Development/php/workspace/Skosmos/vendor/easyrdf/easyrdf/lib/Sparql/Client.php:128
/home/kinow/Development/php/workspace/Skosmos/model/sparql/GenericSparql.php:92
/home/kinow/Development/php/workspace/Skosmos/model/sparql/GenericSparql.php:1155
/home/kinow/Development/php/workspace/Skosmos/tests/GenericSparqlTest.php:613

ERRORS!
Tests: 1, Assertions: 0, Errors: 1.

Generating code coverage report in Clover XML format ... done

Generating code coverage report in HTML format ... done

```

After applying the change it results in:

```
$ ./vendor/phpunit/phpunit/phpunit --filter testQueryConceptsDoubleQuotesTerm


PHPUnit 6.5.5 by Sebastian Bergmann and contributors.

22:31:09 INFO  [557] POST http://localhost:13030/ds/sparql
22:31:09 INFO  [557] Query = PREFIX owl: <http://www.w3.org/2002/07/owl#> PREFIX skos: <http://www.w3.org/2004/02/skos/core#> SELECT DISTINCT ?s ?label ?plabel ?alabel ?hlabel ?graph ?notation (GROUP_CONCAT(DISTINCT STR(?type);separator=' ') as ?types)    WHERE {  GRAPH <http://www.skosmos.skos/test/> {   {      SELECT DISTINCT ?s ?label ?notation (?matchstr AS ?hit)    WHERE {      {      {       VALUES (?prop) { (skos:prefLabel) (skos:altLabel) }      VALUES (?prop ?pri) { (skos:prefLabel 1) (skos:altLabel 3) (skos:hiddenLabel 5)}      ?s ?prop ?match . FILTER (LCASE(STR(?match)) = '"' )      ?s ?prop ?match }      UNION      { ?s skos:notation "\"" }      OPTIONAL {       ?s skos:prefLabel ?label .       FILTER (lang(?match) = '' || LANGMATCHES(lang(?label), lang(?match)))      }       BIND(IF(langMatches(LANG(?match),''), ?pri, ?pri+1) AS ?npri)      BIND(CONCAT(STR(?npri), LANG(?match), '@', STR(?match)) AS ?matchstr)      OPTIONAL { ?s skos:notation ?notation }     }         }       }     FILTER(BOUND(?s))   BIND(STR(SUBSTR(?hit,1,1)) AS ?pri)   BIND(IF((SUBSTR(STRBEFORE(?hit, '@'),1) != ?pri), STRLANG(STRAFTER(?hit, '@'), SUBSTR(STRBEFORE(?hit, '@'),2)), STRAFTER(?hit, '@')) AS ?match)   BIND(IF((?pri = "1" || ?pri = "2") && ?match != ?label, ?match, ?unbound) as ?plabel)   BIND(IF((?pri = "3" || ?pri = "4"), ?match, ?unbound) as ?alabel)   BIND(IF((?pri = "5" || ?pri = "6"), ?match, ?unbound) as ?hlabel)      {      ?s a ?type .        }   FILTER NOT EXISTS { ?s owl:deprecated true }  }   } GROUP BY ?s ?match ?label ?plabel ?alabel ?hlabel ?notation ?graph ORDER BY LCASE(STR(?match)) LANG(?match) 
22:31:09 INFO  [557] exec/select
22:31:09 INFO  [557] 200 OK (4 ms) 
.                                                                   1 / 1 (100%)

Time: 1.45 seconds, Memory: 8.00MB

OK (1 test, 1 assertion)

Generating code coverage report in Clover XML format ... done

Generating code coverage report in HTML format ... done
```

All tests passed locally too.

Hope that helps,
Bruno