### PR TITLE
Replace PHP explode function call by a Turtle list for globalPlugins

### DIFF
--- a/config.ttl.dist
+++ b/config.ttl.dist
@@ -64,7 +64,7 @@
     # default time a user must wait before submitting a form
     skosmos:uiHoneypotTime 5 ;
     # plugins to activate for the whole installation (including all vocabularies)
-    skosmos:globalPlugins "" .
+    skosmos:globalPlugins () .
 
 # Skosmos vocabularies
 

--- a/model/GlobalConfig.php
+++ b/model/GlobalConfig.php
@@ -298,7 +298,14 @@ class GlobalConfig extends BaseConfig {
      */
     public function getGlobalPlugins()
     {
-        return explode(' ', $this->getLiteral('skosmos:globalPlugins', null));
+        $globalPlugins = array();
+        $globalPluginsResource =  $this->getResource()->getResource("skosmos:globalPlugins");
+        if ($globalPluginsResource) {
+            foreach ($globalPluginsResource as $resource) {
+                $globalPlugins[] = $resource->getValue();
+            }
+        }
+        return $globalPlugins;
     }
 
     /**

--- a/model/PluginRegister.php
+++ b/model/PluginRegister.php
@@ -130,7 +130,7 @@ class PluginRegister {
     }
 
     /**
-     * Returns an array of javascript function names to call when loading a new concept
+     * Returns an array of javascript function names to call when loading pages
      * @return array
      */
     public function getCallbacks() {

--- a/tests/GlobalConfigTest.php
+++ b/tests/GlobalConfigTest.php
@@ -122,5 +122,13 @@ class GlobalConfigTest extends PHPUnit\Framework\TestCase
     $actual = $this->config->getCollationEnabled();
     $this->assertFalse($actual);
   }
+
+  /**
+   * @covers GlobalConfig::getGlobalPlugins
+   */
+  public function testGetGlobalPlugins() {
+    $actual = $this->config->getGlobalPlugins();
+    $this->assertEquals(array("alpha", "Bravo", "charlie"), $actual);
+  }
 }
 

--- a/tests/testconfig.ttl
+++ b/tests/testconfig.ttl
@@ -61,7 +61,9 @@
     # whether to enable the spam honey pot or not, enabled by default
     skosmos:uiHoneypotEnabled true ;
     # default time a user must wait before submitting a form
-    skosmos:uiHoneypotTime 5 .
+    skosmos:uiHoneypotTime 5 ;
+    # plugins to activate for the whole installation (including all vocabularies)
+    skosmos:globalPlugins ("alpha" "Bravo" "charlie") .
 
 # Skosmos vocabularies
 


### PR DESCRIPTION
Tested locally in Skosmos + Docker, and also ran `phpunit`. No issues or changes in tests, as we are still returning an array. But in the configuration, instead of using spaces to separate plugin names, now we have a turtle list.

Also updated the docs for a method while reading the code and writing the Wiki page for #774 issue.