### PR TITLE
Use Fuseki 3.8.0 for unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ env:
   global:
     - CC_TEST_REPORTER_ID=fb98170a5c7ea9cc2bbab19ff26268335e6a11a4f8267ca935e5e8ff4624886c
   matrix:
-    - FUSEKI_VERSION=3.7.0
+    - FUSEKI_VERSION=3.8.0
     - FUSEKI_VERSION=SNAPSHOT
 matrix:
   exclude:

--- a/model/Model.php
+++ b/model/Model.php
@@ -76,7 +76,7 @@ class Model
     {
         $ver = null;
         if (file_exists('.git')) {
-            $ver = shell_exec('git describe --tags');
+            $ver = shell_exec('git describe --tags --always');
         }
 
         if ($ver === null) {

--- a/tests/init_fuseki.sh
+++ b/tests/init_fuseki.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Note: This script must be sourced from within bash, e.g. ". init_fuseki.sh"
 
-FUSEKI_VERSION=${FUSEKI_VERSION:-3.7.0}
+FUSEKI_VERSION=${FUSEKI_VERSION:-3.8.0}
 
 if [ "$FUSEKI_VERSION" = "SNAPSHOT" ]; then
 	# find out the latest snapshot version and its download URL by parsing Apache directory listings


### PR DESCRIPTION
Jena 3.8.0 is out. This PR updates the unit tests to use Fuseki 3.8.0 to run the tests.