### PR TITLE
Disable Travis tests for Fuseki snapshot. 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,17 +24,9 @@ after_script:
 env:
   global:
     - CC_TEST_REPORTER_ID=fb98170a5c7ea9cc2bbab19ff26268335e6a11a4f8267ca935e5e8ff4624886c
-  matrix:
     - FUSEKI_VERSION=3.8.0
-    - FUSEKI_VERSION=SNAPSHOT
 matrix:
-  exclude:
-  - php: 7.0
-    env: FUSEKI_VERSION=SNAPSHOT
-  - php: 7.2
-    env: FUSEKI_VERSION=SNAPSHOT
   allow_failures:
   - php: 7.2
-  - env: FUSEKI_VERSION=SNAPSHOT
 notifications:
     slack: kansalliskirjasto:9mOKu3Vws1CIddF5jqWgXbli


### PR DESCRIPTION
There is no longer a Fuseki1 distribution snapshot we could use, after building it was disabled in JENA-1573. So Fuseki 3.8.0 is the last release where our scripts work.

This PR disables the Travis tests that use a Fuseki snapshot release, since they're not working anyway. I think the tests should be migrated to use Fuseki2 instead, then snapshots can be enabled again.