### PR TITLE
Minor improvements

### DIFF
--- a/model/ConceptPropertyValueLiteral.php
+++ b/model/ConceptPropertyValueLiteral.php
@@ -67,7 +67,6 @@ class ConceptPropertyValueLiteral extends VocabularyDataObject
 
     public function hasXlProperties()
     {
-        $ret = array();
         $graph = $this->resource->getGraph();
         $resources = $graph->resourcesMatching('skosxl:literalForm', $this->literal);
         return !empty($resources);

--- a/model/LabelSkosXL.php
+++ b/model/LabelSkosXL.php
@@ -9,7 +9,7 @@ class LabelSkosXL extends DataObject
     }
 
     public function getPrefLabel() {
-        $label;
+        $label = null;
         $labels = $this->resource->allResources('skosxl:prefLabel');
         foreach($labels as $labres) {
             $label = $labres->getLiteral('skosxl:literalForm');

--- a/model/sparql/GenericSparql.php
+++ b/model/sparql/GenericSparql.php
@@ -1886,7 +1886,6 @@ EOQ;
                 $ret[$uri]['exact'] = $row->exact->getUri();
             }
             if (isset($row->tops)) {
-               $topConceptsList=array();
                $topConceptsList=explode(" ", $row->tops->getValue());
                // sort to garantee an alphabetical ordering of the URI
                sort($topConceptsList);

--- a/model/sparql/GenericSparql.php
+++ b/model/sparql/GenericSparql.php
@@ -768,7 +768,7 @@ EOQ;
             }
         }
 
-        return implode(' UNION ', $typePatterns);;
+        return implode(' UNION ', $typePatterns);
     }
 
     /**

--- a/resource/js/docready.js
+++ b/resource/js/docready.js
@@ -775,7 +775,7 @@ $(function() { // DOCUMENT READY
       var emailMessageVal = $("#message").val();
       var emailAddress = $("#email").val();
       var requiredFields = true;
-      if (emailAddress != '' && emailAddress.indexOf('@') === -1) {
+      if (emailAddress !== '' && emailAddress.indexOf('@') === -1) {
         $("#email").addClass('missing-value');
         requiredFields = false;
       }

--- a/resource/js/hierarchy.js
+++ b/resource/js/hierarchy.js
@@ -129,7 +129,7 @@ function createConceptObject(conceptUri, conceptData) {
  */
 function attachTopConceptsToSchemes(schemes, currentNode, parentData) {
   for (var i = 0; i < schemes.length; i++) {
-    if (parentData[currentNode.uri].tops.indexOf(schemes[i].uri) != -1) {
+    if (parentData[currentNode.uri].tops.indexOf(schemes[i].uri) !== -1) {
       if(Object.prototype.toString.call(schemes[i].children) !== '[object Array]' ) {
         schemes[i].children = [];
       }

--- a/tests/ConceptPropertyTest.php
+++ b/tests/ConceptPropertyTest.php
@@ -82,7 +82,7 @@ class ConceptPropertyTest extends PHPUnit\Framework\TestCase
     $props = $concept->getProperties();
     $prevlabel;
     foreach($props['skos:narrower'] as $val) {
-      $label = is_string($val->getLabel()) ? $val->getLabel() : $val->getLabel()-getValue();
+      $label = is_string($val->getLabel()) ? $val->getLabel() : $val->getLabel()->getValue();
       if ($prevlabel)
         $this->assertEquals(1, strnatcmp($prevlabel, $label));
       $prevlabel = $label;

--- a/tests/ConceptPropertyTest.php
+++ b/tests/ConceptPropertyTest.php
@@ -80,7 +80,7 @@ class ConceptPropertyTest extends PHPUnit\Framework\TestCase
     $concepts = $vocab->getConceptInfo('http://www.skosmos.skos/test/ta1', 'en');
     $concept = $concepts[0];
     $props = $concept->getProperties();
-    $prevlabel;
+    $prevlabel = null;
     foreach($props['skos:narrower'] as $val) {
       $label = is_string($val->getLabel()) ? $val->getLabel() : $val->getLabel()->getValue();
       if ($prevlabel)

--- a/tests/ConceptTest.php
+++ b/tests/ConceptTest.php
@@ -179,7 +179,7 @@ class ConceptTest extends PHPUnit\Framework\TestCase
     $results = $this->vocab->getConceptInfo('http://www.skosmos.skos/test/ta1', 'en');
     $concept = reset($results);
     $props = $concept->getProperties();
-    $prevlabel;
+    $prevlabel = null;
     foreach($props['skos:narrower'] as $val) {
       $label = is_string($val->getLabel()) ? $val->getLabel() : $val->getLabel()->getValue();
       if ($prevlabel)

--- a/tests/ConceptTest.php
+++ b/tests/ConceptTest.php
@@ -181,7 +181,7 @@ class ConceptTest extends PHPUnit\Framework\TestCase
     $props = $concept->getProperties();
     $prevlabel;
     foreach($props['skos:narrower'] as $val) {
-      $label = is_string($val->getLabel()) ? $val->getLabel() : $val->getLabel()-getValue();
+      $label = is_string($val->getLabel()) ? $val->getLabel() : $val->getLabel()->getValue();
       if ($prevlabel)
         $this->assertEquals(1, strnatcmp($prevlabel, $label));
       $prevlabel = $label;


### PR DESCRIPTION
Mentioned in another ticket that I had a few minor improvements to submit. All of these were found with PhpStorm, which I have been using for another project (normally use Eclipse). Simply downloaded a copy with my apache e-mail (free :tada: ), imported the project, and then did an "Inspect Code".

I think it will be easier to review each commit, as I tried to group the enhancements as they appeared in PhpStorm.

Some other interesting entries **not included in this commit** as I think it would require further analysis:

- unnecessary `\.` in JS regex
- Inconsistent return points: several missing return statement (some functions have a return, but if there is an error, it doesn't return anything, nor throws any exception)
- Duplicate array keys: In RestController, around line 228, an array with values is created to be returned. But if you look closer, and search for `title`, you will see that it first is set to `rdfs:label`, and then set again in the array to `dct:title` (@osma not in this commit, as I am not sure which one is correct)
- Void function result used: in controllers, we are using something like `return $this->returnError(....)`, but actually, the returnError does not return. It sets headers and echoes. I _think_ PHP stops the code execution and returns too, being lenient here. But it could change in the future. Will put another ticket for it someday

If we started using a bit more of type setting (e.g. `function blabla(): bool`, also phpdocs annotations, and those nice `@var $ret array`, etc) I think we could spot more probable bugs, and make the code simpler. I am working with a senior symfony guy, who is teaching me a few more tricks while helping on a project he recently set up. Might come back later with a few more ideas later :-) :running_man: 