### PR TITLE
Fix config

### DIFF
--- a/model/GlobalConfig.php
+++ b/model/GlobalConfig.php
@@ -84,6 +84,7 @@ class GlobalConfig extends BaseConfig {
     /**
      * Parses configuration from the config.ttl file
      * @param string $filename path to config.ttl file
+     * @throws \EasyRdf\Exception
      */
     private function parseConfig($filename)
     {
@@ -95,7 +96,7 @@ class GlobalConfig extends BaseConfig {
 
     /**
      * Returns the graph created after parsing the configuration file.
-     * @return Graph
+     * @return \EasyRdf\Graph
      */
     public function getGraph()
     {
@@ -125,7 +126,9 @@ class GlobalConfig extends BaseConfig {
         if (!is_null($languageResources) && !empty($languageResources)) {
             $languages = array();
             foreach ($languageResources as $languageResource) {
+                /** @var \EasyRdf\Literal $languageName */
                 $languageName = $languageResource->getLiteral('rdfs:label');
+                /** @var \EasyRdf\Literal $languageValue */
                 $languageValue = $languageResource->getLiteral('rdf:value');
                 if ($languageName && $languageValue) {
                     $languages[$languageName->getValue()] = $languageValue->getValue();
@@ -199,7 +202,7 @@ class GlobalConfig extends BaseConfig {
      */
     public function getTemplateCache()
     {
-        return $this->getLiteral('TEMPLATE_CACHE', '/tmp/skosmos-template-cache');
+        return $this->getLiteral('skosmos:templateCache', '/tmp/skosmos-template-cache');
     }
 
     /**
@@ -209,7 +212,7 @@ class GlobalConfig extends BaseConfig {
      */
     public function getDefaultSparqlDialect()
     {
-        return $this->getLiteral('DEFAULT_SPARQL_DIALECT', 'Generic');
+        return $this->getLiteral('skosmos:sparqlDialect', 'Generic');
     }
 
     /**
@@ -218,7 +221,7 @@ class GlobalConfig extends BaseConfig {
      */
     public function getFeedbackAddress()
     {
-        return $this->getLiteral('FEEDBACK_ADDRESS', null);
+        return $this->getLiteral('skosmos:feedbackAddress', null);
     }
 
     /**
@@ -227,7 +230,7 @@ class GlobalConfig extends BaseConfig {
      */
     public function getFeedbackSender()
     {
-        return $this->getLiteral('FEEDBACK_SENDER', null);
+        return $this->getLiteral('skosmos:feedbackSender', null);
     }
 
     /**
@@ -236,7 +239,7 @@ class GlobalConfig extends BaseConfig {
      */
     public function getFeedbackEnvelopeSender()
     {
-        return $this->getLiteral('FEEDBACK_ENVELOPE_SENDER', null);
+        return $this->getLiteral('skosmos:feedbackEnvelopeSender', null);
     }
 
     /**
@@ -299,7 +302,7 @@ class GlobalConfig extends BaseConfig {
     }
 
     /**
-     * @return string
+     * @return array
      */
     public function getGlobalPlugins()
     {

--- a/tests/FeedbackTest.php
+++ b/tests/FeedbackTest.php
@@ -8,7 +8,7 @@ class FeedbackTest extends PHPUnit\Framework\TestCase
   private $request;
 
   protected function setUp() {
-    $config = new GlobalConfig('/../tests/testconfig.ttl');
+    $config = new GlobalConfig('/../tests/testconfig-fordefaults.ttl');
     $this->model = new Model($config);
     $this->request = \Mockery::mock('Request', array($this->model))->makePartial();
     $this->request->setLang('en');

--- a/tests/GlobalConfigTest.php
+++ b/tests/GlobalConfigTest.php
@@ -1,134 +1,179 @@
 <?php
 
+/**
+ * Tests for GlobalConfig. Must cover all of its methods, and use at least one file configuratoin that contains
+ * different values than the default ones.
+ */
 class GlobalConfigTest extends PHPUnit\Framework\TestCase
 {
+    /** @var GlobalConfig */
+    private $config;
+    /** @var GlobalConfig */
+    private $configWithDefaults;
 
-  private $config;
+    protected function setUp()
+    {
+        $this->config = new GlobalConfig('/../tests/testconfig.ttl');
+        $this->assertNotNull($this->config->getCache());
+        $this->assertNotNull($this->config->getGraph());
+        $this->configWithDefaults = new GlobalConfig('/../tests/testconfig-fordefaults.ttl');
+    }
 
-  protected function setUp() {
-    putenv("LC_ALL=en_GB.utf8");
-    setlocale(LC_ALL, 'en_GB.utf8');
-    $this->config = new GlobalConfig('/../tests/testconfig.ttl');
-  }
+    // --- tests for values that are overriding default values
 
-  /**
-   * @covers GlobalConfig::getLanguages
-   */
-  public function testLanguagesWithoutConfiguration() {
-    $actual = $this->config->getLanguages();
-    $this->assertEquals(array('en' => 'en_GB.utf8'), $actual);
-  }
+    public function testGetDefaultEndpoint()
+    {
+        $this->assertEquals("http://localhost:13030/ds/sparql", $this->config->getDefaultEndpoint());
+    }
 
-  /**
-   * @covers GlobalConfig::getHttpTimeout
-   */
-  public function testTimeoutDefaultValue() {
-    $actual = $this->config->getHttpTimeout();
-    $this->assertEquals(5, $actual);
-  }
+    public function testGetDefaultSparqlDialect()
+    {
+        $this->assertEquals("JenaText", $this->config->getDefaultSparqlDialect());
+    }
 
-  /**
-   * @covers GlobalConfig::getDefaultEndpoint
-   */
-  public function testEndpointDefaultValue() {
-    $actual = $this->config->getDefaultEndpoint();
-    $this->assertEquals('http://localhost:13030/ds/sparql', $actual);
-  }
+    public function testGetCollationEnabled()
+    {
+        $this->assertEquals(true, $this->config->getCollationEnabled());
+    }
 
-  /**
-   * @covers GlobalConfig::getDefaultTransitiveLimit
-   */
-  public function testTransitiveLimitDefaultValue() {
-    $actual = $this->config->getDefaultTransitiveLimit();
-    $this->assertEquals(1000, $actual);
-  }
+    public function testGetSparqlTimeout()
+    {
+        $this->assertEquals(10, $this->config->getSparqlTimeout());
+    }
 
-  /**
-   * @covers GlobalConfig::getSearchResultsSize
-   */
-  public function testSearchLimitDefaultValue() {
-    $actual = $this->config->getSearchResultsSize();
-    $this->assertEquals(20, $actual);
-  }
+    public function testGetHttpTimeout()
+    {
+        $this->assertEquals(2, $this->config->getHttpTimeout());
+    }
 
-  /**
-   * @covers GlobalConfig::getTemplateCache
-   */
-  public function testTemplateCacheDefaultValue() {
-    $actual = $this->config->getTemplateCache();
-    $this->assertEquals('/tmp/skosmos-template-cache', $actual);
-  }
+    public function testGetServiceName()
+    {
+        $this->assertEquals("Skosmos being tested", $this->config->getServiceName());
+    }
 
-  /**
-   * @covers GlobalConfig::getDefaultSparqlDialect
-   */
-  public function testSparqlDialectDefaultValue() {
-    $actual = $this->config->getDefaultSparqlDialect();
-    $this->assertEquals('Generic', $actual);
-  }
+    public function testGetBaseHref()
+    {
+        $this->assertEquals("http://tests.localhost/Skosmos/", $this->config->getBaseHref());
+    }
 
-  /**
-   * @covers GlobalConfig::getFeedbackAddress
-   */
-  public function testFeedbackAddressDefaultValue() {
-    $actual = $this->config->getFeedbackAddress();
-    $this->assertEquals(null, $actual);
-  }
+    public function testGetLanguages()
+    {
+        $this->assertEquals(array('en' => 'en_GB.utf8'), $this->config->getLanguages());
+    }
 
-  /**
-   * @covers GlobalConfig::getLogCaughtExceptions
-   */
-  public function testExceptionLoggingDefaultValue() {
-    $actual = $this->config->getLogCaughtExceptions();
-    $this->assertEquals(null, $actual);
-  }
+    public function testGetSearchResultsSize()
+    {
+        $this->assertEquals(5, $this->config->getSearchResultsSize());
+    }
 
-  /**
-   * @covers GlobalConfig::getServiceName
-   */
-  public function testServiceNameDefaultValue() {
-    $actual = $this->config->getServiceName();
-    $this->assertEquals('Skosmos', $actual);
-  }
+    public function testGetDefaultTransitiveLimit()
+    {
+        $this->assertEquals(100, $this->config->getDefaultTransitiveLimit());
+    }
 
-  /**
-   * @covers GlobalConfig::getCustomCss
-   */
-  public function testCustomCssDefaultValue() {
-    $actual = $this->config->getCustomCss();
-    $this->assertEquals(null, $actual);
-  }
+    public function testGetLogCaughtExceptions()
+    {
+        $this->assertEquals(true, $this->config->getLogCaughtExceptions());
+    }
 
-  /**
-   * @covers GlobalConfig::getUILanguageDropdown
-   */
-  public function testDefaultValue() {
-    $actual = $this->config->getUILanguageDropdown();
-    $this->assertFalse($actual);
-  }
+    public function testGetLoggingBrowserConsole()
+    {
+        $this->assertEquals(true, $this->config->getLoggingBrowserConsole());
+    }
 
-  /**
-   * @covers GlobalConfig::getBaseHref
-   */
-  public function testBaseHrefDefaultValue() {
-    $actual = $this->config->getBaseHref();
-    $this->assertEquals(null, $actual);
-  }
+    public function testGetLoggingFilename()
+    {
+        $this->assertEquals("/tmp/test_skosmos.log", $this->config->getLoggingFilename());
+    }
 
-  /**
-   * @covers GlobalConfig::getCollationEnabled
-   */
-  public function testGetCollationEnabled() {
-    $actual = $this->config->getCollationEnabled();
-    $this->assertFalse($actual);
-  }
+    public function testGetTemplateCache()
+    {
+        $this->assertEquals("/tmp/skosmos-template-cache/tests", $this->config->getTemplateCache());
+    }
 
-  /**
-   * @covers GlobalConfig::getGlobalPlugins
-   */
-  public function testGetGlobalPlugins() {
-    $actual = $this->config->getGlobalPlugins();
-    $this->assertEquals(array("alpha", "Bravo", "charlie"), $actual);
-  }
+    public function testGetCustomCss()
+    {
+        $this->assertEquals("resource/css/tests-stylesheet.css", $this->config->getCustomCss());
+    }
+
+    public function testGetFeedbackAddress()
+    {
+        $this->assertEquals("tests@skosmos.test", $this->config->getFeedbackAddress());
+    }
+
+    public function testGetFeedbackSender()
+    {
+        $this->assertEquals("tests skosmos", $this->config->getFeedbackSender());
+    }
+
+    public function testGetFeedbackEnvelopeSender()
+    {
+        $this->assertEquals("skosmos tests", $this->config->getFeedbackEnvelopeSender());
+    }
+
+    public function testGetUiLanguageDropdown()
+    {
+        $this->assertEquals(true, $this->config->getUiLanguageDropdown());
+    }
+
+    public function testGetHoneypotEnabled()
+    {
+        $this->assertEquals(false, $this->config->getHoneypotEnabled());
+    }
+
+    public function testGetHoneypotTime()
+    {
+        $this->assertEquals(2, $this->config->getHoneypotTime());
+    }
+
+    public function testGetGlobalPlugins()
+    {
+        $this->assertEquals(["widget"], $this->config->getGlobalPlugins());
+    }
+
+    // --- tests for the exception paths
+
+    /**
+     * @expectedException
+     */
+    public function testInitializeConfigWithoutGraph()
+    {
+        new GlobalConfig('/../tests/testconfig-nograph.ttl');
+    }
+
+    /**
+     * @expectedException
+     */
+    public function testInexistentFile()
+    {
+        new GlobalConfig('/../tests/testconfig-idonotexist.ttl');
+    }
+
+    // --- tests for some default values
+
+    public function testsGetDefaultLanguages()
+    {
+        $this->assertEquals(['en' => 'en_GB.utf8'], $this->configWithDefaults->getLanguages());
+    }
+
+    public function testGetDefaultHttpTimeout()
+    {
+        $this->assertEquals(5, $this->configWithDefaults->getHttpTimeout());
+    }
+
+    public function testGetDefaultFeedbackAddress()
+    {
+        $this->assertEquals(null, $this->configWithDefaults->getFeedbackAddress());
+    }
+
+    public function testGetDefaultLogCaughtExceptions()
+    {
+        $this->assertEquals(false, $this->configWithDefaults->getLogCaughtExceptions());
+    }
+
+    public function testGetDefaultServiceName()
+    {
+        $this->assertEquals("Skosmos", $this->configWithDefaults->getServiceName());
+    }
 }
 

--- a/tests/GlobalConfigTest.php
+++ b/tests/GlobalConfigTest.php
@@ -128,7 +128,7 @@ class GlobalConfigTest extends PHPUnit\Framework\TestCase
 
     public function testGetGlobalPlugins()
     {
-        $this->assertEquals(["widget"], $this->config->getGlobalPlugins());
+        $this->assertEquals(["alpha", "Bravo", "charlie"], $this->config->getGlobalPlugins());
     }
 
     // --- tests for the exception paths

--- a/tests/VocabularyConfigTest.php
+++ b/tests/VocabularyConfigTest.php
@@ -2,13 +2,18 @@
 
 class VocabularyConfigTest extends PHPUnit\Framework\TestCase
 {
-
+  /** @var Model */
   private $model;
 
+  /**
+   * @covers VocabularyConfig::getConfig
+   * @throws Exception
+   */
   protected function setUp() {
     putenv("LC_ALL=en_GB.utf8");
     setlocale(LC_ALL, 'en_GB.utf8');
     $this->model = new Model(new GlobalConfig('/../tests/testconfig.ttl'));
+    $this->assertNotNull($this->model->getVocabulary('test')->getConfig()->getPlugins(), "The PluginRegister of the model was not initialized!");
   }
 
   /**
@@ -378,5 +383,47 @@ class VocabularyConfigTest extends PHPUnit\Framework\TestCase
     $vocab = $this->model->getVocabulary('subtag');
     $this->assertEquals(array('en', 'fr', 'de', 'sv'), $vocab->getConfig()->getLanguageOrder('en'));
     $this->assertEquals(array('fi', 'fr', 'de', 'sv', 'en'), $vocab->getConfig()->getLanguageOrder('fi'));
+  }
+
+  /**
+   * @covers VocabularyConfig::showAlphabeticalIndex
+   */
+  public function testShowAlphabeticalIndex() {
+    $vocab = $this->model->getVocabulary('testdiff');
+    $this->assertTrue($vocab->getConfig()->showAlphabeticalIndex());
+  }
+
+  /**
+   * @covers VocabularyConfig::showNotation
+   */
+  public function testShowNotation() {
+    $vocab = $this->model->getVocabulary('test');
+    $this->assertTrue($vocab->getConfig()->showNotation());
+  }
+
+  /**
+   * @covers VocabularyConfig::getId
+   */
+  public function testGetId() {
+    $vocab = $this->model->getVocabulary('testdiff');
+    $this->assertEquals('testdiff' , $vocab->getConfig()->getId());
+  }
+
+  /**
+   * @covers VocabularyConfig::getMainConceptSchemeURI
+   */
+  public function testGetMainConceptSchemeURI() {
+    $vocab = $this->model->getVocabulary('testdiff');
+    $this->assertEquals('http://www.skosmos.skos/testdiff#conceptscheme' , $vocab->getConfig()->getMainConceptSchemeURI());
+    $vocab = $this->model->getVocabulary('test');
+    $this->assertNull(null , $vocab->getConfig()->getMainConceptSchemeURI());
+  }
+
+  /**
+   * @covers VocabularyConfig::getExtProperties
+   */
+  public function testGetExtProperties() {
+    $vocab = $this->model->getVocabulary('cbd');
+    $this->assertEquals(4 , count($vocab->getConfig()->getExtProperties()));
   }
 }

--- a/tests/testconfig-fordefaults.ttl
+++ b/tests/testconfig-fordefaults.ttl
@@ -1,0 +1,18 @@
+@prefix void: <http://rdfs.org/ns/void#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix dc: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix wv: <http://vocab.org/waiver/terms/norms> .
+@prefix sd: <http://www.w3.org/ns/sparql-service-description#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix skosmos: <http://purl.org/net/skosmos#> .
+@prefix isothes: <http://purl.org/iso25964/skos-thes#> .
+@prefix mdrtype: <http://publications.europa.eu/resource/authority/dataset-type/> .
+@prefix : <#> .
+
+# Skosmos main configuration
+
+:config a skosmos:Configuration .

--- a/tests/testconfig.ttl
+++ b/tests/testconfig.ttl
@@ -24,44 +24,44 @@
     skosmos:sparqlEndpoint <http://localhost:13030/ds/sparql> ;
     # sparql-query extension, or "Generic" for plain SPARQL 1.1
     # set to "JenaText" instead if you use Fuseki with jena-text index
-    skosmos:sparqlDialect "Generic" ;
+    skosmos:sparqlDialect "JenaText" ;
     # whether to enable collation in sparql queries
-    skosmos:sparqlCollationEnabled false ;
+    skosmos:sparqlCollationEnabled true ;
     # HTTP client configuration
-    skosmos:sparqlTimeout 20 ;
-    skosmos:httpTimeout 5 ;
+    skosmos:sparqlTimeout 10 ;
+    skosmos:httpTimeout 2 ;
     # customize the service name
-    skosmos:serviceName "Skosmos" ;
+    skosmos:serviceName "Skosmos being tested" ;
     # customize the base element. Set this if the automatic base url detection doesn't work. For example setups behind a proxy.
-    # skosmos:baseHref "http://localhost/Skosmos/" ;
+    skosmos:baseHref "http://tests.localhost/Skosmos/" ;
     # interface languages available, and the corresponding system locales
     skosmos:languages ( [ rdfs:label "en" ; rdf:value "en_GB.utf8" ] ) ;
     # how many results (maximum) to load at a time on the search results page
-    skosmos:searchResultsSize 20 ;
+    skosmos:searchResultsSize 5 ;
     # how many items (maximum) to retrieve in transitive property queries
-    skosmos:transitiveLimit 1000 ;
+    skosmos:transitiveLimit 100 ;
     # whether or not to log caught exceptions
-    skosmos:logCaughtExceptions false ;
+    skosmos:logCaughtExceptions true ;
     # set to TRUE to enable logging into browser console
-    skosmos:logBrowserConsole false ;
+    skosmos:logBrowserConsole true ;
     # set to a logfile path to enable logging into log file
-    # skosmos:logFileName "" ;
+    skosmos:logFileName "/tmp/test_skosmos.log" ;
     # a default location for Twig template rendering
-    skosmos:templateCache "/tmp/skosmos-template-cache" ;
+    skosmos:templateCache "/tmp/skosmos-template-cache/tests" ;
     # customize the css by adding your own stylesheet
-    # skosmos:customCss "resource/css/stylesheet.css" ;
+    skosmos:customCss "resource/css/tests-stylesheet.css" ;
     # default email address where to send the feedback
-    skosmos:feedbackAddress "" ;
+    skosmos:feedbackAddress "tests@skosmos.test" ;
     # email address to set as the sender for feedback messages
-    skosmos:feedbackSender "" ;
+    skosmos:feedbackSender "tests skosmos" ;
     # email address to set as the envelope sender for feedback messages
-    skosmos:feedbackEnvelopeSender "" ;
+    skosmos:feedbackEnvelopeSender "skosmos tests" ;
     # whether to display the ui language selection as a dropdown (useful for cases where there are more than 3 languages) 
-    skosmos:uiLanguageDropdown false ;
+    skosmos:uiLanguageDropdown true ;
     # whether to enable the spam honey pot or not, enabled by default
-    skosmos:uiHoneypotEnabled true ;
+    skosmos:uiHoneypotEnabled false ;
     # default time a user must wait before submitting a form
-    skosmos:uiHoneypotTime 5 ;
+    skosmos:uiHoneypotTime 2 ;
     # plugins to activate for the whole installation (including all vocabularies)
     skosmos:globalPlugins ("alpha" "Bravo" "charlie") .
 


### PR DESCRIPTION
Fix for #792 . Re-writes `GlobalConfigTest` to test values other than the default ones. Also includes more tests for `VocabularyConfig`.

Tests passing locally, with exception of those JSON-LD ones, that were failing in another PR.

Happy to update the pull request, so feel free to suggest enhancements/fixes, please.

Thank you! And sorry for the regression!
Bruno