### PR TITLE
using fuseki2 for unit tests, fixes #791

### DIFF
--- a/tests/init_fuseki.sh
+++ b/tests/init_fuseki.sh
@@ -1,25 +1,16 @@
 #!/bin/bash
 # Note: This script must be sourced from within bash, e.g. ". init_fuseki.sh"
 
-FUSEKI_VERSION=${FUSEKI_VERSION:-3.4.0}
+FUSEKI_VERSION=${FUSEKI_VERSION:-3.8.0}
+fusekiurl="http://mirror.netinch.com/pub/apache/jena/binaries/apache-jena-fuseki-$FUSEKI_VERSION.tar.gz"
 
-if [ "$FUSEKI_VERSION" = "SNAPSHOT" ]; then
-	# find out the latest snapshot version and its download URL by parsing Apache directory listings
-	snapshotdir="https://repository.apache.org/content/repositories/snapshots/org/apache/jena/jena-fuseki1/"
-	latestdir=$(wget -q -O- "$snapshotdir" | grep 'a href=' | cut -d '"' -f 2 | grep SNAPSHOT | tail -n 1)
-	FUSEKI_VERSION=$(basename "$latestdir")
-	fusekiurl=$(wget -q -O- "$latestdir" | grep 'a href=' | cut -d '"' -f 2 | grep 'distribution\.tar\.gz$' | tail -n 1)
-else
-	fusekiurl="https://repository.apache.org/content/repositories/releases/org/apache/jena/jena-fuseki1/$FUSEKI_VERSION/jena-fuseki1-$FUSEKI_VERSION-distribution.tar.gz"
-fi
-
-if [ ! -f "jena-fuseki1-$FUSEKI_VERSION/fuseki-server" ]; then
+if [ ! -f "apache-jena-fuseki-$FUSEKI_VERSION/fuseki-server" ]; then
   echo "fuseki server file not found - downloading it"
   wget --output-document=fuseki-dist.tar.gz "$fusekiurl"
   tar -zxvf fuseki-dist.tar.gz
 fi
 
-cd "jena-fuseki1-$FUSEKI_VERSION"
+cd "apache-jena-fuseki-$FUSEKI_VERSION"
 ./fuseki-server --config ../fuseki-assembler.ttl &
 until curl --output /dev/null --silent --head --fail http://localhost:3030; do
   printf '.'
@@ -28,7 +19,7 @@ done
 
 for fn in ../test-vocab-data/*.ttl; do
   name=$(basename "${fn}" .ttl)
-  $(./s-put http://localhost:3030/ds/data "http://www.skosmos.skos/$name/" "$fn")
+  $(./bin/s-put http://localhost:3030/ds/data "http://www.skosmos.skos/$name/" "$fn")
 done
 
 cd ..


### PR DESCRIPTION
Updated the bash script init_fuseki.sh to use fuseki2. This should fix #791 