### PR TITLE
Add REST endpoint for mappings [WIP]

### DIFF
--- a/controller/RestController.php
+++ b/controller/RestController.php
@@ -622,6 +622,34 @@ class RestController extends Controller
     }
 
     /**
+     * Get the mappings associated with a concept, enriched with labels and notations.
+     * Returns a JSKOS-compatible JSON object.
+     * @param Request $request
+     */
+    public function mappings(Request $request)
+    {
+        $vocab = $request->getVocab();
+
+        if ($request->getUri()) {
+            $uri = $request->getUri();
+        } else {
+            return $this->returnError(400, 'Bad Request', "uri parameter missing");
+        }
+
+        $results = $vocab->getConceptInfo($uri, $request->getContentLang());
+        $concept = $results[0];
+
+        $ret = [];
+        foreach ($concept->getMappingProperties() as $mappingProperty) {
+            foreach ($mappingProperty->getValues() as $mappingPropertyValue) {
+                $ret[] = $mappingPropertyValue->asJskos();
+            }
+        }
+
+        return $this->returnJson($ret);
+    }
+
+    /**
      * Used for querying labels for a uri.
      * @param Request $request
      * @return object json-ld wrapped labels.

--- a/controller/RestController.php
+++ b/controller/RestController.php
@@ -636,6 +636,8 @@ class RestController extends Controller
             return $this->returnError(400, 'Bad Request', "uri parameter missing");
         }
 
+        $queryExVocabs = $request->getQueryParamBoolean('external', true);
+
         $results = $vocab->getConceptInfo($uri, $request->getContentLang());
         if (empty($results)) {
             return $this->returnError(404, 'Bad Request', "no concept found with given uri");
@@ -646,7 +648,7 @@ class RestController extends Controller
         $ret = [];
         foreach ($concept->getMappingProperties() as $mappingProperty) {
             foreach ($mappingProperty->getValues() as $mappingPropertyValue) {
-                $ret[] = $mappingPropertyValue->asJskos();
+                $ret[] = $mappingPropertyValue->asJskos($queryExVocabs);
             }
         }
 

--- a/controller/RestController.php
+++ b/controller/RestController.php
@@ -637,6 +637,10 @@ class RestController extends Controller
         }
 
         $results = $vocab->getConceptInfo($uri, $request->getContentLang());
+        if (empty($results)) {
+            return $this->returnError(404, 'Bad Request', "no concept found with given uri");
+        }
+
         $concept = $results[0];
 
         $ret = [];

--- a/model/Concept.php
+++ b/model/Concept.php
@@ -430,14 +430,14 @@ class Concept extends VocabularyDataObject
                             }
 
                             if ($response) {
-                                $ret[$prop]->addValue(new ConceptMappingPropertyValue($this->model, $this->vocab, $response, $prop), $this->clang);
+                                $ret[$prop]->addValue(new ConceptMappingPropertyValue($this->model, $this->vocab, $response, $this->resource, $prop), $this->clang);
 
                                 $this->processExternalResource($response);
 
                                 continue;
                             }
                         }
-                        $ret[$prop]->addValue(new ConceptMappingPropertyValue($this->model, $this->vocab, $val, $prop, $this->clang), $this->clang);
+                        $ret[$prop]->addValue(new ConceptMappingPropertyValue($this->model, $this->vocab, $val, $this->resource, $prop, $this->clang), $this->clang);
                     }
                 }
             }

--- a/model/ConceptMappingPropertyValue.php
+++ b/model/ConceptMappingPropertyValue.php
@@ -44,7 +44,7 @@ class ConceptMappingPropertyValue extends VocabularyDataObject
         return $this->type;
     }
 
-    public function getLabel($lang = '')
+    public function getLabel($lang = '', $queryExVocabs = true)
     {
         if (isset($this->labelcache[$lang])) {
             return $this->labelcache[$lang];
@@ -55,7 +55,7 @@ class ConceptMappingPropertyValue extends VocabularyDataObject
         return $label;
     }
 
-    private function queryLabel($lang = '')
+    private function queryLabel($lang = '', $queryExVocabs = true)
     {
         if ($this->clang) {
             $lang = $this->clang;
@@ -68,7 +68,7 @@ class ConceptMappingPropertyValue extends VocabularyDataObject
         }
 
         // if multiple vocabularies are found, the following method will return in priority the current vocabulary of the mapping
-        $exvocab = $this->model->guessVocabularyFromURI($this->resource->getUri(), $this->vocab->getId());
+        $exvocab = $queryExVocabs ? $this->model->guessVocabularyFromURI($this->resource->getUri(), $this->vocab->getId()) : null;
 
         // if the resource is from another vocabulary known by the skosmos instance
         if ($exvocab) {
@@ -166,7 +166,7 @@ class ConceptMappingPropertyValue extends VocabularyDataObject
      * Return the mapping as a JSKOS-compatible array.
      * @return array
      */
-    public function asJskos()
+    public function asJskos($queryExVocabs = true)
     {
         $ret = [
             'type' => [$this->type],
@@ -205,7 +205,7 @@ class ConceptMappingPropertyValue extends VocabularyDataObject
             $ret['to']['memberSet'][0]['notation'] = (string) $notation;
         }
 
-        $label = $this->getLabel();
+        $label = $this->getLabel($queryExVocabs);
         if (isset($label)) {
             if (is_string($label)) {
                 list($labelLang, $labelValue) = ['-', $label];

--- a/model/ConceptMappingPropertyValue.php
+++ b/model/ConceptMappingPropertyValue.php
@@ -207,9 +207,18 @@ class ConceptMappingPropertyValue extends VocabularyDataObject
 
         $label = $this->getLabel();
         if (isset($label)) {
-            $ret['to']['memberSet'][0]['prefLabel'] = [
-                $label->getLang() => $label->getValue(),
-            ];
+            if (is_string($label)) {
+                list($labelLang, $labelValue) = ['-', $label];
+            } else {
+                list($labelLang, $labelValue) = [$label->getLang(), $label->getValue()];
+            }
+            if ($labelValue != $this->getUri()) {
+                // The `queryLabel()` method above will fallback to returning the URI
+                // if no label was found. We don't want that here.
+                $ret['to']['memberSet'][0]['prefLabel'] = [
+                    $labelLang => $labelValue,
+                ];
+            }
         }
 
         return $ret;

--- a/rest.php
+++ b/rest.php
@@ -31,8 +31,6 @@ try {
         $controller->types($request);
     } elseif ($parts[1] == 'data') {
         $controller->data($request);
-    } elseif ($parts[1] == 'mappings') {
-        $controller->mappings($request);
     } elseif (sizeof($parts) == 2) {
         header("Location: " . $parts[1] . "/");
     } else {
@@ -55,6 +53,8 @@ try {
             $controller->topConcepts($request);
         } elseif ($parts[2] == 'data') {
             $controller->data($request);
+        } elseif ($parts[2] == 'mappings') {
+            $controller->mappings($request);
         } elseif ($parts[2] == 'search') {
             $controller->search($request);
         } elseif ($parts[2] == 'label') {

--- a/rest.php
+++ b/rest.php
@@ -31,6 +31,8 @@ try {
         $controller->types($request);
     } elseif ($parts[1] == 'data') {
         $controller->data($request);
+    } elseif ($parts[1] == 'mappings') {
+        $controller->mappings($request);
     } elseif (sizeof($parts) == 2) {
         header("Location: " . $parts[1] . "/");
     } else {

--- a/tests/ConceptMappingPropertyValueTest.php
+++ b/tests/ConceptMappingPropertyValueTest.php
@@ -26,7 +26,8 @@ class ConceptMappingPropertyValueTest extends PHPUnit\Framework\TestCase
    */
   public function testConstructor() {
     $resourcestub = $this->getMockBuilder('EasyRdf\Resource')->disableOriginalConstructor()->getMock();
-    $mapping = new ConceptMappingPropertyValue($this->model, $this->vocab, $resourcestub, 'skos:exactMatch');
+    $sourcestub = $this->getMockBuilder('EasyRdf\Resource')->disableOriginalConstructor()->getMock();
+    $mapping = new ConceptMappingPropertyValue($this->model, $this->vocab, $resourcestub, $sourcestub, 'skos:exactMatch');
     $this->assertEquals('skos:exactMatch', $mapping->getType());
   }
 
@@ -45,6 +46,7 @@ class ConceptMappingPropertyValueTest extends PHPUnit\Framework\TestCase
    * @covers ConceptMappingPropertyValue::queryLabel
    */
   public function testGetLabelResortsToUri() {
+    $mocksource = $this->getMockBuilder('EasyRdf\Resource')->disableOriginalConstructor()->getMock();
     $mockres = $this->getMockBuilder('EasyRdf\Resource')->disableOriginalConstructor()->getMock();
     $labelmap = array(
       array('en', null),
@@ -57,7 +59,7 @@ class ConceptMappingPropertyValueTest extends PHPUnit\Framework\TestCase
     );
     $mockres->method('getLiteral')->will($this->returnValueMap($litmap));
     $mockres->method('getUri')->will($this->returnValue('http://thisdoesntexistatalland.sefsf/2j2h4/'));
-    $mapping = new ConceptMappingPropertyValue($this->model, $this->vocab, $mockres, null);
+    $mapping = new ConceptMappingPropertyValue($this->model, $this->vocab, $mockres, $mocksource, 'skos:exactMatch');
     $this->assertEquals('http://thisdoesntexistatalland.sefsf/2j2h4/', $mapping->getLabel());
   }
 
@@ -66,6 +68,7 @@ class ConceptMappingPropertyValueTest extends PHPUnit\Framework\TestCase
    * @covers ConceptMappingPropertyValue::queryLabel
    */
   public function testGetLabelWithAndWithoutLang() {
+    $mocksource = $this->getMockBuilder('EasyRdf\Resource')->disableOriginalConstructor()->getMock();
     $mockres = $this->getMockBuilder('EasyRdf\Resource')->disableOriginalConstructor()->getMock();
     $labelmap = array(
       array('en', 'english'),
@@ -73,7 +76,7 @@ class ConceptMappingPropertyValueTest extends PHPUnit\Framework\TestCase
     );
     $mockres->method('label')->will($this->returnValueMap($labelmap));
     $mockres->method('getUri')->will($this->returnValue('http://thisdoesntexistatalland.sefsf/2j2h4/'));
-    $mapping = new ConceptMappingPropertyValue($this->model, $this->vocab, $mockres, null);
+    $mapping = new ConceptMappingPropertyValue($this->model, $this->vocab, $mockres, $mocksource, 'skos:exactMatch');
     $this->assertEquals('english', $mapping->getLabel('en'));
     $this->assertEquals('default', $mapping->getLabel());
   }
@@ -83,6 +86,7 @@ class ConceptMappingPropertyValueTest extends PHPUnit\Framework\TestCase
    * @covers ConceptMappingPropertyValue::queryLabel
    */
   public function testGetLabelWithLiteralAndLang() {
+    $mocksource = $this->getMockBuilder('EasyRdf\Resource')->disableOriginalConstructor()->getMock();
     $mockres = $this->getMockBuilder('EasyRdf\Resource')->disableOriginalConstructor()->getMock();
     $labelmap = array(
       array('en', null),
@@ -95,7 +99,7 @@ class ConceptMappingPropertyValueTest extends PHPUnit\Framework\TestCase
     );
     $mockres->method('getLiteral')->will($this->returnValueMap($litmap));
     $mockres->method('getUri')->will($this->returnValue('http://thisdoesntexistatalland.sefsf/2j2h4/'));
-    $mapping = new ConceptMappingPropertyValue($this->model, $this->vocab, $mockres, null);
+    $mapping = new ConceptMappingPropertyValue($this->model, $this->vocab, $mockres, $mocksource, 'skos:exactMatch');
     $this->assertEquals('english lit', $mapping->getLabel('en'));
     $this->assertEquals('default lit', $mapping->getLabel());
   }
@@ -104,6 +108,7 @@ class ConceptMappingPropertyValueTest extends PHPUnit\Framework\TestCase
    * @covers ConceptMappingPropertyValue::getNotation
    */
   public function testGetNotation() {
+    $mocksource = $this->getMockBuilder('EasyRdf\Resource')->disableOriginalConstructor()->getMock();
     $mockres = $this->getMockBuilder('EasyRdf\Resource')->disableOriginalConstructor()->getMock();
     $mocklit = $this->getMockBuilder('EasyRdf\Literal')->disableOriginalConstructor()->getMock();
     $mocklit->method('getValue')->will($this->returnValue('666'));
@@ -112,7 +117,7 @@ class ConceptMappingPropertyValueTest extends PHPUnit\Framework\TestCase
         array(null,null,null,null),
     );
     $mockres->method('get')->will($this->returnValueMap($map));
-    $mapping = new ConceptMappingPropertyValue($this->model, $this->vocab, $mockres, null);
+    $mapping = new ConceptMappingPropertyValue($this->model, $this->vocab, $mockres, $mocksource, 'skos:exactMatch');
     $this->assertEquals(666, $mapping->getNotation());
   }
 
@@ -163,6 +168,38 @@ class ConceptMappingPropertyValueTest extends PHPUnit\Framework\TestCase
   public function testToString() {
     $propvals = $this->props['skos:exactMatch']->getValues();
     $this->assertEquals('Eel', $propvals['Eelhttp://www.skosmos.skos/test/ta115']->__toString());
+  }
+
+  /**
+   * @covers ConceptMappingPropertyValue::asJskos
+   */
+  public function testAsJskos() {
+    $propvals = $this->props['skos:exactMatch']->getValues();
+    $this->assertEquals([
+      'type' => [
+        'skos:exactMatch',
+      ],
+      'toScheme' => [
+        'uri' => 'http://www.skosmos.skos/test/conceptscheme',
+      ],
+      'from' => [
+        'memberSet' => [
+          [
+            'uri' => 'http://www.skosmos.skos/mapping/m1',
+          ]
+        ]
+      ],
+      'to' => [
+        'memberSet' => [
+          [
+            'uri' => 'http://www.skosmos.skos/test/ta115',
+            'prefLabel' => [
+              'en' => 'Eel',
+            ]
+          ]
+        ]
+      ],
+    ], $propvals['Eelhttp://www.skosmos.skos/test/ta115']->asJskos());
   }
 
 }


### PR DESCRIPTION
In the Skosmos UI, the mapping targets are enriched with labels and notations. It would be useful to also expose this data through the REST API, so I made an attempt of implementing this.

Since I think it would be good if the next revision of the API could align with JSKOS (#152), I tried to make a JSKOS-compatible output for this endpoint. It's a little bit verbose since JSKOS can encode more complex mapping relations than SKOS can. The "memberSet" level for instance is great for compound mappings, but a bit superfluous when such mappings are not supported, as is the case with SKOS. Still, it's good if we can align with some kind of standard, and JSKOS seems like a good one to me.

What do you think about adding this method to the v1-api?

At the moment, the endpoint can only return mappings for a single concept, but I guess we could also have it return all mappings when no concept is specified.

Btw. are you ok with adding type hinting? Since Skosmos is now PHP >= 7.0, it should be ok to add type hinting for both classes and primitives, right? 