### PR TITLE
Added a check for empty arrays to avoid the situation in #813

### DIFF
--- a/model/Concept.php
+++ b/model/Concept.php
@@ -514,7 +514,9 @@ class Concept extends VocabularyDataObject
                 // note that this imply that the property has an rdf:type declared for the query to work
                 if(!$proplabel) {
                     $envLangLabels = $this->model->getDefaultSparql()->queryLabel($longUri, $this->getEnvLang());
-                    $proplabel = ($envLangLabels)?$envLangLabels[$this->getEnvLang()]:$this->model->getDefaultSparql()->queryLabel($longUri, '')[''];
+                    
+                    $defaultGraphPropLabel = $this->model->getDefaultSparql()->queryLabel($longUri, '');
+                    $proplabel = ($envLangLabels)?$envLangLabels[$this->getEnvLang()]:($defaultGraphPropLabel)?$defaultGraphPropLabel['']:null;
                 }
 
                 // look for superproperties in the current graph

--- a/model/Concept.php
+++ b/model/Concept.php
@@ -515,8 +515,15 @@ class Concept extends VocabularyDataObject
                 if(!$proplabel) {
                     $envLangLabels = $this->model->getDefaultSparql()->queryLabel($longUri, $this->getEnvLang());
                     
-                    $defaultGraphPropLabel = $this->model->getDefaultSparql()->queryLabel($longUri, '');
-                    $proplabel = ($envLangLabels)?$envLangLabels[$this->getEnvLang()]:($defaultGraphPropLabel)?$defaultGraphPropLabel['']:null;
+                    $defaultPropLabel = $this->model->getDefaultSparql()->queryLabel($longUri, '');
+
+					if($envLangLabels) {
+						$proplabel = $envLangLabels[$this->getEnvLang()];
+                    } else {
+						if($defaultPropLabel) {
+							$proplabel = $defaultPropLabel[''];
+						}
+					}
                 }
 
                 // look for superproperties in the current graph


### PR DESCRIPTION
Fixes #813 by evaluating the result array for null or zero-length to get rid of undefined index errors for the array. Instead, if there's no label found for a property it returns null instead.