### PR TITLE
PHP 7.2 adjustments to Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,10 +31,9 @@ matrix:
   exclude:
   - php: 7.0
     env: FUSEKI_VERSION=SNAPSHOT
-  - php: 7.2
+  - php: 7.1
     env: FUSEKI_VERSION=SNAPSHOT
   allow_failures:
-  - php: 7.2
   - env: FUSEKI_VERSION=SNAPSHOT
 notifications:
     slack: kansalliskirjasto:9mOKu3Vws1CIddF5jqWgXbli


### PR DESCRIPTION
Travis builds using PHP 7.2 appear to be working now, so this PR does two things:
* no longer allow Travis PHP 7.2 builds to fail
* run the build that uses Fuseki snapshots (which is allowed to fail) with PHP 7.2 instead of 7.1