### PR TITLE
Set LANGUAGE environment variable in addition to LC_ALL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ before_script:
   - chmod +x ./cc-test-reporter
   - ./cc-test-reporter before-build
   - cd tests
+  - locale -a
   - sh ./init_fuseki.sh
   - cd ..
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_script:
   - chmod +x ./cc-test-reporter
   - ./cc-test-reporter before-build
   - cd tests
-  - locale -a
+  - export LANGUAGE=fr
   - sh ./init_fuseki.sh
   - cd ..
 after_script:

--- a/controller/Controller.php
+++ b/controller/Controller.php
@@ -48,6 +48,7 @@ class Controller
     {
         if (array_key_exists($lang, $this->languages)) {
             $locale = $this->languages[$lang]['locale'];
+            putenv("LANGUAGE=$locale");
             putenv("LC_ALL=$locale");
             setlocale(LC_ALL, $locale);
         } else {

--- a/tests/ConceptMappingPropertyValueTest.php
+++ b/tests/ConceptMappingPropertyValueTest.php
@@ -8,6 +8,7 @@ class ConceptMappingPropertyValueTest extends PHPUnit\Framework\TestCase
   private $props;
 
   protected function setUp() {
+    putenv("LANGUAGE=en_GB.utf8");
     putenv("LC_ALL=en_GB.utf8");
     setlocale(LC_ALL, 'en_GB.utf8');
     bindtextdomain('skosmos', 'resource/translations');

--- a/tests/ConceptPropertyTest.php
+++ b/tests/ConceptPropertyTest.php
@@ -5,6 +5,7 @@ class ConceptPropertyTest extends PHPUnit\Framework\TestCase
   private $model;
 
   protected function setUp() {
+    putenv("LANGUAGE=en_GB.utf8");
     putenv("LC_ALL=en_GB.utf8");
     setlocale(LC_ALL, 'en_GB.utf8');
     bindtextdomain('skosmos', 'resource/translations');

--- a/tests/ConceptPropertyValueLiteralTest.php
+++ b/tests/ConceptPropertyValueLiteralTest.php
@@ -7,6 +7,7 @@ class ConceptPropertyValueLiteralTest extends PHPUnit\Framework\TestCase
   private $vocab;
 
   protected function setUp() {
+    putenv("LANGUAGE=en_GB.utf8");
     putenv("LC_ALL=en_GB.utf8");
     setlocale(LC_ALL, 'en_GB.utf8');
     bindtextdomain('skosmos', 'resource/translations');

--- a/tests/ConceptPropertyValueTest.php
+++ b/tests/ConceptPropertyValueTest.php
@@ -7,6 +7,7 @@ class ConceptPropertyValueTest extends PHPUnit\Framework\TestCase
   private $vocab;
 
   protected function setUp() {
+    putenv("LANGUAGE=en_GB.utf8");
     putenv("LC_ALL=en_GB.utf8");
     setlocale(LC_ALL, 'en_GB.utf8');
     bindtextdomain('skosmos', 'resource/translations');

--- a/tests/ConceptSearchParametersTest.php
+++ b/tests/ConceptSearchParametersTest.php
@@ -6,6 +6,7 @@ class ConceptSearchParametersTest extends PHPUnit\Framework\TestCase
     private $request;
 
     protected function setUp() {
+        putenv("LANGUAGE=en_GB.utf8");
         putenv("LC_ALL=en_GB.utf8");
         setlocale(LC_ALL, 'en_GB.utf8');
         $this->request = $this->getMockBuilder('Request')->disableOriginalConstructor()->getMock();

--- a/tests/ConceptTest.php
+++ b/tests/ConceptTest.php
@@ -8,6 +8,7 @@ class ConceptTest extends PHPUnit\Framework\TestCase
   private $cbdGraph;
 
   protected function setUp() {
+    putenv("LANGUAGE=en_GB.utf8");
     putenv("LC_ALL=en_GB.utf8");
     setlocale(LC_ALL, 'en_GB.utf8');
     bindtextdomain('skosmos', 'resource/translations');

--- a/tests/GenericSparqlTest.php
+++ b/tests/GenericSparqlTest.php
@@ -9,6 +9,7 @@ class GenericSparqlTest extends PHPUnit\Framework\TestCase
   private $params;
 
   protected function setUp() {
+    putenv("LANGUAGE=en_GB.utf8");
     putenv("LC_ALL=en_GB.utf8");
     setlocale(LC_ALL, 'en_GB.utf8');
     $this->model = new Model(new GlobalConfig('/../tests/testconfig.ttl'));

--- a/tests/JenaTextSparqlTest.php
+++ b/tests/JenaTextSparqlTest.php
@@ -9,6 +9,7 @@ class JenaTextSparqlTest extends PHPUnit\Framework\TestCase
   private $params;
 
   protected function setUp() {
+    putenv("LANGUAGE=en_GB.utf8");
     putenv("LC_ALL=en_GB.utf8");
     setlocale(LC_ALL, 'en_GB.utf8');
     $this->model = new Model(new GlobalConfig('/../tests/jenatestconfig.ttl'));

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -6,6 +6,7 @@ class ModelTest extends PHPUnit\Framework\TestCase
   private $model;
 
   protected function setUp() {
+    putenv("LANGUAGE=en_GB.utf8");
     putenv("LC_ALL=en_GB.utf8");
     setlocale(LC_ALL, 'en_GB.utf8');
     $this->model = new Model(new GlobalConfig('/../tests/testconfig.ttl'));

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -6,6 +6,7 @@ class RequestTest extends PHPUnit\Framework\TestCase
   private $request;
 
   protected function setUp() {
+    putenv("LANGUAGE=en_GB.utf8");
     putenv("LC_ALL=en_GB.utf8");
     setlocale(LC_ALL, 'en_GB.utf8');
     bindtextdomain('skosmos', 'resource/translations');

--- a/tests/RestControllerTest.php
+++ b/tests/RestControllerTest.php
@@ -8,6 +8,7 @@ require_once('controller/RestController.php');
 class RestControllerTest extends \PHPUnit\Framework\TestCase
 {
   protected function setUp() {
+    putenv("LANGUAGE=en_GB.utf8");
     putenv("LC_ALL=en_GB.utf8");
     setlocale(LC_ALL, 'en_GB.utf8');
     bindtextdomain('skosmos', 'resource/translations');

--- a/tests/VocabularyCategoryTest.php
+++ b/tests/VocabularyCategoryTest.php
@@ -6,6 +6,7 @@ class VocabularyCategoryTest extends PHPUnit\Framework\TestCase
   private $mockres;
 
   protected function setUp() {
+    putenv("LANGUAGE=en_GB.utf8");
     putenv("LC_ALL=en_GB.utf8");
     setlocale(LC_ALL, 'en_GB.utf8');
     $this->model = new Model(new GlobalConfig('/../tests/testconfig.ttl'));

--- a/tests/VocabularyConfigTest.php
+++ b/tests/VocabularyConfigTest.php
@@ -10,6 +10,7 @@ class VocabularyConfigTest extends PHPUnit\Framework\TestCase
    * @throws Exception
    */
   protected function setUp() {
+    putenv("LANGUAGE=en_GB.utf8");
     putenv("LC_ALL=en_GB.utf8");
     setlocale(LC_ALL, 'en_GB.utf8');
     $this->model = new Model(new GlobalConfig('/../tests/testconfig.ttl'));

--- a/tests/VocabularyTest.php
+++ b/tests/VocabularyTest.php
@@ -8,6 +8,7 @@ class VocabularyTest extends \PHPUnit\Framework\TestCase
   private $model;
 
   protected function setUp() {
+    putenv("LANGUAGE=en_GB.utf8");
     putenv("LC_ALL=en_GB.utf8");
     setlocale(LC_ALL, 'en_GB.utf8');
     $this->model = new Model(new GlobalConfig('/../tests/testconfig.ttl'));


### PR DESCRIPTION
This PR fixes #816 by making sure that the LANGUAGE environment variable is always set at the same time as LC_ALL.

The unit tests are changed a little (forcing LANGUAGE=fr for Travis) so that we can catch the problem.