### PR TITLE
Switch from FILTER NOT EXISTS to MINUS to avoid Jena 3.8+ performance issue

### DIFF
--- a/model/sparql/GenericSparql.php
+++ b/model/sparql/GenericSparql.php
@@ -367,7 +367,7 @@ EOQ;
                       ?x skos:prefLabel ?xl .
                       FILTER NOT EXISTS {
                         ?x skos:member ?other .
-                        FILTER NOT EXISTS { ?other skos:broader ?uri }
+                        MINUS { ?other skos:broader ?uri }
                       }
                     }";
         }


### PR DESCRIPTION
This is an attempt at a minimally invasive fix for the performance issue #829 .

It's unclear whether this is a good long term solution - it would probably make more sense to avoid the VALUES clause entirely but that would require more changes, since the same query is currently used with multiple URI values in the VALUES clause when rendering the search result page.

Related to #611 and #29