### PR TITLE
Support last modified header

### DIFF
--- a/controller/Controller.php
+++ b/controller/Controller.php
@@ -141,8 +141,19 @@ class Controller
                 header('HTTP/1.0 304 Not Modified');
                 return true;
             }
-            header("Last-Modified: " . $modifiedDate->format('Y-m-d H:i:s'));
+            $this->sendHeader("Last-Modified: " . $modifiedDate->format('Y-m-d H:i:s'));
         }
         return false;
+    }
+
+    /**
+     * Sends HTTP headers. Simply calls PHP built-in header function. But being
+     * a function here, it can easily be tested/mocked.
+     *
+     * @param $header string header to be sent
+     */
+    protected function sendHeader($header): void
+    {
+        header($header);
     }
 }

--- a/controller/Controller.php
+++ b/controller/Controller.php
@@ -121,7 +121,7 @@ class Controller
 
     /**
      * If the $modifiedDate is a valid DateTime, and if the $_SERVER variable contains the right info, and
-     * if the $modifiedDate is more recent than the latest value in $_SERVER, then this function sets the
+     * if the $modifiedDate is not more recent than the latest value in $_SERVER, then this function sets the
      * HTTP 304 not modified and returns true..
      *
      * If the $modifiedDate is still valid, then it sets the Last-Modified header, to be used by the browser for

--- a/controller/Controller.php
+++ b/controller/Controller.php
@@ -136,14 +136,22 @@ class Controller
     protected function sendNotModifiedHeader($modifiedDate): bool
     {
         if ($modifiedDate) {
-            if (isset($_SERVER['HTTP_IF_MODIFIED_SINCE']) &&
-                strtotime($_SERVER['HTTP_IF_MODIFIED_SINCE']) >= $modifiedDate) {
-                header('HTTP/1.0 304 Not Modified');
+            $ifModifiedSince = $this->getIfModifiedSince();
+            $this->sendHeader("Last-Modified: " . $modifiedDate->format('Y-m-d H:i:s'));
+            if (!is_null($ifModifiedSince) && $ifModifiedSince >= $modifiedDate) {
+                $this->sendHeader("HTTP/1.0 304 Not Modified");
                 return true;
             }
-            $this->sendHeader("Last-Modified: " . $modifiedDate->format('Y-m-d H:i:s'));
         }
         return false;
+    }
+
+    /**
+     * @return DateTime|null a DateTime object if the value exists in the $_SERVER variable, null otherwise
+     */
+    protected function getIfModifiedSince()
+    {
+        return isset($_SERVER["HTTP_IF_MODIFIED_SINCE"]) ? strtotime($_SERVER["HTTP_IF_MODIFIED_SINCE"]) : null;
     }
 
     /**
@@ -152,7 +160,7 @@ class Controller
      *
      * @param $header string header to be sent
      */
-    protected function sendHeader($header): void
+    protected function sendHeader($header)
     {
         header($header);
     }

--- a/controller/Controller.php
+++ b/controller/Controller.php
@@ -118,4 +118,31 @@ class Controller
         header("Content-type: text/plain; charset=utf-8");
         echo "$code $status : $message";
     }
+
+    /**
+     * If the $modifiedDate is a valid DateTime, and if the $_SERVER variable contains the right info, and
+     * if the $modifiedDate is more recent than the latest value in $_SERVER, then this function sets the
+     * HTTP 304 not modified and returns true..
+     *
+     * If the $modifiedDate is still valid, then it sets the Last-Modified header, to be used by the browser for
+     * subsequent requests, and returns false.
+     *
+     * Otherwise, it returns false.
+     *
+     * @param DateTime $modifiedDate the last modified date to be compared against server's modified since information
+     * @return bool whether it sent the HTTP 304 not modified headers or not (useful for sending the response without
+     *              further actions)
+     */
+    protected function sendNotModifiedHeader($modifiedDate): bool
+    {
+        if ($modifiedDate) {
+            if (isset($_SERVER['HTTP_IF_MODIFIED_SINCE']) &&
+                strtotime($_SERVER['HTTP_IF_MODIFIED_SINCE']) >= $modifiedDate) {
+                header('HTTP/1.0 304 Not Modified');
+                return true;
+            }
+            header("Last-Modified: " . $modifiedDate->format('Y-m-d H:i:s'));
+        }
+        return false;
+    }
 }

--- a/controller/WebController.php
+++ b/controller/WebController.php
@@ -264,7 +264,6 @@ class WebController extends Controller
                 }
             }
         }
-        // TODO: validate date before sending it!
         return $modifiedDate;
     }
 

--- a/controller/WebController.php
+++ b/controller/WebController.php
@@ -248,6 +248,7 @@ class WebController extends Controller
 
     /**
      * @param Concept $concept
+     * @param Vocabulary $vocab
      * @return DateTime|null
      */
     protected function getModifiedDate(Concept $concept, Vocabulary $vocab)

--- a/model/Concept.php
+++ b/model/Concept.php
@@ -656,6 +656,21 @@ class Concept extends VocabularyDataObject
     }
 
     /**
+     * @return DateTime|null the modified date, or null if not available
+     */
+    public function getModifiedDate()
+    {
+        $modified = null;
+        // finding the modified properties
+        /** @var \EasyRdf\Resource $modifiedResource */
+        $modifiedResource = $this->resource->get('dc:modified');
+        if ($modifiedResource) {
+            $modified = $modifiedResource->getValue();
+        }
+        return $modified;
+    }
+
+    /**
      * Gets the creation date and modification date if available.
      * @return String containing the date information in a human readable format.
      */
@@ -670,10 +685,7 @@ class Concept extends VocabularyDataObject
                 $created = $this->resource->get('dc:created')->getValue();
             }
 
-            // finding the modified properties
-            if ($this->resource->get('dc:modified')) {
-                $modified = $this->resource->get('dc:modified')->getValue();
-            }
+            $modified = $this->getModifiedDate();
 
             // making a human readable string from the timestamps
             if ($created != '') {

--- a/model/Model.php
+++ b/model/Model.php
@@ -403,9 +403,9 @@ class Model
     /**
      * Returns a single cached vocabulary.
      * @param string $vocid the vocabulary id eg. 'mesh'.
-     * @return vocabulary dataobject
+     * @return Vocabulary dataobject
      */
-    public function getVocabulary($vocid)
+    public function getVocabulary($vocid): Vocabulary
     {
         $vocs = $this->getVocabularies();
         foreach ($vocs as $voc) {

--- a/model/Vocabulary.php
+++ b/model/Vocabulary.php
@@ -232,9 +232,9 @@ class Vocabulary extends DataObject
     /**
      * Returns the main Concept Scheme of that Vocabulary, or null if not set.
      * @param string $defaultConceptSchemeURI default concept scheme URI
-     * @return \EasyRdf\Graph
+     * @return \EasyRdf\Graph|mixed
      */
-    public function getConceptScheme(string $defaultConceptSchemeURI): \EasyRdf\Graph
+    public function getConceptScheme(string $defaultConceptSchemeURI)
     {
         return $this->getSparql()->queryConceptScheme($defaultConceptSchemeURI);
     }

--- a/model/Vocabulary.php
+++ b/model/Vocabulary.php
@@ -230,6 +230,16 @@ class Vocabulary extends DataObject
     }
 
     /**
+     * Returns the main Concept Scheme of that Vocabulary, or null if not set.
+     * @param string $defaultConceptSchemeURI default concept scheme URI
+     * @return \EasyRdf\Graph
+     */
+    public function getConceptScheme(string $defaultConceptSchemeURI): \EasyRdf\Graph
+    {
+        return $this->getSparql()->queryConceptScheme($defaultConceptSchemeURI);
+    }
+
+    /**
      * Return the top concepts of a concept scheme in the vocabulary.
      * @param string $conceptScheme URI of concept scheme whose top concepts to return. If not set,
      *                              the default concept scheme of the vocabulary will be used.

--- a/model/VocabularyConfig.php
+++ b/model/VocabularyConfig.php
@@ -450,4 +450,13 @@ class VocabularyConfig extends BaseConfig
         }
         return $ret;
     }
+
+    /**
+     * Returns a boolean value set in the config.ttl config.
+     * @return boolean
+     */
+    public function getUseModifiedDate(): bool
+    {
+        return $this->getBoolean('skosmos:useModifiedDate', false);
+    }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -13,6 +13,7 @@
       <directory>vendor</directory>
     </blacklist>
     <whitelist processUncoveredFilesFromWhitelist="true">
+        <directory suffix=".php">controller</directory>
         <directory suffix=".php">model</directory>
         <directory suffix=".php">model/sparql</directory>
     </whitelist>

--- a/tests/ConceptTest.php
+++ b/tests/ConceptTest.php
@@ -22,7 +22,7 @@ class ConceptTest extends PHPUnit\Framework\TestCase
 
     $this->cbdVocab = $this->model->getVocabulary('cbd');
     $this->cbdGraph =  new EasyRdf\Graph();
-    $this->cbdGraph->parseFile("tests/test-vocab-data/cbd.ttl", "turtle");
+    $this->cbdGraph->parseFile(__DIR__ . "/test-vocab-data/cbd.ttl", "turtle");
 
   }
 

--- a/tests/ConceptTest.php
+++ b/tests/ConceptTest.php
@@ -475,4 +475,36 @@ class ConceptTest extends PHPUnit\Framework\TestCase
     $contains_count = substr_count($json, "CONTAINS");
     $this->assertEquals($contains_count, 3);
   }
+
+  /**
+   * Data provider for testGetModifiedDate test method.
+   * @return array
+   */
+  public function modifiedDateDataProvider() {
+    return [
+      ["cat", "2018-12-13T06:28:14", "+00:00"],  # set #0
+      ["dog", null, null],  # set #1
+      ["owl", "2018-10-22T00:00:00", "+00:00"],  # set #2
+      ["parrot", "2018-10-22T00:00:00", "+00:00"],  # set #3
+      ["macaw", "2018-10-22T12:34:45", "+00:00"],  # set #4
+      ["sloth", "2018-10-22T12:34:45", "+05:30"],  # set #5
+    ];
+  }
+
+  /**
+   * @covers Concept::getModifiedDate
+   * @dataProvider modifiedDateDataProvider
+   */
+  public function testGetModifiedDate($animal, $expected_time, $expected_timezone) {
+    $vocab = $this->model->getVocabulary('http304');
+    $results = $vocab->getConceptInfo('http://www.skosmos.skos/test/' . $animal, 'en');
+    $concept = reset($results);
+    if (is_null($expected_time)) {
+        $modifiedDate = $concept->getModifiedDate();
+        $this->assertNull($modifiedDate);
+    } else {
+        $modifiedDate = $concept->getModifiedDate();
+        $this->assertEquals($expected_time . $expected_timezone, $modifiedDate->format("c"));
+    }
+  }
 }

--- a/tests/Http304Test.php
+++ b/tests/Http304Test.php
@@ -1,0 +1,159 @@
+<?php
+
+use \PHPUnit\Framework\TestCase;
+
+class Http304Test extends TestCase
+{
+
+    /**
+     * @var \Mockery\Mock|Model
+     */
+    private $model;
+    /**
+     * @var \Mockery\Mock|Vocabulary
+     */
+    private $vocab;
+    /**
+     * @var \Mockery\Mock|WebController
+     */
+    private $controller;
+    /**
+     * @var \Mockery\Mock|Request
+     */
+    private $request;
+    /**
+     * @var \Mockery\Mock|Twig_Environment
+     */
+    private $twig;
+
+    /**
+     * Initializes the test objects. Not using setUp here as the $vocabularyName
+     * needs to be specified per test.
+     * @param $vocabularyName string name of the vocabulary used for this test
+     * @throws Exception if any error occurs during vocabulary creation
+     */
+    public function initObjects(string $vocabularyName): void
+    {
+        putenv("LANGUAGE=en_GB.utf8");
+        putenv("LC_ALL=en_GB.utf8");
+        setlocale(LC_ALL, 'en_GB.utf8');
+        bindtextdomain('skosmos', 'resource/translations');
+        bind_textdomain_codeset('skosmos', 'UTF-8');
+        textdomain('skosmos');
+        $this->model = Mockery::mock(new Model(new GlobalConfig('/../tests/testconfig.ttl')))->makePartial();
+        $this->vocab = Mockery::mock($this->model->getVocabulary($vocabularyName))->makePartial();
+        $this->controller = Mockery::mock('WebController')
+            ->shouldAllowMockingProtectedMethods()
+            ->makePartial();
+        $this->request = Mockery::mock('Request');
+        $this->request->allows([
+            "getLang" => "en",
+            "getContentLang" => "en",
+            "getVocab" => $this->vocab
+        ]);
+        $this->twig = Mockery::mock("Twig_Environment")->makePartial();
+        $mockedTemplate = Mockery::mock();
+        $mockedTemplate->shouldReceive("render")->andReturn("rendered");
+        $this->twig->allows([
+            "loadTemplate" => $mockedTemplate
+        ]);
+        $this->controller->twig = $this->twig;
+    }
+
+    /**
+     * Test that a vocabulary that has disabled the use of HTTP 304, never invokes the
+     * method that sends these HTTP headers.
+     * @throws Exception
+     */
+    public function testHttp304NotUsedWhenDisabled()
+    {
+        $this->initObjects("http304disabled");
+
+        $this->controller
+            ->shouldReceive("setLanguageProperties")
+            ->withArgs(["en"]);
+        $this->request
+            ->shouldReceive("getURI")
+            ->andReturn("");
+        $this->vocab
+            ->shouldReceive("getConceptURI")
+            ->andReturn("");
+
+        $concepts = [];
+        $concept = Mockery::mock("Concept")->makePartial();
+        $concept->allows([
+            "getType" => ["skos:Concept"]
+        ]);
+        $concepts[] = $concept;
+        $this->vocab
+            ->shouldReceive("getConceptInfo")
+            ->andReturn($concepts);
+        $this->vocab
+            ->shouldReceive("getBreadCrumbs")
+            ->andReturn([
+                "breadcrumbs" => "",
+                "combined" => ""
+            ]);
+
+        $this->controller->shouldNotReceive("http304disabled");
+        $this->controller->shouldNotReceive("sendHeader");
+
+        ob_start();
+        $this->controller->invokeVocabularyConcept($this->request);
+        $content = ob_get_clean();
+        $this->assertEquals("rendered", $content);
+    }
+
+    /**
+     * Test that on the first ever request, the real content is sent, and not just
+     * the HTTP 304 response.
+     * @throws Exception
+     */
+    public function testHttp304FirstEverRequest()
+    {
+        $this->initObjects("http304");
+
+        $this->controller
+            ->shouldReceive("setLanguageProperties")
+            ->withArgs(["en"]);
+        $this->request
+            ->shouldReceive("getURI")
+            ->andReturn("");
+        $this->vocab
+            ->shouldReceive("getConceptURI")
+            ->andReturn("");
+
+        $concepts = [];
+        $concept = Mockery::mock("Concept")->makePartial();
+        $concept->allows([
+            "getType" => ["skos:Concept"]
+        ]);
+        $concepts[] = $concept;
+        $this->vocab
+            ->shouldReceive("getConceptInfo")
+            ->andReturn($concepts);
+        $this->vocab
+            ->shouldReceive("getBreadCrumbs")
+            ->andReturn([
+                "breadcrumbs" => "",
+                "combined" => ""
+            ]);
+
+        // the main logic of this test
+        {
+            $modifiedDate = DateTime::createFromFormat('j-M-Y', '15-Feb-2009');
+            $this->controller
+                ->shouldReceive("getModifiedDate")
+                ->andReturn($modifiedDate);
+            $this->controller
+                ->shouldReceive("sendHeader")
+                ->withArgs(["Last-Modified: " . $modifiedDate->format('Y-m-d H:i:s')])
+                ->andReturn(true);
+        }
+
+        ob_start();
+        $this->controller->invokeVocabularyConcept($this->request);
+        $content = ob_get_clean();
+        $this->assertEquals("rendered", $content);
+    }
+}

--- a/tests/VocabularyConfigTest.php
+++ b/tests/VocabularyConfigTest.php
@@ -443,4 +443,14 @@ class VocabularyConfigTest extends PHPUnit\Framework\TestCase
     $vocab = $this->model->getVocabulary('multiple-schemes');
     $this->assertEquals("ysa/gen" , $vocab->getConfig()->getMarcSourceCode("fi"));
   }
+
+  /**
+   * @covers VocabularyConfig::getUseModifiedDate
+   */
+  public function testGetVocabularyUseModifiedDate() {
+    $vocab = $this->model->getVocabulary('http304');
+    $this->assertEquals(true , $vocab->getConfig()->getUseModifiedDate());
+    $vocab = $this->model->getVocabulary('http304disabled');
+    $this->assertEquals(false , $vocab->getConfig()->getUseModifiedDate());
+  }
 }

--- a/tests/VocabularyTest.php
+++ b/tests/VocabularyTest.php
@@ -1,5 +1,4 @@
 <?php
-require_once('model/Model.php');
 
 class VocabularyTest extends \PHPUnit\Framework\TestCase
 {

--- a/tests/VocabularyTest.php
+++ b/tests/VocabularyTest.php
@@ -1,10 +1,11 @@
 <?php
-
 require_once('model/Model.php');
 
 class VocabularyTest extends \PHPUnit\Framework\TestCase
 {
-
+  /**
+   * @var Model
+   */
   private $model;
 
   protected function setUp() {
@@ -436,5 +437,18 @@ class VocabularyTest extends \PHPUnit\Framework\TestCase
     $this->assertEquals(1, sizeof($concept));
   }
 
+  /**
+   * @covers Vocabulary::getConceptScheme
+   */
+  public function testGetConceptScheme() {
+    $vocab = $this->model->getVocabulary('http304');
+    $conceptSchemeUri = $vocab->getDefaultConceptScheme();
+    $conceptScheme = $vocab->getConceptScheme($conceptSchemeUri);
+    print($conceptSchemeUri);
+    $this->assertEquals(
+      "Test Main Concept Scheme",
+      $conceptScheme->getLiteral($conceptSchemeUri,"skos:prefLabel")
+    );
+  }
 }
 

--- a/tests/WebControllerTest.php
+++ b/tests/WebControllerTest.php
@@ -1,0 +1,73 @@
+<?php
+
+use \PHPUnit\Framework\TestCase;
+
+class WebControllerTest extends TestCase
+{
+
+    /**
+     * Data for testGetModifiedDate.
+     * @return array
+     */
+    public function modifiedDateDataProvider()
+    {
+        return [
+            [null, null, false, null], # set #0
+            [$this->datetime('15-Feb-2009'), null, false, $this->datetime('15-Feb-2009')], # set #1
+            [null, $this->datetime('01-Feb-2009'), false, $this->datetime('01-Feb-2009')], # set #2
+            [null, $this->datetime('01-Feb-2009'), true, null] # set #3
+        ];
+    }
+
+    /**
+     * Utility method to create a datetime for data provider.
+     * @param string $string
+     * @return bool|DateTime
+     */
+    private function datetime(string $string)
+    {
+        return DateTime::createFromFormat("j-M-Y", $string);
+    }
+
+    /**
+     * Test that the behaviour of getModifiedDate works as expected. If there is a concept with a modified
+     * date, then it will return that value. If there is no modified date in the concept, but the main
+     * concept scheme contains a date, then the main concept scheme's modified date will be returned instead.
+     * Finally, if neither of the previous scenarios occur, then it returns null.
+     * @dataProvider modifiedDateDataProvider
+     */
+    public function testGetModifiedDate($conceptDate, $schemeDate, $isSchemeEmpty, $expected)
+    {
+        $concept = Mockery::mock("Concept");
+        $concept
+            ->shouldReceive("getModifiedDate")
+            ->andReturn($conceptDate);
+        $vocab = Mockery::mock("Vocabulary");
+        // if no scheme date, we return that same value as default concept scheme to stop the flow
+        $defaultScheme = (isset($schemeDate) ? "http://test/" : null);
+        $vocab
+            ->shouldReceive("getDefaultConceptScheme")
+            ->andReturn($defaultScheme);
+        if (!is_null($schemeDate)) {
+            $scheme = Mockery::mock("ConceptScheme");
+            $vocab
+                ->shouldReceive("getConceptScheme")
+                ->andReturn($scheme);
+            $scheme
+                ->shouldReceive("isEmpty")
+                ->andReturn($isSchemeEmpty);
+            $literal = Mockery::mock();
+            $scheme
+                ->shouldReceive("getLiteral")
+                ->andReturn($literal);
+            $literal
+                ->shouldReceive("getValue")
+                ->andReturn($schemeDate);
+        }
+        $controller = Mockery::mock('WebController')
+            ->shouldAllowMockingProtectedMethods()
+            ->makePartial();
+        $date = $controller->getModifiedDate($concept, $vocab);
+        $this->assertEquals($expected, $date);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,3 +1,3 @@
 <?php
-require_once('vendor/autoload.php');
-require_once('model/Model.php');
+require_once(__DIR__ . '/../vendor/autoload.php');
+require_once(__DIR__ . '/../model/Model.php');

--- a/tests/test-vocab-data/http304.ttl
+++ b/tests/test-vocab-data/http304.ttl
@@ -1,0 +1,52 @@
+@prefix void: <http://rdfs.org/ns/void#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix dc: <http://purl.org/dc/terms/> .
+@prefix dc11: <http://purl.org/dc/elements/1.1/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix wv: <http://vocab.org/waiver/terms/norms> .
+@prefix sd: <http://www.w3.org/ns/sparql-service-description#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix skosmos: <http://purl.org/net/skosmos#> .
+@prefix isothes: <http://purl.org/iso25964/skos-thes#>.
+@prefix meta: <http://www.skosmos.skos/test-meta/> .
+@prefix my: <http://example.com/myns#> .
+@prefix mdrtype: <http://publications.europa.eu/resource/authority/dataset-type/> .
+@prefix test: <http://www.skosmos.skos/test/> .
+
+test:http304mainconceptscheme a skos:ConceptScheme;
+    skos:prefLabel "Test Main Concept Scheme"@en;
+    dc:modified "2018-12-13T06:28:14+00:00"^^xsd:dateTime .
+
+test:anotherConceptScheme a skos:ConceptScheme;
+    skos:prefLabel "Another Test Concept Scheme"@en;
+    dc:modified "2013-11-01T02:28:14+00:00"^^xsd:dateTime .
+
+test:cat a skos:Concept ;
+	skos:prefLabel "Cat"@en;
+	dc:modified "2018-12-13T06:28:14+00:00"^^xsd:dateTime .
+
+test:dog a skos:Concept ;
+    skos:prefLabel "Dog"@en .
+
+test:owl a skos:Concept ;
+	skos:prefLabel "Owl"@en;
+	dc:modified "20181022"^^xsd:dateTime .
+
+test:parrot a skos:Concept ;
+	skos:prefLabel "Parrot"@en;
+	dc:modified "2018-10-22"^^xsd:dateTime .
+
+test:macaw a skos:Concept ;
+	skos:prefLabel "Macaw"@en;
+	dc:modified "2018-10-22T12:34:45"^^xsd:dateTime .
+
+test:sloth a skos:Concept ;
+	skos:prefLabel "Sloth"@en;
+	dc:modified "2018-10-22T12:34:45+05:30"^^xsd:dateTime .
+
+test:lizard a skos:Concept ;
+	skos:prefLabel "Lizard"@en;
+	dc:modified "2018-00-00"^^xsd:dateTime .

--- a/tests/testconfig.ttl
+++ b/tests/testconfig.ttl
@@ -14,6 +14,7 @@
 @prefix meta: <http://www.skosmos.skos/test-meta/> .
 @prefix my: <http://example.com/myns#> .
 @prefix mdrtype: <http://publications.europa.eu/resource/authority/dataset-type/> .
+@prefix test: <http://www.skosmos.skos/test/> .
 @prefix : <#> .
 
 # Skosmos main configuration
@@ -263,6 +264,25 @@
     skosmos:language "en";
     skosmos:sparqlGraph <http://www.skosmos.skos/xl/> .
 
+:http304disabled a skosmos:Vocabulary, void:Dataset ;
+    dc11:title "A vocabulary for testing HTTP 304 new settings"@en ;
+    dc:subject :cat_general ;
+    void:uriSpace "http://www.skosmos.skos/http304disabled/";
+    void:sparqlEndpoint <http://localhost:13030/ds/sparql> ;
+    skosmos:language "fi";
+    skosmos:useModifiedDate "false";
+    skosmos:sparqlGraph <http://www.skosmos.skos/http304/>;
+    skosmos:mainConceptScheme test:http304mainconceptscheme .
+
+:http304 a skosmos:Vocabulary, void:Dataset ;
+    dc11:title "A vocabulary for testing HTTP 304 new settings"@en ;
+    dc:subject :cat_general ;
+    void:uriSpace "http://www.skosmos.skos/http304enabled/";
+    void:sparqlEndpoint <http://localhost:13030/ds/sparql> ;
+    skosmos:language "fi";
+    skosmos:useModifiedDate "true";
+    skosmos:sparqlGraph <http://www.skosmos.skos/http304/>;
+    skosmos:mainConceptScheme test:http304mainconceptscheme .
 
 <http://skosmos.skos/dump/test/groups> dc:format "application/rdf+xml" .
 


### PR DESCRIPTION
For #575 and #574. Adds support to last modified header. Only works if the vocabulary configuration, in config.ttl, contains the `skosmos:useModifiedDate "true";`.

It first tries to load the modified from the concept. If this date is not found, then it tries to use the main concept scheme's modified.

If the modified date was found, then it tries to set the HTTP 304 header. This only happens when the `$_SERVER` variable has been populated by PHP&Browser. Otherwise it will simply put the date in the `Last-Modified` header. This gets picked up by the browser for the next requests.

WIP for now. Missing steps:

- There's one TODO right after it retrieves the modified date (either from Concept or ConceptScheme), to validate the date. That will be a simple pattern match against YYYY-mm-ddTHH:MM:SS or so (WDYT @osma ? Should we validate more, checking for the year or so?)
- It is clearly missing unit tests :grimacing: but they are coming. First had to do some development with local tests to refresh how the 304 header worked with browsers, and also to craft the code around EasyRDF classes.

Final note, it is being created for PHP 7.2+, with code hints everywhere. Which removes the need to test for things like null, instanceof, etc, in some cases. But happy to revert that part if necessary.

Cheers
Bruno