### PR TITLE
Prevent error when the system is configured to use dc:modified, but neither concept nor scheme have dates

### DIFF
--- a/controller/WebController.php
+++ b/controller/WebController.php
@@ -247,6 +247,14 @@ class WebController extends Controller
     }
 
     /**
+     * Return the modified date. First try to get the modified date from the concept. If found, return this
+     * date.
+     *
+     * Then try to get the modified date from the vocabulary's main concept scheme. If found, then return this
+     * date.
+     *
+     * Finally, if no date found, return null.
+     *
      * @param Concept $concept
      * @param Vocabulary $vocab
      * @return DateTime|null
@@ -260,7 +268,9 @@ class WebController extends Controller
                 $conceptSchemeGraph = $vocab->getConceptScheme($conceptSchemeURI);
                 if (!$conceptSchemeGraph->isEmpty()) {
                     $literal = $conceptSchemeGraph->getLiteral($conceptSchemeURI, "dc:modified");
-                    $modifiedDate = $literal->getValue();
+                    if ($literal) {
+                        $modifiedDate = $literal->getValue();
+                    }
                 }
             }
         }


### PR DESCRIPTION
Following up on #839 , this pull request adds one more test case that should cover the case when the vocabulary is enabled to use the modified dates. But neither concept nor scheme have any dates.

Previous to this change, it would result in an unexpected error due to calling a method on a `null` value. Wrote a small unit test, and executed locally to confirm others worked, but this one was failing now.

```bash
Testing started at 6:39 PM ...
/usr/bin/php /home/kinow/Development/php/workspace/Skosmos/vendor/phpunit/phpunit/phpunit --bootstrap /home/kinow/Development/php/workspace/Skosmos/vendor/autoload.php --configuration /home/kinow/Development/php/workspace/Skosmos/phpunit.xml --filter "/(::testGetModifiedDate)( .*)?$/" WebControllertest /home/kinow/Development/php/workspace/Skosmos/tests/WebControllerTest.php --teamcity
PHPUnit 6.5.5 by Sebastian Bergmann and contributors.

Error : Call to a member function getValue() on null
 /home/kinow/Development/php/workspace/Skosmos/controller/WebController.php:264
 /home/kinow/Development/php/workspace/Skosmos/tests/WebControllerTest.php:116
 
Time: 1.93 seconds, Memory: 6.00MB

ERRORS!
Tests: 5, Assertions: 4, Errors: 1.

Generating code coverage report in Clover XML format ... done
Generating code coverage report in HTML format ... done
Process finished with exit code 2
```

Then patched the current code to check if the `dc:modified` value from the concept scheme exists. If not, it will simply return `null` as in the other case when there is no date for a concept, and everything should work fine (i.e. 200 HTTP responses).

Also added more comments to one method, and also to the unit test data provider, both for myself, and also for any future developer maintaining this feature :grin: 

@osma , would you be able to test this one against IPTC, please?

Cheers
Bruno