### PR TITLE
Remove duplicated array index

### DIFF
--- a/controller/RestController.php
+++ b/controller/RestController.php
@@ -218,7 +218,6 @@ class RestController extends Controller
                 'dct' => 'http://purl.org/dc/terms/',
                 'uri' => '@id',
                 'type' => '@type',
-                'title' => 'rdfs:label',
                 'conceptschemes' => 'onki:hasConceptScheme',
                 'id' => 'onki:vocabularyIdentifier',
                 'defaultLanguage' => 'onki:defaultLanguage',


### PR DESCRIPTION
This had been bothering, but I never found time to check which value was actually used. I suspected the last value set, but thought it was still better to check.

Screenshot from debugger attached to the docker container running latest version. It's possible to see that rdfs:label is not used, so it should be safe to remove that entry, and leave the `dct:title` only.

![screenshot from 2019-01-20 16-59-13](https://user-images.githubusercontent.com/304786/51435124-3687ec00-1cd5-11e9-8ffc-650b443a6ba4.png)

Just to avoid possible issues when other developers could try to update these keys/values.

Cheers
Bruno
