### PR TITLE
Avoid unnecessary properties when calling getMappingProperties from search result page

### DIFF
--- a/model/Concept.php
+++ b/model/Concept.php
@@ -391,7 +391,7 @@ class Concept extends VocabularyDataObject
         }
     }
 
-    public function getMappingProperties()
+    public function getMappingProperties(array $whitelist = null)
     {
         $ret = array();
 
@@ -401,9 +401,13 @@ class Concept extends VocabularyDataObject
                 // shortening property labels if possible
                 $prop = $sprop = EasyRdf\RdfNamespace::shorten($prop);
             } else {
+                // EasyRdf requires full URIs to be in angle brackets
                 $sprop = "<$prop>";
             }
-            // EasyRdf requires full URIs to be in angle brackets
+            if ($whitelist && !in_array($prop, $whitelist)) {
+                // whitelist in use and this is not a whitelisted property, skipping
+                continue;
+            }
 
             if (in_array($prop, $this->MAPPING_PROPERTIES) && !in_array($prop, $this->DELETED_PROPERTIES)) {
                 $propres = new EasyRdf\Resource($prop, $this->graph);

--- a/view/search-result.twig
+++ b/view/search-result.twig
@@ -88,7 +88,7 @@
     </div>
   {% endif %}
   {% if concept.vocab.config.additionalSearchProperties %} 
-    {% set mappingProperties = concept.mappingProperties %}
+    {% set mappingProperties = concept.mappingProperties(concept.vocab.config.additionalSearchProperties) %}
     {% if mappingProperties %}
       {% for property in mappingProperties %} {# loop through ConceptProperty objects #}
         {% if property.type in concept.vocab.config.additionalSearchProperties %}


### PR DESCRIPTION
The Concept.getMappingProperties now takes a property whitelist parameter and it is used to restrict mapping property lookups to only those that are actually needed by the search result page.

Part of #836