### PR TITLE
Use a default vocabulary ID when guessing vocabulary, to save lookups

### DIFF
--- a/model/Concept.php
+++ b/model/Concept.php
@@ -597,7 +597,7 @@ class Concept extends VocabularyDataObject
 
                     if (isset($ret[$prop])) {
                         // checking if the property value is not in the current vocabulary
-                        $exvoc = $this->model->guessVocabularyFromURI($val->getUri());
+                        $exvoc = $this->model->guessVocabularyFromURI($val->getUri(), $this->vocab->getId());
                         if ($exvoc && $exvoc->getId() !== $this->vocab->getId()) {
                             $ret[$prop]->addValue(new ConceptMappingPropertyValue($this->model, $this->vocab, $val, $this->resource, $prop, $this->clang), $this->clang);
                             continue;

--- a/model/Model.php
+++ b/model/Model.php
@@ -255,7 +255,7 @@ class Model
 
             // if uri is a external vocab uri that is included in the current vocab
             $realvoc = $this->guessVocabularyFromURI($hit['uri'], $voc !== null ? $voc->getId() : null);
-            if ($realvoc != $hitvoc) {
+            if ($realvoc !== $hitvoc) {
                 unset($hit['localname']);
                 $hit['exvocab'] = ($realvoc !== null) ? $realvoc->getId() : "???";
             }

--- a/model/Model.php
+++ b/model/Model.php
@@ -237,24 +237,25 @@ class Model
 
         foreach ($results as $hit) {
             if (sizeof($vocabs) == 1) {
+                $hitvoc = $voc;
                 $hit['vocab'] = $vocabs[0]->getId();
             } else {
                 try {
-                    $voc = $this->getVocabularyByGraph($hit['graph']);
-                    $hit['vocab'] = $voc->getId();
+                    $hitvoc = $this->getVocabularyByGraph($hit['graph']);
+                    $hit['vocab'] = $hitvoc->getId();
                 } catch (Exception $e) {
                     trigger_error($e->getMessage(), E_USER_WARNING);
-                    $voc = null;
+                    $hitvoc = null;
                     $hit['vocab'] = "???";
                 }
             }
             unset($hit['graph']);
 
-            $hit['voc'] = $voc;
+            $hit['voc'] = $hitvoc;
 
             // if uri is a external vocab uri that is included in the current vocab
-            $realvoc = $this->guessVocabularyFromURI($hit['uri']);
-            if ($realvoc !== $voc) {
+            $realvoc = $this->guessVocabularyFromURI($hit['uri'], $voc !== null ? $voc->getId() : null);
+            if ($realvoc != $hitvoc) {
                 unset($hit['localname']);
                 $hit['exvocab'] = ($realvoc !== null) ? $realvoc->getId() : "???";
             }


### PR DESCRIPTION
Part of #836

This change makes better use of the `defaultVocabId` parameter in `guessVocabularyFromURI` method in two places. When handling search results and concept properties, the ID of the current vocabulary is used as default so that when a URI that is within the URI space of current vocabulary (e.g. YSO) is encountered, it is assumed to be within the current vocabulary, even though theoretically it could be from another vocabulary (e.g. YSO Places) which uses the same URI namespace.

This may be a little bit risky, for example if a YSO concept links to a YSO Places concept using a property that is not a mapping property.