### PR TITLE
Support last modified header

### DIFF
--- a/controller/Controller.php
+++ b/controller/Controller.php
@@ -151,7 +151,12 @@ class Controller
      */
     protected function getIfModifiedSince()
     {
-        return isset($_SERVER["HTTP_IF_MODIFIED_SINCE"]) ? strtotime($_SERVER["HTTP_IF_MODIFIED_SINCE"]) : null;
+        $ifModifiedSince = null;
+        if (isset($_SERVER["HTTP_IF_MODIFIED_SINCE"])) {
+            // example value set by a browser: "2019-04-13 08:28:23"
+            $ifModifiedSince = DateTime::createFromFormat("Y-m-d H:i:s", $_SERVER["HTTP_IF_MODIFIED_SINCE"]);
+        }
+        return $ifModifiedSince;
     }
 
     /**

--- a/controller/Controller.php
+++ b/controller/Controller.php
@@ -7,7 +7,7 @@ class Controller
 {
     /**
      * The controller has to know the model to access the data stored there.
-     * @param $model contains the Model object.
+     * @var Model $model contains the Model object.
      */
     public $model;
 

--- a/controller/WebController.php
+++ b/controller/WebController.php
@@ -12,6 +12,11 @@ use \Punic\Language;
 class WebController extends Controller
 {
     /**
+     * How long to store retrieved disk configuration for HTTP 304 header,
+     * like git configuration, or file modification date.
+     */
+    const READ_MODIFIED_CONFIG_TTL = 600; // 10 minutes
+    /**
      * Provides access to the templating engine.
      * @property object $twig the twig templating engine.
      */
@@ -320,7 +325,7 @@ class WebController extends Controller
             if (!$commitDate) {
                 $commitDate = $this->executeGitModifiedDateCommand($gitCommand);
                 if ($commitDate) {
-                    $cache->store($cacheKey, $commitDate, Model::URI_FETCH_TTL);
+                    $cache->store($cacheKey, $commitDate, static::READ_MODIFIED_CONFIG_TTL);
                 }
             }
         } else {
@@ -365,7 +370,7 @@ class WebController extends Controller
             if (!$dateTime) {
                 $dateTime = $this->retrieveConfigModifiedDate($filename);
                 if ($dateTime) {
-                    $cache->store($cacheKey, $dateTime, Model::URI_FETCH_TTL);
+                    $cache->store($cacheKey, $dateTime, static::READ_MODIFIED_CONFIG_TTL);
                 }
             }
         } else {

--- a/controller/WebController.php
+++ b/controller/WebController.php
@@ -352,9 +352,9 @@ class WebController extends Controller
     }
 
     /**
-     * Return the datetime of the modified time of the config.ttl file. If the file does not exist, or it
-     * fails to read the modified date time, or if the modified date time is not a valid time, then it returns
-     * null.
+     * Return the datetime of the modified time of the config file. This value is read in the GlobalConfig
+     * for every request, so we simply access that value and if not null, we will return a datetime. Otherwise,
+     * we return a null value.
      *
      * @see http://php.net/manual/en/function.filemtime.php
      * @return DateTime|null
@@ -362,38 +362,9 @@ class WebController extends Controller
     protected function getConfigModifiedDate()
     {
         $dateTime = null;
-        $cache = $this->model->getConfig()->getCache();
-        $cacheKey = "config:modified_date";
-        $filename = realpath(__DIR__ . "/../config.ttl");
-        if ($cache->isAvailable()) {
-            $dateTime = $cache->fetch($cacheKey);
-            if (!$dateTime) {
-                $dateTime = $this->retrieveConfigModifiedDate($filename);
-                if ($dateTime) {
-                    $cache->store($cacheKey, $dateTime, static::READ_MODIFIED_CONFIG_TTL);
-                }
-            }
-        } else {
-            $dateTime = $this->retrieveConfigModifiedDate($filename);
-        }
-        return $dateTime;
-    }
-
-    /**
-     * Retrieve the modified date for the configuration file. Return null if the file is not found, or if an
-     * error occurred while reading the file.
-     *
-     * @param string $filename
-     * @return DateTime|null
-     */
-    protected function retrieveConfigModifiedDate($filename)
-    {
-        $dateTime = null;
-        if (file_exists($filename)) {
-            $modifiedTime = filemtime($filename);
-            if (!is_bool($modifiedTime)) {
-                $dateTime = (new DateTime())->setTimestamp($modifiedTime);
-            }
+        $configModifiedTime = $this->model->getConfig()->getConfigModifiedTime();
+        if (!is_null($configModifiedTime)) {
+            $dateTime = (new DateTime())->setTimestamp($configModifiedTime);
         }
         return $dateTime;
     }

--- a/controller/WebController.php
+++ b/controller/WebController.php
@@ -261,11 +261,17 @@ class WebController extends Controller
      */
     protected function getModifiedDate(Concept $concept, Vocabulary $vocab)
     {
+        $modifiedDate = null;
+
         $conceptModifiedDate = $this->getConceptModifiedDate($concept, $vocab);
         $gitModifiedDate = $this->getGitModifiedDate();
         $configModifiedDate = $this->getConfigModifiedDate();
-        // TODO return most recent of three
-        return null;
+
+        // max with an empty list raises an error and returns bool
+        if ($conceptModifiedDate || $gitModifiedDate || $configModifiedDate) {
+            $modifiedDate = max($conceptModifiedDate, $gitModifiedDate, $configModifiedDate);
+        }
+        return $modifiedDate;
     }
 
     /**

--- a/controller/WebController.php
+++ b/controller/WebController.php
@@ -12,10 +12,10 @@ use \Punic\Language;
 class WebController extends Controller
 {
     /**
-     * How long to store retrieved disk configuration for HTTP 304 header,
-     * like git configuration, or file modification date.
+     * How long to store retrieved disk configuration for HTTP 304 header
+     * from git information.
      */
-    const READ_MODIFIED_CONFIG_TTL = 600; // 10 minutes
+    const GIT_MODIFIED_CONFIG_TTL = 600; // 10 minutes
     /**
      * Provides access to the templating engine.
      * @property object $twig the twig templating engine.
@@ -325,7 +325,7 @@ class WebController extends Controller
             if (!$commitDate) {
                 $commitDate = $this->executeGitModifiedDateCommand($gitCommand);
                 if ($commitDate) {
-                    $cache->store($cacheKey, $commitDate, static::READ_MODIFIED_CONFIG_TTL);
+                    $cache->store($cacheKey, $commitDate, static::GIT_MODIFIED_CONFIG_TTL);
                 }
             }
         } else {

--- a/controller/WebController.php
+++ b/controller/WebController.php
@@ -312,7 +312,7 @@ class WebController extends Controller
     protected function getGitModifiedDate()
     {
         $commitDate = null;
-        $cache = $this->model->globalConfig->getCache();
+        $cache = $this->model->getConfig()->getCache();
         $cacheKey = "git:modified_date";
         $gitCommand = 'git log -1 --date=iso --pretty=format:%cd';
         if ($cache->isAvailable()) {
@@ -357,7 +357,7 @@ class WebController extends Controller
     protected function getConfigModifiedDate()
     {
         $dateTime = null;
-        $cache = $this->model->globalConfig->getCache();
+        $cache = $this->model->getConfig()->getCache();
         $cacheKey = "config:modified_date";
         $filename = realpath(__DIR__ . "/../config.ttl");
         if ($cache->isAvailable()) {

--- a/tests/WebControllerTest.php
+++ b/tests/WebControllerTest.php
@@ -6,10 +6,10 @@ class WebControllerTest extends TestCase
 {
 
     /**
-     * Data for testGetModifiedDate.
+     * Data for testConceptGetModifiedDate.
      * @return array
      */
-    public function modifiedDateDataProvider()
+    public function conceptModifiedDateDataProvider()
     {
         return [
             # when there is no modified date for a concept, and there is no modified date for the main concept scheme,
@@ -206,13 +206,13 @@ class WebControllerTest extends TestCase
     }
 
     /**
-     * Test that the behaviour of getModifiedDate works as expected. If there is a concept with a modified
+     * Test that the behaviour of getConceptModifiedDate works as expected. If there is a concept with a modified
      * date, then it will return that value. If there is no modified date in the concept, but the main
      * concept scheme contains a date, then the main concept scheme's modified date will be returned instead.
      * Finally, if neither of the previous scenarios occur, then it returns null.
-     * @dataProvider modifiedDateDataProvider
+     * @dataProvider conceptModifiedDateDataProvider
      */
-    public function testGetModifiedDate($conceptDate, $schemeDate, $isSchemeEmpty, $isLiteralNull, $expected)
+    public function testConceptGetModifiedDate($conceptDate, $schemeDate, $isSchemeEmpty, $isLiteralNull, $expected)
     {
         $concept = Mockery::mock("Concept");
         $concept
@@ -249,7 +249,7 @@ class WebControllerTest extends TestCase
         $controller = Mockery::mock('WebController')
             ->shouldAllowMockingProtectedMethods()
             ->makePartial();
-        $date = $controller->getModifiedDate($concept, $vocab);
+        $date = $controller->getConceptModifiedDate($concept, $vocab);
         $this->assertEquals($expected, $date);
     }
 }

--- a/tests/WebControllerTest.php
+++ b/tests/WebControllerTest.php
@@ -152,7 +152,7 @@ class WebControllerTest extends TestCase
      * @param bool $cacheAvailable
      * @param DateTime|null $cachedValue
      * @param DateTime|null $modifiedDate
-     * @dataProvider gitModifiedDateDataProvider
+     * @dataProvider gitAndConfigModifiedDateDataProvider
      */
     public function testGetGitModifiedDate($cacheAvailable, $cachedValue, $modifiedDate)
     {
@@ -204,7 +204,7 @@ class WebControllerTest extends TestCase
      * @param bool $cacheAvailable
      * @param DateTime|null $cachedValue
      * @param DateTime|null $modifiedDate
-     * @dataProvider gitModifiedDateDataProvider
+     * @dataProvider gitAndConfigModifiedDateDataProvider
      */
     public function testGetConfigModifiedDate($cacheAvailable, $cachedValue, $modifiedDate)
     {

--- a/tests/WebControllerTest.php
+++ b/tests/WebControllerTest.php
@@ -171,7 +171,8 @@ class WebControllerTest extends TestCase
         $globalConfig->shouldReceive('getCache')
             ->andReturn($cache);
         $model = Mockery::mock('Model');
-        $model->globalConfig = $globalConfig;
+        $model->shouldReceive('getConfig')
+            ->andReturn($globalConfig);
         $controller = Mockery::mock('WebController')
             ->shouldAllowMockingProtectedMethods()
             ->makePartial();
@@ -223,7 +224,8 @@ class WebControllerTest extends TestCase
         $globalConfig->shouldReceive('getCache')
             ->andReturn($cache);
         $model = Mockery::mock('Model');
-        $model->globalConfig = $globalConfig;
+        $model->shouldReceive('getConfig')
+            ->andReturn($globalConfig);
         $controller = Mockery::mock('WebController')
             ->shouldAllowMockingProtectedMethods()
             ->makePartial();

--- a/tests/WebControllerTest.php
+++ b/tests/WebControllerTest.php
@@ -90,6 +90,54 @@ class WebControllerTest extends TestCase
         ];
     }
 
+    public function modifiedDateDataProvider()
+    {
+        return [
+            # concept has the most recent date time
+            [
+                $this->datetime('01-Feb-2011'), # concept
+                $this->datetime('01-Feb-2002'), # git
+                $this->datetime('01-Feb-2003'), # config
+                $this->datetime('01-Feb-2011')  # returned
+            ], # set #0
+            # concept has the most recent date time
+            [
+                $this->datetime('01-Feb-2011'), # concept
+                null, # git
+                $this->datetime('01-Feb-2003'), # config
+                $this->datetime('01-Feb-2011')  # returned
+            ], # set #1
+            # concept has the most recent date time
+            [
+                $this->datetime('01-Feb-2011'), # concept
+                null, # git
+                null, # config
+                $this->datetime('01-Feb-2011')  # returned
+            ], # set #2
+            # git has the most recent date time
+            [
+                $this->datetime('01-Feb-2001'), # concept
+                $this->datetime('01-Feb-2012'), # git
+                $this->datetime('01-Feb-2003'), # config
+                $this->datetime('01-Feb-2012')  # returned
+            ], # set #3
+            # config has the most recent date time
+            [
+                $this->datetime('01-Feb-2001'), # concept
+                $this->datetime('01-Feb-2002'), # git
+                $this->datetime('01-Feb-2013'), # config
+                $this->datetime('01-Feb-2013')  # returned
+            ], # set #4
+            # no date time found
+            [
+                null, # concept
+                null, # git
+                null, # config
+                null  # returned
+            ], # set #4
+        ];
+    }
+
     /**
      * Utility method to create a datetime for data provider.
      * @param string $string
@@ -203,6 +251,30 @@ class WebControllerTest extends TestCase
         $dateTime = $controller->retrieveConfigModifiedDate($filename);
         $this->assertInstanceOf('DateTime', $dateTime);
         $this->assertTrue($dateTime > (new DateTime())->setTimeStamp(1));
+    }
+
+    /**
+     * @param DateTime|null $concept
+     * @param DateTime|null $git
+     * @param DateTime|null $config
+     * @param DateTime|null $modifiedDate
+     * @dataProvider modifiedDateDataProvider
+     */
+    public function testGetModifiedDate($concept, $git, $config, $modifiedDate)
+    {
+        $controller = Mockery::mock('WebController')
+            ->shouldAllowMockingProtectedMethods()
+            ->makePartial();
+        $controller->shouldReceive('getConceptModifiedDate')
+            ->andReturn($concept);
+        $controller->shouldReceive('getGitModifiedDate')
+            ->andReturn($git);
+        $controller->shouldReceive('getConfigModifiedDate')
+            ->andReturn($config);
+        $concept = Mockery::mock('Concept');
+        $vocabulary = Mockery::mock('Vocabulary');
+        $returnedValue = $controller->getModifiedDate($concept, $vocabulary);
+        $this->assertEquals($modifiedDate, $returnedValue);
     }
 
     /**

--- a/tests/WebControllerTest.php
+++ b/tests/WebControllerTest.php
@@ -209,20 +209,9 @@ class WebControllerTest extends TestCase
      */
     public function testGetConfigModifiedDate($cacheAvailable, $cachedValue, $modifiedDate)
     {
-        $cache = Mockery::spy('Cache');
-        $cache->shouldReceive('isAvailable')
-            ->andReturn($cacheAvailable);
-        if ($cacheAvailable) {
-            $cache->shouldReceive('fetch')
-                ->andReturn($cachedValue);
-            if ($modifiedDate) {
-                $cache->shouldReceive('store')
-                    ->andReturn(true);
-            }
-        }
         $globalConfig = Mockery::mock('GlobalConfig');
-        $globalConfig->shouldReceive('getCache')
-            ->andReturn($cache);
+        $globalConfig->shouldReceive('getConfigModifiedTime')
+            ->andReturn(1);
         $model = Mockery::mock('Model');
         $model->shouldReceive('getConfig')
             ->andReturn($globalConfig);
@@ -237,22 +226,7 @@ class WebControllerTest extends TestCase
         $configModifiedDate = $controller->getConfigModifiedDate();
 
         $this->assertNotNull($configModifiedDate);
-        $this->assertTrue($configModifiedDate > (new DateTime())->setTimeStamp(1));
-    }
-
-    /**
-     * Retrieve the modified date of the local config.ttl.dist and test that it returns a valid date time. It should
-     * be safe to test this as Travis-CI and developer environments should have a config.ttl.dist file.
-     */
-    public function testRetrieveConfigModifiedDate()
-    {
-        $controller = Mockery::mock('WebController')
-            ->shouldAllowMockingProtectedMethods()
-            ->makePartial();
-        $filename = realpath(__DIR__ . "/../config.ttl.dist");
-        $dateTime = $controller->retrieveConfigModifiedDate($filename);
-        $this->assertInstanceOf('DateTime', $dateTime);
-        $this->assertTrue($dateTime > (new DateTime())->setTimeStamp(1));
+        $this->assertEquals((new DateTime())->setTimeStamp(1), $configModifiedDate);
     }
 
     /**


### PR DESCRIPTION
Fix for #574 .

This pull request adds the support to the [HTTP 304 Not Modified header](https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#3xx_Redirection) in Skosmos.

Changes are mainly in `WebController`, for the method that handles displaying the concept information. The logic is as follow:

- Skip this if `config.ttl` has `skosmos:useModifiedDate = false`. Otherwise continue.
- Call new method `getModifiedDate` to get the the modified date of the current `Concept`. It searches for the `Concept`'s `dc:modified` literal value.
- If the `Concept`'s `dc:modified` is not found, then it still tries to get the `dc:modified` literal value of the main concept scheme (via `Vocabulary::getDefaultConceptScheme()`, which should return  `skosmos:mainConceptScheme` or the URI of the last concept scheme).
- Call new method `getGitModifiedDate`, which executes `git log -1 --date=iso --pretty=format:%cd` and stores in the local cache for an interval `READ_MODIFIED_CONFIG_TTL` of 10 minutes.
- Call new method `getConfigModifiedDate`, which uses PHP's [filemtime](http://php.net/manual/en/function.filemtime.php) on the `config.ttl` local file, retrieving the modification date and also storing in the local cache for the same interval `READ_MODIFIED_CONFIG_TTL` of 10 minutes. NB: file modification dates depends on file system, operating system, and other settings.
- If at least one of the three values (Concept modified date, git modified date, configuration modified date) was found, we use the most recent one.
- The most recent modified date is then sent in the `Last-Modified` header.
- If the user (probably its browser) sent a [`If-Modified-Since`](https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.25) value in the HTTP Request headers, it means it understands HTTP 304. So we will compare the modified since from the browser with our most recent modified date. If our most recent modified date is **not** greater than the browser modified since date, then we end the request-response transaction with a `HTTP/1.0 304 Not Modified` header.

Unit tests included use mocking library to reach almost 100% coverage of the changes. Performed local tests using the `Dockerfile` in local environment, and two browsers with incognito mode and closing/opening the browsers to force cleaning the cache.

This pull request covers the [If-Modified-Since](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-Modified-Since) header. @osma, this pull request does not cover [If-None-Match](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-None-Match). I think this could be done later (involves `ETAG`'s, covers `HEAD` requests too) if necessary.

Cheers
Bruno
