### PR TITLE
Rename docker-compose created container from "web" to "skosmos"

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
   # visit https://hub.docker.com/r/stain/jena-fuseki/ for other alternatives
   # volumes:
   #  - ${PWD}/fuseki:/fuseki
-  web:
+  skosmos:
     container_name: skosmos
     build: .
     volumes:
@@ -27,4 +27,4 @@ services:
 # 1. create dataset
 # >curl -I -u admin:admin -XPOST --data "dbName=skosmos&dbType=tdb" -G http://localhost:3030/$/datasets/
 # 2. load example vocabulary
-# >curl -I -X POST -H Content-Type:text/turtle -T config.ttl -G http://localhost:3030/skosmos/data
+# >curl -I -X POST -H Content-Type:text/turtle -T yso.ttl -G http://localhost:3030/skosmos/data


### PR DESCRIPTION
There was a note in the Docker installation documentation about renaming it. I'd agree it makes more sense, so prepared this PR.

Will update the Wiki afterwards if approved :+1: 