### PR TITLE
Turn off mouse events on the dropdown menu

### DIFF
--- a/resource/js/docready.js
+++ b/resource/js/docready.js
@@ -755,6 +755,16 @@ $(function() { // DOCUMENT READY
         $('.clear-search').addClass('clear-search-dark');
       }
     });
+
+    // monkey-patching TypeAhead's Dropdown object for: https://github.com/NatLibFi/Skosmos/issues/773
+    // Updating typeahead.js to 0.11 requires a few changes that are not really complicated.
+    // However, our dropdown style is broken, and it appears hard to be fixed. typeahead.js
+    // Also does not appear to be maintained, so this temporary fix will prevent
+    // accidental selection of values. TODO: we must fix this in a future release, possibly
+    // using another library.
+    var typeaheadInstance = $typeahead.data("ttTypeahead");
+    typeaheadInstance.dropdown.$menu.off("mouseenter.tt", ".tt-suggestion");
+    typeaheadInstance.dropdown.$menu.off("mouseleave.tt", ".tt-suggestion");
   }
 
   // storing the search input before autocompletion changes it


### PR DESCRIPTION
Hi,

Close #773 

I started working on this convinced that upgrading the library to the latest version was a good idea. but I regretted it :disappointed_relieved: 

I managed to fix the API issues after reading the documentation and the code (the documentation is lacking a few details). Then found a few examples to confirm what was different. Some methods were simply renamed, while other were removed, or changed the return function.

Once [everything was in place](https://github.com/kinow/Skosmos/commits/fix-typeahead-mouse), the final CSS was probably off, as the layout was broken. And I couldn't see the dropdown menu with a scrollbar, as we have in dev.finto.fi. After a couple hours, thought it was too much time spent trying to do that (plus some minutes yesterday). 

Then looked at the workarounds, and spent another hour or so trying each one and understand what was done, and why. Unfortunately only one workaround worked. One where we patched some methods, but as result both mouse and keyboard stopped working. i.e. arrow keys would not select the items in the menu any longer.

Finally, decided to try opening the typeahead source code, change `scripts.twig` to use the non minified versions, and add breakpoints and start debugging it. After a while, I realized that the object `$typeahead` had the `dropdown` property.

Trying to monkey-patch it wasn't working (as in the other workarounds). But debugging I noticed that there was an event variable in the method, `$e`. That event was for `mouseover`, translated by JQuery after TypeAhead called `.on`.

I believe the event was triggering the method that it was initially bound to. Even after monkey patching the method, the even would still trigger the old one. 

With a piece of paper took note of the context and event, found another place in `docready.js` to add a note for the future developer about the issue, and called JQuery's `.off` on the same context and event.

It appears to have worked! :tada: 

Tested on Firefox and Chrome, on Ubuntu LTS.

Cheers