### PR TITLE
Improve guessVocabularyFromURI 

### DIFF
--- a/model/Concept.php
+++ b/model/Concept.php
@@ -599,8 +599,8 @@ class Concept extends VocabularyDataObject
                         // create a ConceptPropertyValue first, assuming the resource exists in current vocabulary
                         $value = new ConceptPropertyValue($this->model, $this->vocab, $val, $prop, $this->clang);
                         // check whether we know the label of the resource
-                        $label = $value->getLabel();
-                        if ($label == $value->resource->shorten() || $label == $value->getUri()) {
+                        $label = $value->getLabel('', 'null');
+                        if ($label === null) {
                             // we don't know a label for the resource
                             // checking if the property value is not in the current vocabulary
                             $exvoc = $this->model->guessVocabularyFromURI($val->getUri(), $this->vocab->getId());

--- a/model/ConceptPropertyValue.php
+++ b/model/ConceptPropertyValue.php
@@ -35,7 +35,7 @@ class ConceptPropertyValue extends VocabularyDataObject
         return $this->getEnvLang();
     }
 
-    public function getLabel($lang = '')
+    public function getLabel($lang = '', $fallback = 'uri')
     {
         if ($this->clang) {
             $lang = $this->clang;
@@ -68,9 +68,13 @@ class ConceptPropertyValue extends VocabularyDataObject
         } elseif ($this->resource->getLiteral('rdf:value') !== null) { // any language
             return $this->resource->getLiteral('rdf:value');
         }
-        // uri if no label is found
-        $label = $this->resource->shorten() ? $this->resource->shorten() : $this->getUri();
-        return $label;
+
+        if ($fallback == 'uri') {
+            // return uri if no label is found
+            $label = $this->resource->shorten() ? $this->resource->shorten() : $this->getUri();
+            return $label;
+        }
+        return null;
     }
 
     public function getType()

--- a/model/Model.php
+++ b/model/Model.php
@@ -253,11 +253,13 @@ class Model
 
             $hit['voc'] = $hitvoc;
 
-            // if uri is a external vocab uri that is included in the current vocab
-            $realvoc = $this->guessVocabularyFromURI($hit['uri'], $voc !== null ? $voc->getId() : null);
-            if ($realvoc !== $hitvoc) {
-                unset($hit['localname']);
-                $hit['exvocab'] = ($realvoc !== null) ? $realvoc->getId() : "???";
+            if (!$hitvoc->containsURI($hit['uri'])) {
+                // if uri is a external vocab uri that is included in the current vocab
+                $realvoc = $this->guessVocabularyFromURI($hit['uri'], $voc !== null ? $voc->getId() : null);
+                if ($realvoc !== $hitvoc) {
+                    unset($hit['localname']);
+                    $hit['exvocab'] = ($realvoc !== null) ? $realvoc->getId() : "???";
+                }
             }
 
             $ret[] = $hit;
@@ -468,7 +470,13 @@ class Model
         if($preferredVocabId != null) {
             foreach ($vocabs as $vocab) {
                 if($vocab->getId() == $preferredVocabId) {
-                    return $vocab;
+                    // double check that a label exists in the preferred vocabulary
+                    if ($vocab->getConceptLabel($uri, null) !== null) {
+                        return $vocab;
+                    } else {
+                        // not found in preferred vocabulary, fall back to next method
+                        break;
+                    }
                 }
             }
         }

--- a/model/Vocabulary.php
+++ b/model/Vocabulary.php
@@ -80,6 +80,18 @@ class Vocabulary extends DataObject
     }
 
     /**
+     * Return true if the URI is within the URI space of this vocabulary.
+     *
+     * @param string full URI of concept
+     * @return bool true if URI is within URI namespace, false otherwise
+     */
+
+    public function containsURI($uri)
+    {
+        return (strpos($uri, $this->getUriSpace()) === 0);
+    }
+
+    /**
      * Get the full URI of a concept in a vocabulary. If the passed local
      * name is already a full URI, return it unchanged.
      *


### PR DESCRIPTION
This is a fix for #868. I had to do a bit of work to fix the problem without introducing additional overhead, so the solution is divided into several parts:

1. Make disambiguateVocabulary (called from within guessVocabularyFromURI) double-check that a URI exists in a vocabulary, even though it is the "preferred" one. This is necessary in some edge cases, e.g. to distinguish between YSO and YSO Places concepts, because the vocabularies have the same URI namespace, but it does introduce an additional SPARQL query to check for a label.
2. To avoid triggering the overhead, in Concept.getProperties(), we first check whether a label for a URI already exists within the graph (the CONSTRUCT query response), and if a label is found, avoid calling guessVocabularyFromURI.
3. Similarly in Model.searchConcepts, when examining the search results, check first if their URIs are within the URI namespace of the current vocabulary (this requires a new method Vocabulary.containsURI) and if it is, skip calling guessVocabularyFromURI.

All in all this PR seems to fix the problem on the concept page while avoiding additional overhead.

While crafting this I also found a way to speed up the search result page a little bit (~10%) by using a whitelist parameter for Concept.getProperties (similar to the one in Concept.getMappingProperties introduced in PR #849), but I'll leave that for another PR.