### PR TITLE
fix 788

### DIFF
--- a/resource/css/styles.css
+++ b/resource/css/styles.css
@@ -959,6 +959,12 @@ div.input-group > .input-group-addon {
   list-style-type: none;
 }
 
+.alphabetical-search-results li a {
+  display: inline-block;
+  text-indent: -11px;
+  margin-left: 11px;
+}
+
 #alphabetical-menu {
   margin: 15px 0 0 15px;
 }


### PR DESCRIPTION
Fixes #788 by introducing a text indent to such wrapped links.

The only downside of this method is that it does not "cut" the <a> block since it is set to be a block (inline-block, to be precise), thus, creating a clickable "empty" space in the ends of wrapped lines.