### PR TITLE
add twig sorting plugin for foreign language labels (fixes #835)

### DIFF
--- a/view/concept-shared.twig
+++ b/view/concept-shared.twig
@@ -147,14 +147,12 @@
       <div class="row">
         <div class="property-label"><span class="versal property-click" title="{% trans "foreign prefLabel help" %}" >{{ 'foreign prefLabels'|trans|upper }}</span></div>
         <div class="property-value-column"><div class="property-value-wrapper">
-          {% set prevlang = '' %}{# Only displaying the language when it appears for the very first time #}
-          {% for language,labels in concept.foreignLabels %}
-            {% for value in labels %}
-              <div class="row other-languages{% if prevlang != language %} first-of-language{% endif %}">
+          {% for language, labels in concept.foreignLabels %}
+            {% for value in labels|label_sorter %}
+              <div class="row other-languages{% if loop.first %} first-of-language{% endif %}">
                 <div class="col-xs-6 versal{% if value.type == "skos:altLabel" %} replaced{%else %} versal-pref{% endif %}">{% if value.hasXlProperties %}<span class="reified-property-value xl-label"><img src="resource/pics/about.png"></span><div class="reified-tooltip">{% for key, val in value.getXlProperties %}{% if key != 'rdf:type' and key != 'skosxl:literalForm' and val != '' %}<p>{{ key|trans }}: <span class="versal">{{ val }}</span></p>{% endif %}{% endfor %}</div>{% endif %}{{ value.label }}</div>
-                <div class="col-xs-6 versal">{% if prevlang != language %}<p>{{ language }}</p>{% endif %}</div>
+                <div class="col-xs-6 versal">{% if loop.first %}<p>{{ language }}</p>{% endif %}</div>
               </div>
-              {% set prevlang = language %}
             {% endfor %}
           {% endfor %}
           </div>


### PR DESCRIPTION
This should fix the aforementioned issue by introducing a plugin for sorting the alt/preflabels (in case of multiple). Also replaced unnecessary looping template code with loop.first.