### PR TITLE
Enhancement for passing notification messages for a general-purpose plugin

### DIFF
--- a/controller/WebController.php
+++ b/controller/WebController.php
@@ -236,6 +236,7 @@ class WebController extends Controller
                 return;
             }
         }
+        $pluginMessages = $vocab->getConfig()->getPluginMessages();
         /** @var \Twig\Template $template */
         $template = (in_array('skos:Concept', $results[0]->getType()) || in_array('skos:ConceptScheme', $results[0]->getType())) ? $this->twig->loadTemplate('concept-info.twig') : $this->twig->loadTemplate('group-contents.twig');
 
@@ -243,6 +244,7 @@ class WebController extends Controller
         echo $template->render(array(
             'search_results' => $results,
             'vocab' => $vocab,
+            'plugin_messages' => $pluginMessages,
             'languages' => $this->languages,
             'explicit_langcodes' => $langcodes,
             'bread_crumbs' => $crumbs['breadcrumbs'],

--- a/controller/WebController.php
+++ b/controller/WebController.php
@@ -693,6 +693,7 @@ class WebController extends Controller
         $vocab = $request->getVocab();
 
         $defaultView = $vocab->getConfig()->getDefaultSidebarView();
+        $pluginMessages = $vocab->getConfig()->getPluginMessages();
         // load template
         if ($defaultView === 'groups') {
             $this->invokeGroupIndex($request, true);
@@ -707,6 +708,7 @@ class WebController extends Controller
                 'vocab' => $vocab,
                 'search_letter' => 'A',
                 'active_tab' => $defaultView,
+                'plugin_messages' => $pluginMessages,
                 'request' => $request,
             ));
     }

--- a/controller/WebController.php
+++ b/controller/WebController.php
@@ -236,7 +236,7 @@ class WebController extends Controller
                 return;
             }
         }
-        $pluginMessages = $vocab->getConfig()->getPluginMessages();
+        $pluginParameters = $vocab->getConfig()->getPluginParameters();
         /** @var \Twig\Template $template */
         $template = (in_array('skos:Concept', $results[0]->getType()) || in_array('skos:ConceptScheme', $results[0]->getType())) ? $this->twig->loadTemplate('concept-info.twig') : $this->twig->loadTemplate('group-contents.twig');
 
@@ -244,7 +244,7 @@ class WebController extends Controller
         echo $template->render(array(
             'search_results' => $results,
             'vocab' => $vocab,
-            'plugin_messages' => $pluginMessages,
+            'plugin_params' => $pluginParameters,
             'languages' => $this->languages,
             'explicit_langcodes' => $langcodes,
             'bread_crumbs' => $crumbs['breadcrumbs'],
@@ -693,7 +693,7 @@ class WebController extends Controller
         $vocab = $request->getVocab();
 
         $defaultView = $vocab->getConfig()->getDefaultSidebarView();
-        $pluginMessages = $vocab->getConfig()->getPluginMessages();
+        $pluginParameters = $vocab->getConfig()->getPluginParameters();
         // load template
         if ($defaultView === 'groups') {
             $this->invokeGroupIndex($request, true);
@@ -708,7 +708,7 @@ class WebController extends Controller
                 'vocab' => $vocab,
                 'search_letter' => 'A',
                 'active_tab' => $defaultView,
-                'plugin_messages' => $pluginMessages,
+                'plugin_params' => $pluginParameters,
                 'request' => $request,
             ));
     }

--- a/model/VocabularyConfig.php
+++ b/model/VocabularyConfig.php
@@ -6,6 +6,7 @@
 class VocabularyConfig extends BaseConfig
 {
     private $plugins;
+    private $pluginMessages;
     private $languageOrderCache = array();
 
     public function __construct($resource, $globalPlugins=array())
@@ -13,9 +14,22 @@ class VocabularyConfig extends BaseConfig
         $this->resource = $resource;
         $plugins = $this->resource->allLiterals('skosmos:usePlugin');
         $pluginArray = array();
+        $this->pluginMessages = array();
         if ($plugins) {
             foreach ($plugins as $pluginlit) {
                 $pluginArray[] = $pluginlit->getValue();
+            }
+        }
+        //Get message plugins defined as resources and their respective message literals
+        $pluginResources = $this->resource->allResources('skosmos:useMessagePlugin');
+        if ($pluginResources) {
+            foreach($pluginResources as $pluginResource) {
+                $pluginName = $pluginResource->getLiteral('skosmos:usePlugin')->getValue();
+                $pluginMessageLiterals = $pluginResource->allLiterals('skosmos:pluginMessage');
+                foreach ($pluginMessageLiterals as $message) {
+                    $this->pluginMessages[$message->getLang()] = $message->getValue();
+                }
+                $pluginArray[] = $pluginName;
             }
         }
         $this->plugins = new PluginRegister(array_merge($globalPlugins, $pluginArray));
@@ -360,6 +374,9 @@ class VocabularyConfig extends BaseConfig
         return $this->plugins;
     }
 
+    public function getPluginMessages() {
+        return $this->pluginMessages;
+    }
     /**
      * Returns the property/properties used for visualizing concept hierarchies.
      * @return string array class URI or null

--- a/view/scripts.twig
+++ b/view/scripts.twig
@@ -11,9 +11,6 @@ var expand = "{% trans %}Show all breadcrumb paths{% endtrans %}";
 var hiertrans = "{% trans "Hier-nav" %}";
 
 <!-- variables passed through to javascript -->
-{% if plugin_messages%}
-var pluginMessages = { {% for lang,message in plugin_messages %} "{{lang}}" : "{{message}}" {% if not loop.last %}, {% endif %}{% endfor %} };
-{% endif %}
 var lang = "{{ request.lang }}";
 var content_lang = "{{ request.contentLang }}";
 var vocab = "{{ request.vocabid }}";
@@ -32,6 +29,12 @@ var showNotation = {% if request.vocab and request.vocab.config.showNotation == 
 var languageOrder = [{% for lang in request.vocab.config.languageOrder(request.contentLang) %}"{{ lang }}"{% if not loop.last %},{% endif %}{% endfor %}];
 {% endif %}
 </script>
+
+{% if plugin_params%}
+<script type="application/ld+json">
+{{ plugin_params|raw }}
+</script>
+{% endif %}
 
 {% if request.page == 'page' and search_results and search_results|length == 1 %}
 <script type="application/ld+json">

--- a/view/scripts.twig
+++ b/view/scripts.twig
@@ -11,6 +11,9 @@ var expand = "{% trans %}Show all breadcrumb paths{% endtrans %}";
 var hiertrans = "{% trans "Hier-nav" %}";
 
 <!-- variables passed through to javascript -->
+{% if plugin_messages%}
+var pluginMessages = { {% for lang,message in plugin_messages %} "{{lang}}" : "{{message}}" {% if not loop.last %}, {% endif %}{% endfor %} };
+{% endif %}
 var lang = "{{ request.lang }}";
 var content_lang = "{{ request.contentLang }}";
 var vocab = "{{ request.vocabid }}";
@@ -55,4 +58,3 @@ var languageOrder = [{% for lang in request.vocab.config.languageOrder(request.c
 {% for files in request.plugins.pluginsJS %}{% for file in files %}<script type="text/javascript" src="{{ file }}"></script>{% endfor %}{% endfor %}
 {% if request.plugins.callbacks %}<script type="text/javascript">var pluginCallbacks = [{% for function in request.plugins.callbacks %}{% if not loop.first %}, {% endif %}"{{ function }}"{% endfor %}];</script>{% endif %}
 <script type="text/javascript" src="resource/js/docready.js"></script>
-


### PR DESCRIPTION
This feature enables vocabulary specialists to create notifications for concept plages of a specific vocabulary without the need to write special plugins for each message or mess with the update schedule for the vocabularies in the main triple store. The messages are stored in vocabulary config file as RDF resources.

As it is, the feature for displaying the messages is still implemented as a separate message plugin - but should the functionality be more closely integrated as a part of Skosmos?