### PR TITLE
Set the order of isothes hierarchy properties

### DIFF
--- a/model/Concept.php
+++ b/model/Concept.php
@@ -78,7 +78,7 @@ class Concept extends VocabularyDataObject
     public function __construct($model, $vocab, $resource, $graph, $clang)
     {
         parent::__construct($model, $vocab, $resource);
-        $this->order = array("rdf:type", "dc:isReplacedBy", "skos:definition", "skos:broader", "skos:narrower", "skos:related", "skos:altLabel", "skosmos:memberOf", "skos:note", "skos:scopeNote", "skos:historyNote", "rdfs:comment", "dc11:source", "dc:source", "skos:prefLabel");
+        $this->order = array("rdf:type", "dc:isReplacedBy", "skos:definition", "skos:broader", "isothes:broaderGeneric", "isothes:broaderPartitive", "isothes:broaderInstantial", "skos:narrower", "isothes:narrowerGeneric", "isothes:narrowerPartitive", "isothes:narrowerInstantial", "skos:related", "skos:altLabel", "skosmos:memberOf", "skos:note", "skos:scopeNote", "skos:historyNote", "rdfs:comment", "dc11:source", "dc:source", "skos:prefLabel");
         $this->graph = $graph;
         $this->clang = $clang;
         // setting the Punic plugins locale for localized datetime conversions


### PR DESCRIPTION
This PR changes the way more specific hierarchy properties (broaderGeneric, broaderPartitive, broaderInstantial + the narrower equivalents) so that they are displayed in the same order as regular SKOS broader/narrower properties.

This problem was noticed when testing the new YSO hierarchical properties in http://dev.finto.fi/ysotietomalliuudistus/fi/