### PR TITLE
Fix "Any language" label not showing in edge case

### DIFF
--- a/resource/js/docready.js
+++ b/resource/js/docready.js
@@ -543,7 +543,7 @@ $(function() { // DOCUMENT READY
   } else if (!search_lang) {
       langPretty = $('a[hreflang=' + lang + ']').html();
       search_lang = lang;
-      if (!langPretty) { langPretty = $('a[hreflang="anything"]').html(); }
+      if (!langPretty) { langPretty = $('.lang-button-all').html(); }
       $('#lang-dropdown-toggle').html(langPretty + ' <span class="caret"></span>');
       qlang = lang;
   } else {
@@ -558,7 +558,7 @@ $(function() { // DOCUMENT READY
   });
 
   if (!search_lang_possible && search_lang !== 'anything') {
-    langPretty = $('a[hreflang=""]').html();
+    langPretty = $('.lang-button-all').html();
     $('#lang-dropdown-toggle').html(langPretty + ' <span class="caret"></span>');
     qlang = '';
     createCookie('SKOSMOS_SEARCH_LANG', qlang, 365);


### PR DESCRIPTION
Came across an edge case where the search language selector button showed as "undefined"

![Skjermbilde 2019-11-12 kl  17 14 03](https://user-images.githubusercontent.com/434495/68688901-dcac2780-056f-11ea-8a49-3bff563251b4.png)

It only seems to happen when 

1. the UI language (English for instance) is not a valid search language (because we don't have any English vocabularies) 
2. and when no vocabulary has been selected (that is, on the front page), since otherwise the default language for the vocabulary would kick in
3. and the `SKOSMOS_SEARCH_LANG` cookie has not been set

This PR fixes the issue for me, but please check if it makes sense. My *guess* is that `[hreflang="anything"]` was changed to `[hreflang=""]` at some point and eventually removed since it's not a valid language code.