### PR TITLE
Upgrade to PHP 7.1-7.4 and Fuseki 3.14.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ env:
   global:
     - CC_TEST_REPORTER_ID=fb98170a5c7ea9cc2bbab19ff26268335e6a11a4f8267ca935e5e8ff4624886c
   matrix:
-    - FUSEKI_VERSION=3.9.0
+    - FUSEKI_VERSION=3.14.0
     - FUSEKI_VERSION=SNAPSHOT
 matrix:
   exclude:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,9 +31,11 @@ env:
     - FUSEKI_VERSION=SNAPSHOT
 matrix:
   exclude:
-  - php: 7.0
-    env: FUSEKI_VERSION=SNAPSHOT
   - php: 7.1
+    env: FUSEKI_VERSION=SNAPSHOT
+  - php: 7.2
+    env: FUSEKI_VERSION=SNAPSHOT
+  - php: 7.4
     env: FUSEKI_VERSION=SNAPSHOT
   allow_failures:
   - php: 7.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ matrix:
   - php: 7.1
     env: FUSEKI_VERSION=SNAPSHOT
   allow_failures:
+  - php: 7.4
   - env: FUSEKI_VERSION=SNAPSHOT
 notifications:
     slack: kansalliskirjasto:9mOKu3Vws1CIddF5jqWgXbli

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,10 @@ sudo: required
 dist: trusty
 language: php
 php:
-  - 7.0
   - 7.1
   - 7.2
+  - 7.3
+  - 7.4
 install:
   - composer install
 cache:

--- a/tests/init_fuseki.sh
+++ b/tests/init_fuseki.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Note: This script must be sourced from within bash, e.g. ". init_fuseki.sh"
 
-FUSEKI_VERSION=${FUSEKI_VERSION:-3.9.0}
+FUSEKI_VERSION=${FUSEKI_VERSION:-3.14.0}
 
 if [ "$FUSEKI_VERSION" = "SNAPSHOT" ]; then
     # find out the latest snapshot version and its download URL by parsing Apache directory listings
@@ -20,7 +20,7 @@ if [ ! -f "apache-jena-fuseki-$FUSEKI_VERSION/fuseki-server" ]; then
 fi
 
 cd "apache-jena-fuseki-$FUSEKI_VERSION"
-chmod +x fuseki-server
+chmod +x fuseki-server bin/s-put
 ./fuseki-server --port=13030 --config ../fuseki-assembler.ttl &
 until curl --output /dev/null --silent --head --fail http://localhost:13030; do
     printf '.'

--- a/tests/init_fuseki.sh
+++ b/tests/init_fuseki.sh
@@ -20,6 +20,7 @@ if [ ! -f "apache-jena-fuseki-$FUSEKI_VERSION/fuseki-server" ]; then
 fi
 
 cd "apache-jena-fuseki-$FUSEKI_VERSION"
+chmod +x fuseki-server
 ./fuseki-server --port=13030 --config ../fuseki-assembler.ttl &
 until curl --output /dev/null --silent --head --fail http://localhost:13030; do
     printf '.'


### PR DESCRIPTION
This PR changes the Travis CI environment where tests are run.

Support for PHP 7.0 is dropped (we no longer run the tests using it)
Support for PHP 7.1 and 7.2 remains
Support for PHP 7.3 is introduced (and tests confirm it)

Tests are also run with PHP 7.4, but currently the [builds fail](https://travis-ci.org/NatLibFi/Skosmos/jobs/645471054) - they are marked as "allowed failures" in Travis configuration. I will open a separate issue on fixing the PHP 7.4 related problems.

The Fuseki version used for running integration tests is upgraded from 3.9.0 to 3.14.0. There was a problem in this version that scripts were not executable in the tarball distribution, so this PR adds a chmod command to work around it (issue [reported and fixed](https://issues.apache.org/jira/browse/JENA-1834) in subsequent Jena Fuseki versions)

Fixes #917 

