### PR TITLE
Use phpdbg instead of Xdebug for Travis coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_script:
   - sh ./init_fuseki.sh
   - cd ..
 script:
-  - phpdbg -qrr phpunit
+  - phpdbg -qrr vendor/bin/phpunit
 after_script:
   - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ php:
   - 7.3
   - 7.4
 install:
+  - phpenv config-rm xdebug.ini
   - composer install
 cache:
   directories:
@@ -20,6 +21,8 @@ before_script:
   - export LANGUAGE=fr
   - sh ./init_fuseki.sh
   - cd ..
+script:
+  - phpdbg -qrr phpunit
 after_script:
   - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
   - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
Travis CI environment by default uses Xdebug to create coverage reports. But this slows down unit tests significantly. This PR disabled Xdebug and instead uses phpdbg, which reduces the time spent on Travis CI jobs by around half, from 12 minutes to 6 minutes (per job, but those are usually run in parallel).