### PR TITLE
fix some test coverage annotations after PR #921

### DIFF
--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -532,8 +532,6 @@ test:ta125
 
   /**
    * @covers Model::getResourceFromUri
-   * @covers Model::getResourceLabel
-   * @covers Model::fetchResourceFromUri
    */
   public function testGetResourceFromUri() {
     $resource = $this->model->getResourceFromUri('http://www.yso.fi/onto/yso/p19378');

--- a/tests/ResolverTest.php
+++ b/tests/ResolverTest.php
@@ -11,6 +11,8 @@ class ResolverTest extends PHPUnit\Framework\TestCase
 
   /**
    * @covers Resolver::resolve
+   * @covers RemoteResource::__construct
+   * @covers LOCResource::resolve
    * @uses Resolver
    */
   public function testResolveLOCZeroTimeout()
@@ -22,6 +24,8 @@ class ResolverTest extends PHPUnit\Framework\TestCase
 
   /**
    * @covers Resolver::resolve
+   * @covers RemoteResource::__construct
+   * @covers WDQSResource::resolve
    * @uses Resolver
    */
   public function testResolveWDQSZeroTimeout()
@@ -33,6 +37,8 @@ class ResolverTest extends PHPUnit\Framework\TestCase
 
   /**
    * @covers Resolver::resolve
+   * @covers RemoteResource::__construct
+   * @covers LinkedDataResource::resolve
    * @uses Resolver
    */
   public function testResolveLDZeroTimeout()


### PR DESCRIPTION
The method `Model::fetchResourceFromUri` no longer exists and `getResourceLabel` was never called in the testGetResourceFromUri test.

The other methods are now mentioned as covered, since they are exercised (at least partly) by the tests.