### PR TITLE
Fix null-handling of skosmos:sparqlGraph

### DIFF
--- a/model/Model.php
+++ b/model/Model.php
@@ -568,7 +568,7 @@ class Model
      * Returns a SPARQL endpoint object.
      * @param string $dialect eg. 'JenaText'.
      * @param string $endpoint url address of endpoint
-     * @param string $graph uri for the target graph.
+     * @param string|null $graph uri for the target graph.
      */
     public function getSparqlImplementation($dialect, $endpoint, $graph)
     {

--- a/model/Vocabulary.php
+++ b/model/Vocabulary.php
@@ -37,7 +37,7 @@ class Vocabulary extends DataObject
     /**
      * Get the SPARQL graph URI for this vocabulary
      *
-     * @return string graph URI
+     * @return string|null graph URI
      */
     public function getGraph()
     {

--- a/model/sparql/GenericSparql.php
+++ b/model/sparql/GenericSparql.php
@@ -34,7 +34,8 @@ class GenericSparql {
     /**
      * Requires the following three parameters.
      * @param string $endpoint SPARQL endpoint address.
-     * @param object $graph an EasyRDF SPARQL graph instance.
+     * @param string|null $graph Which graph to query: Either an URI, the special value "?graph"
+     *                           to use the default graph, or NULL to not use a GRAPH clause.
      * @param object $model a Model instance.
      */
     public function __construct($endpoint, $graph, $model) {
@@ -113,15 +114,9 @@ class GenericSparql {
         if (!$vocabs) {
             return $this->graph !== '?graph' && $this->graph !== NULL ? "FROM <$this->graph>" : '';
         }
-        foreach($vocabs as $vocab) {
-            $graph = $vocab->getGraph();
-            if (!in_array($graph, $graphs)) {
-                array_push($graphs, $graph);
-            }
-        }
+        $graphs = $this->getVocabGraphs($vocabs);
         foreach ($graphs as $graph) {
-            if($graph !== NULL)
-                $clause .= "FROM NAMED <$graph> "; 
+            $clause .= "FROM NAMED <$graph> ";
         }
         return $clause;
     }
@@ -152,7 +147,7 @@ class GenericSparql {
      */
 
     protected function isDefaultEndpoint() {
-        return $this->graph[0] == '?';
+        return !is_null($this->graph) && $this->graph[0] == '?';
     }
 
     /**
@@ -700,7 +695,10 @@ EOQ;
         }
         $graphs = array();
         foreach ($vocabs as $voc) {
-            $graphs[] = $voc->getGraph();
+            $graph = $voc->getGraph();
+            if (!is_null($graph) && !in_array($graph, $graphs)) {
+                $graphs[] = $graph;
+            }
         }
         return $graphs;
     }

--- a/model/sparql/GenericSparql.php
+++ b/model/sparql/GenericSparql.php
@@ -730,7 +730,9 @@ EOQ;
         foreach ($graphs as $graph) {
           $values[] = "<$graph>";
         }
-        return "FILTER (?graph IN (" . implode(',', $values) . "))";
+        if (count($values)) {
+          return "FILTER (?graph IN (" . implode(',', $values) . "))";
+        }
     }
 
     /**


### PR DESCRIPTION
The `skosmos:sparqlGraph` vocabulary property is listed as optional, but when not set, Skosmos will produce a notice:

    Notice:  Trying to access array offset on value of type null in /var/www/html/model/sparql/GenericSparql.php on line 155

### The first commit:

- Adds a null check to the `GenericSparql::isDefaultEndpoint()` method.
- Moves the null check from `GenericSparql::generateFromClause()` to `GenericSparql::getVocabGraphs()` and updates the former method to use the latter to reduce code duplication.
- Updates docstrings to use `string|null`

### The second commit:

- Updates `GenericSparql::formatFilterGraph` to not add a FILTER clause if none of the vocabularies have a `skosmos:sparqlGraph`. This adreses the issues where you would always get zero results if you didn't specify `skosmos:sparqlGraph` for any vocabulary, since that would result in this: `FILTER (?graph IN ())`.

Note: Apart from the case `skosmos:sparqlGraph` is not defined for any vocabulary, there is also the case where `skosmos:sparqlGraph` is specified for *some* of the vocabularies, but not for others. In that case, the default search will only return results for the vocabularies that do specify `skosmos:sparqlGraph`, which is potentially confusing I guess. Perhaps it should be noted in the docs that it's a good idea to either include `skosmos:sparqlGraph` for all vocabularies or for none?