### PR TITLE
Fix problems displaying external links 

### DIFF
--- a/model/Concept.php
+++ b/model/Concept.php
@@ -606,8 +606,11 @@ class Concept extends VocabularyDataObject
                             // checking if the property value is not in the current vocabulary
                             $exvoc = $this->model->guessVocabularyFromURI($val->getUri(), $this->vocab->getId());
                             if ($exvoc && $exvoc->getId() !== $this->vocab->getId()) {
-                                $value = new ConceptPropertyValue($this->model, $exvoc, $val, $prop, $this->clang, true);
+                                $voc = $exvoc;
+                            } else {
+                                $voc = $this->vocab;
                             }
+                            $value = new ConceptPropertyValue($this->model, $voc, $val, $prop, $this->clang, true);
                         }
                         $ret[$prop]->addValue($value, $this->clang);
                     }

--- a/model/Concept.php
+++ b/model/Concept.php
@@ -599,19 +599,6 @@ class Concept extends VocabularyDataObject
                     if (isset($ret[$prop])) {
                         // create a ConceptPropertyValue first, assuming the resource exists in current vocabulary
                         $value = new ConceptPropertyValue($this->model, $this->vocab, $val, $prop, $this->clang);
-                        // check whether we know the label of the resource
-                        $label = $value->getLabel('', 'null');
-                        if ($label === null) {
-                            // we don't know a label for the resource
-                            // checking if the property value is not in the current vocabulary
-                            $exvoc = $this->model->guessVocabularyFromURI($val->getUri(), $this->vocab->getId());
-                            if ($exvoc && $exvoc->getId() !== $this->vocab->getId()) {
-                                $voc = $exvoc;
-                            } else {
-                                $voc = $this->vocab;
-                            }
-                            $value = new ConceptPropertyValue($this->model, $voc, $val, $prop, $this->clang, true);
-                        }
                         $ret[$prop]->addValue($value, $this->clang);
                     }
 

--- a/model/ConceptMappingPropertyValue.php
+++ b/model/ConceptMappingPropertyValue.php
@@ -144,11 +144,6 @@ class ConceptMappingPropertyValue extends VocabularyDataObject
         // @codeCoverageIgnoreEnd
     }
 
-    public function isExternal() {
-        // if we don't know enough of this resource
-        return $this->resource->label() == null && $this->resource->get('rdf:value') == null;
-    }
-
     public function getNotation()
     {
         if ($this->resource->get('skos:notation')) {

--- a/model/ConceptPropertyValue.php
+++ b/model/ConceptPropertyValue.php
@@ -97,11 +97,7 @@ class ConceptPropertyValue extends VocabularyDataObject
 
     public function getExVocab()
     {
-        if ($this->isExternal()) {
-            return $this->vocab;
-        } else {
-            return null;
-        }
+        return $this->model->guessVocabularyFromURI($this->getUri(), $this->vocab->getId());
     }
 
     public function getVocab()

--- a/model/ConceptPropertyValue.php
+++ b/model/ConceptPropertyValue.php
@@ -14,13 +14,21 @@ class ConceptPropertyValue extends VocabularyDataObject
     /** whether the property value is external w.r.t. to the subject resource */
     private $external;
 
-    public function __construct($model, $vocab, $resource, $prop, $clang = '', $external = false)
+    public function __construct($model, $vocab, $resource, $prop, $clang = '')
     {
         parent::__construct($model, $vocab, $resource);
         $this->submembers = array();
         $this->type = $prop;
         $this->clang = $clang;
-        $this->external = $external;
+        // check if the resource is external to the current vocabulary
+        $this->external = ($this->getLabel('', 'null') === null);
+        if ($this->external) {
+            // if we find the resource in another vocabulary, use it instead
+            $exvocab = $this->getExVocab();
+            if ($exvocab !== null) {
+                $this->vocab = $exvocab;
+            }
+        }
     }
 
     public function __toString()

--- a/tests/ConceptPropertyValueTest.php
+++ b/tests/ConceptPropertyValueTest.php
@@ -25,6 +25,7 @@ class ConceptPropertyValueTest extends PHPUnit\Framework\TestCase
    */
   public function testConstructor() {
     $mockres = $this->getMockBuilder('EasyRdf\\Resource')->disableOriginalConstructor()->getMock();
+    $mockres->method('getUri')->willReturn('http://example.org/');
     $propval = new ConceptPropertyValue($this->model, $this->vocab, $mockres, 'skosmos:testProp', 'en');
     $this->assertInstanceOf('ConceptPropertyValue', $propval);
   }
@@ -112,6 +113,7 @@ class ConceptPropertyValueTest extends PHPUnit\Framework\TestCase
    */
   public function testGetNotationWhenThereIsNone() {
     $mockres = $this->getMockBuilder('EasyRdf\\Resource')->disableOriginalConstructor()->getMock();
+    $mockres->method('getUri')->willReturn('http://example.org/');
     $propval = new ConceptPropertyValue($this->model, $this->vocab, $mockres, 'en');
     $this->assertEquals(null, $propval->getNotation());
   }
@@ -199,6 +201,7 @@ class ConceptPropertyValueTest extends PHPUnit\Framework\TestCase
    */
   public function testGetSubMembersEmpty() {
     $mockres = $this->getMockBuilder('EasyRdf\\Resource')->disableOriginalConstructor()->getMock();
+    $mockres->method('getUri')->willReturn('http://example.org/');
     $propval = new ConceptPropertyValue($this->model, $this->vocab, $mockres, 'en');
     $this->assertEquals(null, $propval->getSubMembers());
   }


### PR DESCRIPTION
by more judicious use of isExternal and getExVocab. Fixes #935

ConceptMappingPropertyValue.isExternal() is removed because it is no longer being used.