### PR TITLE
Issue896 notated alphabetical listing

### DIFF
--- a/model/Vocabulary.php
+++ b/model/Vocabulary.php
@@ -504,7 +504,7 @@ class Vocabulary extends DataObject
      */
     public function searchConceptsAlphabetical($letter, $limit = null, $offset = null, $clang = null)
     {
-        return $this->getSparql()->queryConceptsAlphabetical($letter, $clang, $limit, $offset, $this->config->getIndexClasses(),$this->config->getShowDeprecated());
+        return $this->getSparql()->queryConceptsAlphabetical($letter, $clang, $limit, $offset, $this->config->getIndexClasses(), $this->config->getShowDeprecated(), $this->config->getAlphabeticalListQualifier());
     }
 
     /**

--- a/model/VocabularyConfig.php
+++ b/model/VocabularyConfig.php
@@ -415,6 +415,16 @@ class VocabularyConfig extends BaseConfig
     }
 
     /**
+     * Returns the alphabetical list qualifier in this vocabulary,
+     * or null if not set.
+     * @return EasyRdf\Resource|null alphabetical list qualifier resource or null
+     */
+    public function getAlphabeticalListQualifier()
+    {
+        return $this->resource->getResource('skosmos:alphabeticalListQualifier');
+    }
+
+    /**
      * Returns a boolean value set in the config.ttl config.
      * @return boolean
      */

--- a/model/sparql/GenericSparql.php
+++ b/model/sparql/GenericSparql.php
@@ -1239,7 +1239,7 @@ WHERE {
   $filterDeprecated
   $values
 }
-ORDER BY STR(LCASE(COALESCE(?alabel, ?label))) $limitandoffset
+ORDER BY LCASE(STR(COALESCE(?alabel, ?label))) STR(?s) LCASE(STR(?qualifier)) $limitandoffset
 EOQ;
         return $query;
     }

--- a/model/sparql/GenericSparql.php
+++ b/model/sparql/GenericSparql.php
@@ -1196,9 +1196,10 @@ EOQ;
      * @param integer $offset offsets the result set
      * @param array|null $classes
      * @param boolean $showDeprecated whether to include deprecated concepts in the result (default: false)
+     * @param \EasyRdf\Resource|null $qualifier alphabetical list qualifier resource or null (default: null)
      * @return string sparql query
      */
-    protected function generateAlphabeticalListQuery($letter, $lang, $limit, $offset, $classes, $showDeprecated = false) {
+    protected function generateAlphabeticalListQuery($letter, $lang, $limit, $offset, $classes, $showDeprecated = false, $qualifier = null) {
         $fcl = $this->generateFromClause();
         $classes = ($classes) ? $classes : array('http://www.w3.org/2004/02/skos/core#Concept');
         $values = $this->formatValues('?type', $classes, 'uri');
@@ -1206,12 +1207,13 @@ EOQ;
         $conditions = $this->formatFilterConditions($letter, $lang);
         $filtercondLabel = $conditions['filterpref'];
         $filtercondALabel = $conditions['filteralt'];
+        $qualifierClause = $qualifier ? "OPTIONAL { ?s <" . $qualifier->getURI() . "> ?qualifier }" : "";
         $filterDeprecated="";
         if(!$showDeprecated){
             $filterDeprecated="FILTER NOT EXISTS { ?s owl:deprecated true }";
         }
         $query = <<<EOQ
-SELECT DISTINCT ?s ?label ?alabel $fcl
+SELECT DISTINCT ?s ?label ?alabel ?qualifier $fcl
 WHERE {
   {
     ?s skos:prefLabel ?label .
@@ -1233,6 +1235,7 @@ WHERE {
     }
   }
   ?s a ?type .
+  $qualifierClause
   $filterDeprecated
   $values
 }
@@ -1268,6 +1271,15 @@ EOQ;
                 $hit['lang'] = $row->alabel->getLang();
             }
 
+            if (isset($row->qualifier)) {
+                if ($row->qualifier instanceof EasyRdf\Literal) {
+                    $hit['qualifier'] = $row->qualifier->getValue();
+                }
+                else {
+                    $hit['qualifier'] = $row->qualifier->localName();
+                }
+            }
+
             $ret[] = $hit;
         }
 
@@ -1283,9 +1295,10 @@ EOQ;
      * @param integer $offset offsets the result set
      * @param array $classes
      * @param boolean $showDeprecated whether to include deprecated concepts in the result (default: false)
+     * @param \EasyRdf\Resource|null $qualifier alphabetical list qualifier resource or null (default: null)
      */
-    public function queryConceptsAlphabetical($letter, $lang, $limit = null, $offset = null, $classes = null,$showDeprecated = false) {
-        $query = $this->generateAlphabeticalListQuery($letter, $lang, $limit, $offset, $classes,$showDeprecated);
+    public function queryConceptsAlphabetical($letter, $lang, $limit = null, $offset = null, $classes = null, $showDeprecated = false, $qualifier = null) {
+        $query = $this->generateAlphabeticalListQuery($letter, $lang, $limit, $offset, $classes, $showDeprecated, $qualifier);
         $results = $this->query($query);
         return $this->transformAlphabeticalListResults($results);
     }

--- a/model/sparql/JenaTextSparql.php
+++ b/model/sparql/JenaTextSparql.php
@@ -117,7 +117,7 @@ class JenaTextSparql extends GenericSparql
         $lcletter = mb_strtolower($letter, 'UTF-8'); // convert to lower case, UTF-8 safe
         $textcondPref = $this->createTextQueryCondition($letter . '*', 'skos:prefLabel', $lang);
         $textcondAlt = $this->createTextQueryCondition($letter . '*', 'skos:altLabel', $lang);
-        $orderbyclause = $this->formatOrderBy("LCASE(?match)", $lang);
+        $orderbyclause = $this->formatOrderBy("LCASE(?match)", $lang) . " STR(?s) LCASE(STR(?qualifier))";
 
         $qualifierClause = $qualifier ? "OPTIONAL { ?s <" . $qualifier->getURI() . "> ?qualifier }" : "";
 

--- a/tests/GenericSparqlTest.php
+++ b/tests/GenericSparqlTest.php
@@ -181,6 +181,133 @@ class GenericSparqlTest extends PHPUnit\Framework\TestCase
   /**
    * @covers GenericSparql::queryConceptsAlphabetical
    * @covers GenericSparql::generateAlphabeticalListQuery
+   * @covers GenericSparql::transformAlphabeticalListResults
+   */
+  public function testQualifiedNotationAlphabeticalList() {
+    $voc = $this->model->getVocabulary('test-qualified-notation');
+    $res = new EasyRdf\Resource("http://www.w3.org/2004/02/skos/core#notation");
+    $sparql = new GenericSparql('http://localhost:13030/skosmos-test/sparql', $voc->getGraph(), $this->model);
+
+    $actual = $sparql->queryConceptsAlphabetical("a", "en", $limit = null, $offset = null, $classes=null, $showDeprecated=false, $qualifier=$res);
+
+    $expected = array (
+      0 => array (
+        'uri' => 'http://www.skosmos.skos/test/qn1',
+        'localname' => 'qn1',
+        'prefLabel' => 'A',
+        'lang' => 'en',
+        'qualifier' => 'A'
+      ),
+      1 => array (
+        'uri' => 'http://www.skosmos.skos/test/qn1b',
+        'localname' => 'qn1b',
+        'prefLabel' => 'A',
+        'lang' => 'en',
+        'qualifier' => 'A'
+      ),
+      2 => array (
+        'uri' => 'http://www.skosmos.skos/test/qn1c',
+        'localname' => 'qn1c',
+        'prefLabel' => 'A',
+        'lang' => 'en',
+      ),
+    );
+    $this->assertEquals($expected, $actual);
+
+    $actual = $sparql->queryConceptsAlphabetical("b", "en", $limit = null, $offset = null, $classes=null, $showDeprecated=false, $qualifier=$res);
+
+    $expected = array (
+      0 => array (
+        'uri' => 'http://www.skosmos.skos/test/qn2',
+        'localname' => 'qn2',
+        'prefLabel' => 'B',
+        'lang' => 'en',
+        'qualifier' => 'B'
+      ),
+      1 => array (
+        'uri' => 'http://www.skosmos.skos/test/qn2',
+        'localname' => 'qn2',
+        'prefLabel' => 'B',
+        'lang' => 'en',
+        'qualifier' => 'C'
+      ),
+      2 => array (
+        'uri' => 'http://www.skosmos.skos/test/qn2b',
+        'localname' => 'qn2b',
+        'prefLabel' => 'B',
+        'lang' => 'en',
+        'qualifier' => 'B'
+      ),
+      3 => array (
+        'uri' => 'http://www.skosmos.skos/test/qn2b',
+        'localname' => 'qn2b',
+        'prefLabel' => 'B',
+        'lang' => 'en',
+        'qualifier' => 'C'
+      ),
+    );
+    $this->assertEquals($expected, $actual);
+  }
+
+  /**
+   * @covers GenericSparql::queryConceptsAlphabetical
+   * @covers GenericSparql::generateAlphabeticalListQuery
+   * @covers GenericSparql::transformAlphabeticalListResults
+   */
+  public function testQualifiedBroaderAlphabeticalList() {
+    $voc = $this->model->getVocabulary('test-qualified-broader');
+    $res = new EasyRdf\Resource("http://www.w3.org/2004/02/skos/core#broader");
+    $sparql = new GenericSparql('http://localhost:13030/skosmos-test/sparql', $voc->getGraph(), $this->model);
+
+    $actual = $sparql->queryConceptsAlphabetical("a", "en", $limit = null, $offset = null, $classes=null, $showDeprecated=false, $qualifier=$res);
+
+    $expected = array (
+      0 => array (
+        'uri' => 'http://www.skosmos.skos/test/qb1',
+        'localname' => 'qb1',
+        'prefLabel' => 'A',
+        'lang' => 'en',
+      ),
+    );
+    $this->assertEquals($expected, $actual);
+
+    $actual = $sparql->queryConceptsAlphabetical("b", "en", $limit = null, $offset = null, $classes=null, $showDeprecated=false, $qualifier=$res);
+
+    $expected = array (
+      0 => array (
+        'uri' => 'http://www.skosmos.skos/test/qb2',
+        'localname' => 'qb2',
+        'prefLabel' => 'B',
+        'lang' => 'en',
+        'qualifier' => 'qb1'
+      ),
+    );
+    $this->assertEquals($expected, $actual);
+
+    $actual = $sparql->queryConceptsAlphabetical("c", "en", $limit = null, $offset = null, $classes=null, $showDeprecated=false, $qualifier=$res);
+
+    $expected = array (
+      0 => array (
+        'uri' => 'http://www.skosmos.skos/test/qb3',
+        'localname' => 'qb3',
+        'prefLabel' => 'C',
+        'lang' => 'en',
+        'qualifier' => 'qb1'
+      ),
+      1 => array (
+        'uri' => 'http://www.skosmos.skos/test/qb3',
+        'localname' => 'qb3',
+        'prefLabel' => 'C',
+        'lang' => 'en',
+        'qualifier' => 'qb2'
+      ),
+    );
+    $this->assertEquals($expected, $actual);
+  }
+
+  /**
+   * @covers GenericSparql::queryConceptsAlphabetical
+   * @covers GenericSparql::generateAlphabeticalListQuery
    * @covers GenericSparql::formatFilterConditions
    * @covers GenericSparql::transformAlphabeticalListResults
    */

--- a/tests/GenericSparqlTest.php
+++ b/tests/GenericSparqlTest.php
@@ -188,7 +188,7 @@ class GenericSparqlTest extends PHPUnit\Framework\TestCase
     $res = new EasyRdf\Resource("http://www.w3.org/2004/02/skos/core#notation");
     $sparql = new GenericSparql('http://localhost:13030/skosmos-test/sparql', $voc->getGraph(), $this->model);
 
-    $actual = $sparql->queryConceptsAlphabetical("a", "en", $limit = null, $offset = null, $classes=null, $showDeprecated=false, $qualifier=$res);
+    $actual = $sparql->queryConceptsAlphabetical("a", "en", null, null, null, false, $res);
 
     $expected = array (
       0 => array (
@@ -214,7 +214,7 @@ class GenericSparqlTest extends PHPUnit\Framework\TestCase
     );
     $this->assertEquals($expected, $actual);
 
-    $actual = $sparql->queryConceptsAlphabetical("b", "en", $limit = null, $offset = null, $classes=null, $showDeprecated=false, $qualifier=$res);
+    $actual = $sparql->queryConceptsAlphabetical("b", "en", null, null, null, false, $res);
 
     $expected = array (
       0 => array (
@@ -259,7 +259,7 @@ class GenericSparqlTest extends PHPUnit\Framework\TestCase
     $res = new EasyRdf\Resource("http://www.w3.org/2004/02/skos/core#broader");
     $sparql = new GenericSparql('http://localhost:13030/skosmos-test/sparql', $voc->getGraph(), $this->model);
 
-    $actual = $sparql->queryConceptsAlphabetical("a", "en", $limit = null, $offset = null, $classes=null, $showDeprecated=false, $qualifier=$res);
+    $actual = $sparql->queryConceptsAlphabetical("a", "en", null, null, null, false, $res);
 
     $expected = array (
       0 => array (
@@ -271,7 +271,7 @@ class GenericSparqlTest extends PHPUnit\Framework\TestCase
     );
     $this->assertEquals($expected, $actual);
 
-    $actual = $sparql->queryConceptsAlphabetical("b", "en", $limit = null, $offset = null, $classes=null, $showDeprecated=false, $qualifier=$res);
+    $actual = $sparql->queryConceptsAlphabetical("b", "en", null, null, null, false, $res);
 
     $expected = array (
       0 => array (
@@ -284,7 +284,7 @@ class GenericSparqlTest extends PHPUnit\Framework\TestCase
     );
     $this->assertEquals($expected, $actual);
 
-    $actual = $sparql->queryConceptsAlphabetical("c", "en", $limit = null, $offset = null, $classes=null, $showDeprecated=false, $qualifier=$res);
+    $actual = $sparql->queryConceptsAlphabetical("c", "en", null, null, null, false, $res);
 
     $expected = array (
       0 => array (

--- a/tests/GlobalConfigTest.php
+++ b/tests/GlobalConfigTest.php
@@ -28,7 +28,7 @@ class GlobalConfigTest extends PHPUnit\Framework\TestCase
 
     public function testGetDefaultSparqlDialect()
     {
-        $this->assertEquals("JenaText", $this->config->getDefaultSparqlDialect());
+        $this->assertEquals("Generic", $this->config->getDefaultSparqlDialect());
     }
 
     public function testGetCollationEnabled()

--- a/tests/JenaTextSparqlTest.php
+++ b/tests/JenaTextSparqlTest.php
@@ -109,7 +109,7 @@ class JenaTextSparqlTest extends PHPUnit\Framework\TestCase
     $res = new EasyRdf\Resource("http://www.w3.org/2004/02/skos/core#notation");
     $sparql = new GenericSparql('http://localhost:13030/skosmos-test/sparql', $voc->getGraph(), $this->model);
 
-    $actual = $sparql->queryConceptsAlphabetical("a", "en", $limit = null, $offset = null, $classes=null, $showDeprecated=false, $qualifier=$res);
+    $actual = $sparql->queryConceptsAlphabetical("a", "en", null, null, null, false, $res);
 
     $expected = array (
       0 => array (
@@ -135,7 +135,7 @@ class JenaTextSparqlTest extends PHPUnit\Framework\TestCase
     );
     $this->assertEquals($expected, $actual);
 
-    $actual = $sparql->queryConceptsAlphabetical("b", "en", $limit = null, $offset = null, $classes=null, $showDeprecated=false, $qualifier=$res);
+    $actual = $sparql->queryConceptsAlphabetical("b", "en", null, null, null, false, $res);
 
     $expected = array (
       0 => array (
@@ -180,7 +180,7 @@ class JenaTextSparqlTest extends PHPUnit\Framework\TestCase
     $res = new EasyRdf\Resource("http://www.w3.org/2004/02/skos/core#broader");
     $sparql = new JenaTextSparql('http://localhost:13030/skosmos-test/sparql', $voc->getGraph(), $this->model);
 
-    $actual = $sparql->queryConceptsAlphabetical("a", "en", $limit = null, $offset = null, $classes=null, $showDeprecated=false, $qualifier=$res);
+    $actual = $sparql->queryConceptsAlphabetical("a", "en", null, null, null, false, $res);
 
     $expected = array (
       0 => array (
@@ -192,7 +192,7 @@ class JenaTextSparqlTest extends PHPUnit\Framework\TestCase
     );
     $this->assertEquals($expected, $actual);
 
-    $actual = $sparql->queryConceptsAlphabetical("b", "en", $limit = null, $offset = null, $classes=null, $showDeprecated=false, $qualifier=$res);
+    $actual = $sparql->queryConceptsAlphabetical("b", "en", null, null, null, false, $res);
 
     $expected = array (
       0 => array (
@@ -205,7 +205,7 @@ class JenaTextSparqlTest extends PHPUnit\Framework\TestCase
     );
     $this->assertEquals($expected, $actual);
 
-    $actual = $sparql->queryConceptsAlphabetical("c", "en", $limit = null, $offset = null, $classes=null, $showDeprecated=false, $qualifier=$res);
+    $actual = $sparql->queryConceptsAlphabetical("c", "en", null, null, null, false, $res);
 
     $expected = array (
       0 => array (

--- a/tests/JenaTextSparqlTest.php
+++ b/tests/JenaTextSparqlTest.php
@@ -100,6 +100,133 @@ class JenaTextSparqlTest extends PHPUnit\Framework\TestCase
   }
 
   /**
+   * @covers GenericSparql::queryConceptsAlphabetical
+   * @covers GenericSparql::generateAlphabeticalListQuery
+   * @covers GenericSparql::transformAlphabeticalListResults
+   */
+  public function testQualifiedNotationAlphabeticalList() {
+    $voc = $this->model->getVocabulary('test-qualified-notation');
+    $res = new EasyRdf\Resource("http://www.w3.org/2004/02/skos/core#notation");
+    $sparql = new GenericSparql('http://localhost:13030/skosmos-test/sparql', $voc->getGraph(), $this->model);
+
+    $actual = $sparql->queryConceptsAlphabetical("a", "en", $limit = null, $offset = null, $classes=null, $showDeprecated=false, $qualifier=$res);
+
+    $expected = array (
+      0 => array (
+        'uri' => 'http://www.skosmos.skos/test/qn1',
+        'localname' => 'qn1',
+        'prefLabel' => 'A',
+        'lang' => 'en',
+        'qualifier' => 'A'
+      ),
+      1 => array (
+        'uri' => 'http://www.skosmos.skos/test/qn1b',
+        'localname' => 'qn1b',
+        'prefLabel' => 'A',
+        'lang' => 'en',
+        'qualifier' => 'A'
+      ),
+      2 => array (
+        'uri' => 'http://www.skosmos.skos/test/qn1c',
+        'localname' => 'qn1c',
+        'prefLabel' => 'A',
+        'lang' => 'en',
+      ),
+    );
+    $this->assertEquals($expected, $actual);
+
+    $actual = $sparql->queryConceptsAlphabetical("b", "en", $limit = null, $offset = null, $classes=null, $showDeprecated=false, $qualifier=$res);
+
+    $expected = array (
+      0 => array (
+        'uri' => 'http://www.skosmos.skos/test/qn2',
+        'localname' => 'qn2',
+        'prefLabel' => 'B',
+        'lang' => 'en',
+        'qualifier' => 'B'
+      ),
+      1 => array (
+        'uri' => 'http://www.skosmos.skos/test/qn2',
+        'localname' => 'qn2',
+        'prefLabel' => 'B',
+        'lang' => 'en',
+        'qualifier' => 'C'
+      ),
+      2 => array (
+        'uri' => 'http://www.skosmos.skos/test/qn2b',
+        'localname' => 'qn2b',
+        'prefLabel' => 'B',
+        'lang' => 'en',
+        'qualifier' => 'B'
+      ),
+      3 => array (
+        'uri' => 'http://www.skosmos.skos/test/qn2b',
+        'localname' => 'qn2b',
+        'prefLabel' => 'B',
+        'lang' => 'en',
+        'qualifier' => 'C'
+      ),
+    );
+    $this->assertEquals($expected, $actual);
+  }
+
+  /**
+   * @covers JenaTextSparql::queryConceptsAlphabetical
+   * @covers JenaTextSparql::generateAlphabeticalListQuery
+   * @covers JenaTextSparql::transformAlphabeticalListResults
+   */
+  public function testQualifiedBroaderAlphabeticalList() {
+    $voc = $this->model->getVocabulary('test-qualified-broader');
+    $res = new EasyRdf\Resource("http://www.w3.org/2004/02/skos/core#broader");
+    $sparql = new JenaTextSparql('http://localhost:13030/skosmos-test/sparql', $voc->getGraph(), $this->model);
+
+    $actual = $sparql->queryConceptsAlphabetical("a", "en", $limit = null, $offset = null, $classes=null, $showDeprecated=false, $qualifier=$res);
+
+    $expected = array (
+      0 => array (
+        'uri' => 'http://www.skosmos.skos/test/qb1',
+        'localname' => 'qb1',
+        'prefLabel' => 'A',
+        'lang' => 'en',
+      ),
+    );
+    $this->assertEquals($expected, $actual);
+
+    $actual = $sparql->queryConceptsAlphabetical("b", "en", $limit = null, $offset = null, $classes=null, $showDeprecated=false, $qualifier=$res);
+
+    $expected = array (
+      0 => array (
+        'uri' => 'http://www.skosmos.skos/test/qb2',
+        'localname' => 'qb2',
+        'prefLabel' => 'B',
+        'lang' => 'en',
+        'qualifier' => 'qb1'
+      ),
+    );
+    $this->assertEquals($expected, $actual);
+
+    $actual = $sparql->queryConceptsAlphabetical("c", "en", $limit = null, $offset = null, $classes=null, $showDeprecated=false, $qualifier=$res);
+
+    $expected = array (
+      0 => array (
+        'uri' => 'http://www.skosmos.skos/test/qb3',
+        'localname' => 'qb3',
+        'prefLabel' => 'C',
+        'lang' => 'en',
+        'qualifier' => 'qb1'
+      ),
+      1 => array (
+        'uri' => 'http://www.skosmos.skos/test/qb3',
+        'localname' => 'qb3',
+        'prefLabel' => 'C',
+        'lang' => 'en',
+        'qualifier' => 'qb2'
+      ),
+    );
+    $this->assertEquals($expected, $actual);
+  }
+
+  /**
    * @covers JenaTextSparql::generateAlphabeticalListQuery
    */
   public function testQueryConceptsAlphabeticalNoResults() {

--- a/tests/VocabularyTest.php
+++ b/tests/VocabularyTest.php
@@ -12,6 +12,7 @@ class VocabularyTest extends \PHPUnit\Framework\TestCase
     putenv("LC_ALL=en_GB.utf8");
     setlocale(LC_ALL, 'en_GB.utf8');
     $this->model = new Model(new GlobalConfig('/../tests/testconfig.ttl'));
+    $this->jenamodel = new Model(new GlobalConfig('/../tests/jenatestconfig.ttl'));
   }
 
   /**
@@ -259,6 +260,92 @@ class VocabularyTest extends \PHPUnit\Framework\TestCase
       $concepts = $vocab->searchConceptsAlphabetical('T', null, null, 'en');
       $this->assertCount(1, $concepts);
       $this->assertEquals('Tuna', $concepts[0]['prefLabel']);
+  }
+
+  /**
+   * @covers Vocabulary::searchConceptsAlphabetical
+   * @covers GenericSparql::queryConceptsAlphabetical
+   * @covers GenericSparql::generateAlphabeticalListQuery
+   * @covers GenericSparql::transformAlphabeticalListResults
+   */
+  public function testSearchConceptsAlphabeticalQualifiedNotationGeneric() {
+    $vocab = $this->model->getVocabulary('test-qualified-notation');
+
+    $concepts = $vocab->searchConceptsAlphabetical('A', null, null, 'en');
+    $this->assertCount(3, $concepts);
+    $this->assertEquals('A', $concepts[0]['qualifier']);
+    $this->assertEquals('qn1b', $concepts[1]['localname']);
+
+    $concepts = $vocab->searchConceptsAlphabetical('B', null, null, 'en');
+    $this->assertCount(4, $concepts);
+    $this->assertEquals('C', $concepts[3]['qualifier']);
+  }
+
+  /**
+   * @covers Vocabulary::searchConceptsAlphabetical
+   * @covers JenaTextSparql::queryConceptsAlphabetical
+   * @covers JenaTextSparql::generateAlphabeticalListQuery
+   * @covers JenaTextSparql::transformAlphabeticalListResults
+   */
+  public function testSearchConceptsAlphabeticalQualifiedNotation() {
+    $vocab = $this->jenamodel->getVocabulary('test-qualified-notation');
+
+    $concepts = $vocab->searchConceptsAlphabetical('A', null, null, 'en');
+    $this->assertCount(3, $concepts);
+    $this->assertEquals('A', $concepts[0]['qualifier']);
+    $this->assertEquals('qn1b', $concepts[1]['localname']);
+
+    $concepts = $vocab->searchConceptsAlphabetical('B', null, null, 'en');
+    $this->assertCount(4, $concepts);
+    $this->assertEquals('C', $concepts[3]['qualifier']);
+  }
+
+  /**
+   * @covers Vocabulary::searchConceptsAlphabetical
+   * @covers GenericSparql::queryConceptsAlphabetical
+   * @covers GenericSparql::generateAlphabeticalListQuery
+   * @covers GenericSparql::transformAlphabeticalListResults
+   */
+  public function testSearchConceptsAlphabeticalQualifiedBroaderGeneric() {
+    $vocab = $this->model->getVocabulary('test-qualified-broader');
+
+    $concepts = $vocab->searchConceptsAlphabetical('A', null, null, 'en');
+    $this->assertCount(1, $concepts);
+    $this->assertArrayNotHasKey('qualifier', $concepts[0]);
+    $this->assertEquals('qb1', $concepts[0]['localname']);
+
+    $concepts = $vocab->searchConceptsAlphabetical('B', null, null, 'en');
+    $this->assertCount(1, $concepts);
+    $this->assertEquals('qb1', $concepts[0]['qualifier']);
+
+    $concepts = $vocab->searchConceptsAlphabetical('C', null, null, 'en');
+    $this->assertCount(2, $concepts);
+    $this->assertEquals('qb1', $concepts[0]['qualifier']);
+    $this->assertEquals('qb2', $concepts[1]['qualifier']);
+  }
+
+  /**
+   * @covers Vocabulary::searchConceptsAlphabetical
+   * @covers JenaTextSparql::queryConceptsAlphabetical
+   * @covers JenaTextSparql::generateAlphabeticalListQuery
+   * @covers JenaTextSparql::transformAlphabeticalListResults
+   */
+  public function testSearchConceptsAlphabeticalQualifiedBroader() {
+    $vocab = $this->jenamodel->getVocabulary('test-qualified-broader');
+
+    $concepts = $vocab->searchConceptsAlphabetical('A', null, null, 'en');
+    $this->assertCount(1, $concepts);
+    $this->assertArrayNotHasKey('qualifier', $concepts[0]);
+    $this->assertEquals('qb1', $concepts[0]['localname']);
+
+    $concepts = $vocab->searchConceptsAlphabetical('B', null, null, 'en');
+    $this->assertCount(1, $concepts);
+    $this->assertEquals('qb1', $concepts[0]['qualifier']);
+
+    $concepts = $vocab->searchConceptsAlphabetical('C', null, null, 'en');
+    $this->assertCount(2, $concepts);
+    $this->assertEquals('qb1', $concepts[0]['qualifier']);
+    $this->assertEquals('qb2', $concepts[1]['qualifier']);
   }
 
   /**

--- a/tests/jenatestconfig.ttl
+++ b/tests/jenatestconfig.ttl
@@ -83,6 +83,30 @@
                     "Testi lyhyt"@fi;
 	skosmos:sparqlGraph <http://www.skosmos.skos/test/> .
 
+:test-qualified-broader a skosmos:Vocabulary, void:Dataset ;
+    dc:title "Test qualified alphabetical listing queries (skos:broader)"@en ;
+    dc:subject :cat_science ;
+    dc:type mdrtype:ONTOLOGY ;
+    void:sparqlEndpoint <http://localhost:13030/skosmos-test/sparql> ;
+    void:uriSpace "http://www.skosmos.skos/test-qualified-broader/" ;
+    skosmos:defaultLanguage "en" ;
+    skosmos:groupClass skos:Collection ;
+    skosmos:language "en" ;
+    skosmos:alphabeticalListQualifier skos:broader ;
+    skosmos:sparqlGraph <http://www.skosmos.skos/test-qualified-broader/> .
+
+:test-qualified-notation a skosmos:Vocabulary, void:Dataset ;
+    dc:title "Test qualified alphabetical listing queries (skos:notation)"@en ;
+    dc:subject :cat_science ;
+    dc:type mdrtype:ONTOLOGY ;
+    void:sparqlEndpoint <http://localhost:13030/skosmos-test/sparql> ;
+    void:uriSpace "http://www.skosmos.skos/test-qualified-notation/" ;
+    skosmos:defaultLanguage "en" ;
+    skosmos:groupClass skos:Collection ;
+    skosmos:language "en" ;
+    skosmos:alphabeticalListQualifier skos:notation ;
+    skosmos:sparqlGraph <http://www.skosmos.skos/test-qualified-notation/> .
+
 :multiple-schemes a skosmos:Vocabulary, void:Dataset ;
 	skos:prefLabel "Mutiple Schemes vocabulary"@en ;
 	dc:title "Mutiple Schemes vocabulary"@en ;

--- a/tests/test-vocab-data/test-qualified-broader.ttl
+++ b/tests/test-vocab-data/test-qualified-broader.ttl
@@ -1,0 +1,24 @@
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix dc11: <http://purl.org/dc/elements/1.1/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix test: <http://www.skosmos.skos/test/> .
+@prefix meta: <http://www.skosmos.skos/test-meta/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix skosmos: <http://www.skosmos.skos/> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix mads: <http://www.loc.gov/mads/rdf/v1#> .
+
+test:qb1 a skos:Concept, meta:TestClass ;
+    skos:prefLabel "A"@en .
+
+test:qb2 a skos:Concept, meta:TestClass ;
+    skos:broader test:qb1 ;
+    skos:prefLabel "B"@en .
+
+test:qb3 a skos:Concept, meta:TestClass ;
+    skos:broader test:qb1, test:qb2 ;
+    skos:prefLabel "C"@en .

--- a/tests/test-vocab-data/test-qualified-notation.ttl
+++ b/tests/test-vocab-data/test-qualified-notation.ttl
@@ -1,0 +1,32 @@
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix dc11: <http://purl.org/dc/elements/1.1/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix test: <http://www.skosmos.skos/test/> .
+@prefix meta: <http://www.skosmos.skos/test-meta/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix skosmos: <http://www.skosmos.skos/> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix mads: <http://www.loc.gov/mads/rdf/v1#> .
+
+test:qn1 a skos:Concept, meta:TestClass ;
+    skos:notation "A";
+    skos:prefLabel "A"@en .
+
+test:qn1b a skos:Concept, meta:TestClass ;
+    skos:notation "A"^^skosmos:test;
+    skos:prefLabel "A"@en .
+
+test:qn1c a skos:Concept, meta:TestClass ;
+    skos:prefLabel "A"@en .
+
+test:qn2 a skos:Concept, meta:TestClass ;
+    skos:notation "B", "C";
+    skos:prefLabel "B"@en .
+
+test:qn2b a skos:Concept, meta:TestClass ;
+    skos:notation "B"@en, "C"@fi;
+    skos:prefLabel "B"@en .

--- a/tests/testconfig.ttl
+++ b/tests/testconfig.ttl
@@ -25,7 +25,7 @@
     skosmos:sparqlEndpoint <http://localhost:13030/skosmos-test/sparql> ;
     # sparql-query extension, or "Generic" for plain SPARQL 1.1
     # set to "JenaText" instead if you use Fuseki with jena-text index
-    skosmos:sparqlDialect "JenaText" ;
+    # skosmos:sparqlDialect "JenaText" ;
     # whether to enable collation in sparql queries
     skosmos:sparqlCollationEnabled true ;
     # HTTP client configuration
@@ -86,6 +86,30 @@
 	skosmos:shortName "Test short",
                     "Testi lyhyt"@fi;
 	skosmos:sparqlGraph <http://www.skosmos.skos/test/> .
+
+:test-qualified-broader a skosmos:Vocabulary, void:Dataset ;
+    dc:title "Test qualified alphabetical listing queries (skos:broader)"@en ;
+    dc:subject :cat_science ;
+    dc:type mdrtype:ONTOLOGY ;
+    void:sparqlEndpoint <http://localhost:13030/skosmos-test/sparql> ;
+    void:uriSpace "http://www.skosmos.skos/test-qualified-broader/" ;
+    skosmos:defaultLanguage "en" ;
+    skosmos:groupClass skos:Collection ;
+    skosmos:language "en" ;
+    skosmos:alphabeticalListQualifier skos:broader ;
+    skosmos:sparqlGraph <http://www.skosmos.skos/test-qualified-broader/> .
+
+:test-qualified-notation a skosmos:Vocabulary, void:Dataset ;
+    dc:title "Test qualified alphabetical listing queries (skos:notation)"@en ;
+    dc:subject :cat_science ;
+    dc:type mdrtype:ONTOLOGY ;
+    void:sparqlEndpoint <http://localhost:13030/skosmos-test/sparql> ;
+    void:uriSpace "http://www.skosmos.skos/test-qualified-notation/" ;
+    skosmos:defaultLanguage "en" ;
+    skosmos:groupClass skos:Collection ;
+    skosmos:language "en" ;
+    skosmos:alphabeticalListQualifier skos:notation ;
+    skosmos:sparqlGraph <http://www.skosmos.skos/test-qualified-notation/> .
 
 :test-marc a skosmos:Vocabulary, void:Dataset ;
     skos:prefLabel "Test marc source"@en ;

--- a/view/light.twig
+++ b/view/light.twig
@@ -75,9 +75,9 @@
               {% endif %}
               <li>
               {% if value.altLabel %}
-              <span class="replaced">{{ value.altLabel }}</span>	&rarr; <a href="{{ value.uri | link_url(vocab,request.lang,'page',request.contentLang) }}">{{ value.prefLabel }}</a>
+              <span class="replaced">{{ value.altLabel }}</span>	&rarr; <a href="{{ value.uri | link_url(vocab,request.lang,'page',request.contentLang) }}">{{ value.prefLabel }}{% if value.qualifier %} ({{ value.qualifier }}){% endif %}</a>
               {% else %}
-              <a href="{{ value.uri | link_url(vocab,request.lang,'page',request.contentLang) }}">{{ value.prefLabel }}</a>
+              <a href="{{ value.uri | link_url(vocab,request.lang,'page',request.contentLang) }}">{{ value.prefLabel }}{% if value.qualifier %} ({{ value.qualifier }}){% endif %}</a>
               {% endif %}
              </li>
               {% endfor %}


### PR DESCRIPTION
Fixes #896 via introducing a `qualifier` attribute to the search result, if one exists. In case of multiple, they are returned in separate rows.

For literals, only plain literal value is shown. For IRIs, local name is shown.