### PR TITLE
fixes #934

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -77,7 +77,7 @@
     "grimmlink/qtip2": "3.0.3"
   },
   "require-dev": {
-    "phpunit/phpunit": "4.8 - 7.5.10",
+    "phpunit/phpunit": "7.2.0 - 7.5.20",
     "umpirsky/twig-gettext-extractor": "1.3.*",
     "symfony/dom-crawler": "3.4.3",
     "mockery/mockery": "1.0"

--- a/tests/FeedbackTest.php
+++ b/tests/FeedbackTest.php
@@ -44,6 +44,7 @@ class FeedbackTest extends PHPUnit\Framework\TestCase
    * @covers Honeypot::validateHoneytime
    */
   public function testHoneypotAndHoneypot() {
+    $this->expectNotToPerformAssertions();
     $this->request
         ->shouldReceive('getQueryParamPOST')
         ->with('message')
@@ -84,6 +85,7 @@ class FeedbackTest extends PHPUnit\Framework\TestCase
    * @covers Honeypot::validateHoneytime
    */
   public function testHoneypotAndHoneypotDisabled() {
+    $this->expectNotToPerformAssertions();
     $this->controller->honeypot->disable();
     $this->request
         ->shouldReceive('getQueryParamPOST')
@@ -126,6 +128,7 @@ class FeedbackTest extends PHPUnit\Framework\TestCase
    * @covers Honeypot::validateHoneytime
    */
   public function testHoneytimeTooFast() {
+    $this->expectNotToPerformAssertions();
     $this->request
         ->shouldReceive('getQueryParamPOST')
         ->with('message')
@@ -165,6 +168,7 @@ class FeedbackTest extends PHPUnit\Framework\TestCase
    * @covers Honeypot::validateHoneypot
    */
   public function testHoneypotNotEmpty() {
+    $this->expectNotToPerformAssertions();
     $this->request
         ->shouldReceive('getQueryParamPOST')
         ->with('message')

--- a/tests/GlobalConfigTest.php
+++ b/tests/GlobalConfigTest.php
@@ -133,20 +133,16 @@ class GlobalConfigTest extends PHPUnit\Framework\TestCase
 
     // --- tests for the exception paths
 
-    /**
-     * @expectedException
-     */
     public function testInitializeConfigWithoutGraph()
     {
+        $this->expectOutputString('Error: config.ttl must have exactly one skosmos:Configuration');
         $conf = new GlobalConfig('/../tests/testconfig-nograph.ttl');
         $this->assertNotNull($conf);
     }
 
-    /**
-     * @expectedException
-     */
     public function testInexistentFile()
     {
+        $this->expectOutputString('Error: config.ttl file is missing, please provide one.');
         $conf = new GlobalConfig('/../tests/testconfig-idonotexist.ttl');
         $this->assertNotNull($conf);
     }

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -59,7 +59,7 @@ class ModelTest extends PHPUnit\Framework\TestCase
    * @covers Model::getVocabulariesInCategory
    */
   public function testGetVocabulariesInCategory() {
-    $category = $this->model->getVocabulariesInCategory('cat_science');
+    $category = $this->model->getVocabulariesInCategory(new EasyRdf\Resource('http://base/#cat_science'));
     foreach($category as $vocab)
       $this->assertInstanceOf('Vocabulary', $vocab);
   }
@@ -237,6 +237,12 @@ class ModelTest extends PHPUnit\Framework\TestCase
     $result = $this->model->searchConcepts($this->params);
     $this->assertEquals('http://www.skosmos.skos/test/ta123', $result[0]['uri']);
     $this->assertEquals('multiple broaders', $result[0]['prefLabel']);
+
+    // sort by URI to ensure their relative order
+    usort($result[0]['skos:broader'], function($a, $b) {
+        return strnatcasecmp($a['uri'], $b['uri']);
+    });
+
     $this->assertCount(2, $result[0]['skos:broader']); // two broader concepts
     $this->assertEquals('http://www.skosmos.skos/test/ta118', $result[0]['skos:broader'][0]['uri']);
     $this->assertEquals('-"special" character \\example\\', $result[0]['skos:broader'][0]['prefLabel']);

--- a/tests/RestControllerTest.php
+++ b/tests/RestControllerTest.php
@@ -19,6 +19,10 @@ class RestControllerTest extends \PHPUnit\Framework\TestCase
     $this->controller = new RestController($this->model);
   }
 
+  protected function tearDown() {
+    ob_clean();
+  }
+
   /**
    * @covers RestController::data
    */

--- a/tests/VocabularyTest.php
+++ b/tests/VocabularyTest.php
@@ -443,7 +443,6 @@ class VocabularyTest extends \PHPUnit\Framework\TestCase
     $vocab = $this->model->getVocabulary('http304');
     $conceptSchemeUri = $vocab->getDefaultConceptScheme();
     $conceptScheme = $vocab->getConceptScheme($conceptSchemeUri);
-    print($conceptSchemeUri);
     $this->assertEquals(
       "Test Main Concept Scheme",
       $conceptScheme->getLiteral($conceptSchemeUri,"skos:prefLabel")

--- a/tests/jenatestconfig.ttl
+++ b/tests/jenatestconfig.ttl
@@ -14,7 +14,7 @@
 @prefix meta: <http://www.skosmos.skos/test-meta/> .
 @prefix my: <http://example.com/myns#> .
 @prefix mdrtype: <http://publications.europa.eu/resource/authority/dataset-type/> .
-@prefix : <#> .
+@prefix : <http://base/#> .
 
 # Skosmos main configuration
 

--- a/tests/testconfig-fordefaults.ttl
+++ b/tests/testconfig-fordefaults.ttl
@@ -11,7 +11,7 @@
 @prefix skosmos: <http://purl.org/net/skosmos#> .
 @prefix isothes: <http://purl.org/iso25964/skos-thes#> .
 @prefix mdrtype: <http://publications.europa.eu/resource/authority/dataset-type/> .
-@prefix : <#> .
+@prefix : <http://base/#> .
 
 # Skosmos main configuration
 

--- a/tests/testconfig.ttl
+++ b/tests/testconfig.ttl
@@ -15,7 +15,7 @@
 @prefix my: <http://example.com/myns#> .
 @prefix mdrtype: <http://publications.europa.eu/resource/authority/dataset-type/> .
 @prefix test: <http://www.skosmos.skos/test/> .
-@prefix : <#> .
+@prefix : <http://base/#> .
 
 # Skosmos main configuration
 


### PR DESCRIPTION
This PR fixes #934 pretty straightforward except for
```
1) ConceptPropertyTest::testAddValue
This test did not perform any assertions
/skosmos/tests/ConceptPropertyTest.php:79

2) ConceptTest::testGetPropertiesAlphabeticalSortingOfPropertyValues
This test did not perform any assertions
/skosmos/tests/ConceptTest.php:178
```
Both of which require a more detailed intervention and changes in logic. One can see #938 for example implementation.