### PR TITLE
additional fixes for #934

### DIFF
--- a/model/ConceptProperty.php
+++ b/model/ConceptProperty.php
@@ -86,10 +86,35 @@ class ConceptProperty
 
     private function sortValues()
     {
+        # TODO: sort by URI as last resort
+        # Note that getLabel() returns URIs in case of no label and may return a prefixed value which affects sorting
         if (!empty($this->values)) {
-            uksort($this->values, function($a, $b) {
-                return $this->sort_by_notation ? strnatcasecmp($a, $b) : strcoll(strtolower($a),strtolower($b));
-            });
+            if ($this->sort_by_notation) {
+                uasort($this->values, function($a, $b) {
+                    $anot = $a->getNotation();
+                    $bnot = $b->getNotation();
+                    if ($anot == null) {
+                        if ($bnot == null) {
+                            // assume that labels are unique
+                            return strcoll(strtolower($a->getLabel()), strtolower($b->getLabel()));
+                        }
+                        return 1;
+                    }
+                    else if ($bnot == null) {
+                        return -1;
+                    }
+                    else {
+                        // assume that notations are unique
+                        return strnatcasecmp($anot, $bnot);
+                    }
+                });
+            }
+            else {
+                uasort($this->values, function($a, $b) {
+                    // assume that labels are unique
+                    return strcoll(strtolower($a->getLabel()), strtolower($b->getLabel()));
+                });
+            }
         }
         $this->is_sorted = true;
     }

--- a/tests/ConceptPropertyTest.php
+++ b/tests/ConceptPropertyTest.php
@@ -82,12 +82,30 @@ class ConceptPropertyTest extends PHPUnit\Framework\TestCase
     $concept = $concepts[0];
     $props = $concept->getProperties();
     $prevlabel = null;
-    foreach($props['skos:narrower'] as $val) {
-      $label = is_string($val->getLabel()) ? $val->getLabel() : $val->getLabel()->getValue();
+    foreach($props['skos:narrower']->getValues() as $val) {
+      $label = $val->getLabel();
       if ($prevlabel)
-        $this->assertEquals(1, strnatcmp($prevlabel, $label));
+        $this->assertEquals(-1, strnatcasecmp($prevlabel, $label));
       $prevlabel = $label;
     }
+  }
+
+  /**
+   * @covers ConceptProperty::addValue
+   * @covers ConceptProperty::sortValues
+   */
+  public function testSortNotatedValues() {
+    $vocab = $this->model->getVocabulary('test-notation-sort');
+    $concepts = $vocab->getConceptInfo('http://www.skosmos.skos/test/ta01', 'en');
+    $concept = $concepts[0];
+    $props = $concept->getProperties();
+    $expected = array("test:ta0112", "test:ta0119", "test:ta0117", "test:ta0116", "test:ta0114","test:ta0115","test:ta0113", "test:ta0120", "test:ta0111", );
+    $ret = array();
+
+    foreach($props['skos:narrower']->getValues() as $val) {
+        $ret[] = EasyRdf\RdfNamespace::shorten($val->getUri());
+    }
+    $this->assertEquals($expected, $ret);
   }
 
   /**

--- a/tests/ConceptTest.php
+++ b/tests/ConceptTest.php
@@ -181,10 +181,10 @@ class ConceptTest extends PHPUnit\Framework\TestCase
     $concept = reset($results);
     $props = $concept->getProperties();
     $prevlabel = null;
-    foreach($props['skos:narrower'] as $val) {
-      $label = is_string($val->getLabel()) ? $val->getLabel() : $val->getLabel()->getValue();
+    foreach($props['skos:narrower']->getValues() as $val) {
+      $label = $val->getLabel();
       if ($prevlabel)
-        $this->assertEquals(1, strnatcmp($prevlabel, $label));
+        $this->assertEquals(-1, strnatcasecmp($prevlabel, $label));
       $prevlabel = $label;
     }
   }

--- a/tests/test-vocab-data/test-notation-sort.ttl
+++ b/tests/test-vocab-data/test-notation-sort.ttl
@@ -1,0 +1,146 @@
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix dc11: <http://purl.org/dc/elements/1.1/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix test: <http://www.skosmos.skos/test/> .
+@prefix meta: <http://www.skosmos.skos/test-meta/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix skosmos: <http://www.skosmos.skos/> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix mads: <http://www.loc.gov/mads/rdf/v1#> .
+
+meta:TestClass a owl:Class ;
+    rdfs:subClassOf skos:Concept ;
+    rdfs:label "Test class"@en .
+
+skosmos:testprop a rdf:Property ;
+    rdfs:label "Skosmos test property"@en .
+
+skos:prefLabel a rdf:Property ;
+    rdfs:label "preferred label"@en .
+
+skos:altLabel a rdf:Property ;
+    rdfs:label "alternative label"@en .
+
+skos:scopeNote a rdf:Property ;
+    rdfs:label "scope note"@en .
+
+skos:broader a rdf:Property ;
+    rdfs:label "has broader"@en .
+
+skos:narrower a rdf:Property ;
+    rdfs:label "has narrower"@en .
+
+test:ta0111 a skos:Concept, meta:TestClass ;
+    skos:broader test:ta01 ;
+    skos:inScheme test:conceptscheme ;
+    owl:deprecated true ;
+    skos:prefLabel "Tuna"@en .
+
+test:ta0112 a skos:Concept, meta:TestClass ;
+    skosmos:testprop "Test property value" ;
+    skos:notation "665" ;
+    skos:broader test:ta01 ;
+    skos:narrower test:ta0121 ;
+    skos:exactMatch test:ta0118 ;
+    skos:inScheme test:conceptscheme ;
+    skos:prefLabel "Carp"@en,
+        "Karppi"@fi ;
+    skos:altLabel "Golden crucian"@en;
+    skos:hiddenLabel "Karpit"@fi;
+    skos:scopeNote "Carp are oily freshwater fish"@en .
+
+test:ta0114 a skos:Concept, meta:TestClass ;
+    skos:broader test:ta01 ;
+    dct:modified "1986-21-00"^^xsd:date ; # date invalid on purpose
+    skos:inScheme test:conceptscheme ;
+    skos:prefLabel "Buri"@en .
+
+test:ta0115 a skos:Concept, meta:TestClass ;
+    skos:broader test:ta01 ;
+    skos:inScheme test:conceptscheme ;
+    skos:definition "any fish belonging to the order Anguilliformes"@en, 
+      "Iljettävä limanuljaska"@fi ;
+    skos:prefLabel "Eel"@en .
+
+test:ta0116 a skos:Concept, meta:TestClass ;
+    skos:broader test:ta01 ;
+    skos:inScheme test:conceptscheme ;
+    skos:prefLabel "Barracuda"@en .
+
+test:ta0117 a skos:Concept, meta:TestClass ;
+    skos:broader test:ta01 ;
+    skos:inScheme test:conceptscheme ;
+    skos:relatedMatch test:ta0115 ;
+    skos:prefLabel "3D Barracuda"@en .
+
+test:ta0118 a skos:Concept, meta:TestClass ;
+    skos:inScheme test:conceptscheme ;
+    skos:exactMatch test:ta0112 ;
+    skos:prefLabel "-\"special\" character \\example\\"@en .
+
+test:ta0119 a skos:Concept, meta:TestClass ;
+    skos:broader test:ta01 ;
+    skos:inScheme test:conceptscheme ;
+    skos:notation "690" ;
+    skos:prefLabel "Hauki"@fi .
+
+test:ta0120 a skos:Concept, meta:TestClass ;
+    skos:broader test:ta01 ;
+    skos:inScheme test:conceptscheme .
+
+test:ta0121 a skos:Concept, meta:TestClass ;
+    skos:broader test:ta0112 ;
+    skos:inScheme test:conceptscheme ;
+    skos:prefLabel "Crucian carp"@en .
+
+test:ta0122 a skos:Concept, meta:TestClass ;
+    skos:broader test:ta0116 ;
+    skos:inScheme test:conceptscheme ;
+    skos:definition test:caribbean_sea_barracuda_def ;
+    skos:prefLabel "Caribbean Sea barracuda"@en .
+
+test:caribbean_sea_barracuda_def
+    rdf:value "Caribbean Sea barracuda is an exclusively marine fish." .
+
+test:ta0123 a skos:Concept, meta:TestClass ;
+    dct:modified "2014-10-01T16:29:03+00:00"^^xsd:dateTime ;
+    skos:broader test:ta0118, test:ta119 ;
+    skos:inScheme test:conceptscheme ;
+    skos:prefLabel "multiple broaders"@en .
+
+test:ta0124
+  a mads:ComplexSubject, skos:Concept ;
+  skos:prefLabel "Vadefugler : Europa"@nb ;
+  mads:componentList ( test:ta0125 test:ta126 ) .
+
+test:ta0125
+  a mads:Topic, skos:Concept ;
+  skos:prefLabel "Vadefugler"@nb .
+
+test:ta0126
+  a mads:Geographic, skos:Concept ;
+  skos:prefLabel "Europa"@nb .
+
+test:ta01 a skos:Concept, meta:TestClass ;
+    skos:inScheme test:conceptscheme ;
+    skos:narrower test:ta0111,
+        test:ta0112,
+        test:ta0113,
+        test:ta0114,
+        test:ta0115,
+        test:ta0116,
+        test:ta0117,
+        test:ta0119,
+        test:ta0120 ;
+    skos:prefLabel "Fish"@en ;
+    skos:topConceptOf test:conceptscheme .
+
+test:conceptscheme a skos:ConceptScheme ;
+    rdfs:label "Test conceptscheme"@en ;
+    dct:modified "2014-10-01T16:29:03+00:00"^^xsd:dateTime ;
+    owl:versionInfo "The latest and greatest version"^^xsd:string ;
+    skos:hasTopConcept test:ta01 .

--- a/tests/testconfig.ttl
+++ b/tests/testconfig.ttl
@@ -87,6 +87,19 @@
                     "Testi lyhyt"@fi;
 	skosmos:sparqlGraph <http://www.skosmos.skos/test/> .
 
+:test-notation-sort a skosmos:Vocabulary, void:Dataset ;
+	dc:title "Test notation sort ontology"@en ;
+	dc:subject :cat_science ;
+    dc:type mdrtype:ONTOLOGY ;
+	void:sparqlEndpoint <http://localhost:13030/skosmos-test/sparql> ;
+	void:uriSpace "http://www.skosmos.skos/test-notation-sort/";
+    skos:prefLabel "Test notation sort ontology"@en ;
+	skosmos:defaultLanguage "en";
+    skosmos:feedbackRecipient "developer@vocabulary.org";
+    skosmos:sortByNotation "true";
+	skosmos:language "en";
+	skosmos:sparqlGraph <http://www.skosmos.skos/test-notation-sort/> .
+
 :test-marc a skosmos:Vocabulary, void:Dataset ;
     skos:prefLabel "Test marc source"@en ;
     dc:title "Test marc source"@en ;


### PR DESCRIPTION
Previously, there were two risky tests as mentioned by #946. These were fixed in #938, however, they got intermingled with issue #854. This PR fixes the remaining risky tests by introducing a new, better sorting for ConceptProperties, and calls appropriate methods for the aforementioned tests.

For testing, please remember to set the `skosmos:sortByNotation` predicate to `true`.