### PR TITLE
Use a row for the bread crumb (as in other visual elements nearby) and include padding

### DIFF
--- a/resource/css/styles.css
+++ b/resource/css/styles.css
@@ -1159,6 +1159,8 @@ li.sub-group {
 .crumb-path {
   float:left;
   width: 100%;
+  padding-left: 15px;
+  padding-right: 15px;
 }
 
 .foundby {

--- a/view/concept-shared.twig
+++ b/view/concept-shared.twig
@@ -14,6 +14,7 @@
     <div class="concept-info{% if concept.deprecated %} deprecated-concept{% endif %}">
       <div class="concept-main">
       {% if bread_crumbs is defined %}
+        <div class="row">
         {% for path in bread_crumbs %}
         {% if path|length > 1 %}
           {% set crumbId = loop.index %}
@@ -35,6 +36,7 @@
             </div>
           {% endif %}
         {% endfor %}
+        </div>
       {% endif %}
       {% spaceless %}
       <div class="row{% if concept.type == 'skosext:DeprecatedConcept' %} deprecated{% endif %}">


### PR DESCRIPTION
Use a `<div class="row">` around the breadcrumb as in other elements to force it to occupy the whole row-area.

Would be easier if the elements were [flex](https://css-tricks.com/snippets/css/a-guide-to-flexbox/). Haven't used bootstrap in a while, but looks like it supports it too in the [version 4.x](https://getbootstrap.com/docs/4.0/utilities/flex/).

Closes #963 ~but needs a bit more of testing before it's ready for review.~ (tested with `docker-compose.yml`, and found nothing broken in the UI).

Applying changes locally in firefox development mode it looks as follows:

![image](https://user-images.githubusercontent.com/304786/78079595-ecd27f80-7408-11ea-88fc-0dc2d89e106c.png)
