### PR TITLE
Avoid displaying empty type field in search result list

### DIFF
--- a/view/search-result.twig
+++ b/view/search-result.twig
@@ -107,32 +107,20 @@
       {% endfor %}
     {% endif %}
   {% endif %}
-  <div class="property">
-    <span class="property-click" title="{% trans "concept_types" %}">
-      <img class="property-hover" src="resource/pics/type.gif">
-    </span>
-    <div class="property-values">
-      {% for property in conceptProperties %} {# loop through ConceptProperty objects #}
-        {% if property.getSubPropertyOf != 'skos:hiddenLabel' %}
-          {% if request.vocab.config.hasMultiLingualProperty(property.type) %}
-            {% set prevlang = '' %}{# Only displaying the language when it appears for the very first time #}
-            {% for language,labels in concept.allLabels(property.type) %}
-              {% for value in labels %}
-              <div class="row other-languages{% if prevlang != language %} first-of-language{% endif %}"><span class="versal col-xs-6{% if value.type == "skos:altLabel" %} replaced{% endif %}">{{ value.label }}</span><span class="versal col-xs-6">{% if prevlang != language %} {{ language }}{% endif %}</span></div>
-              {% set prevlang = language %}
-              {% endfor %}
-            {% endfor %}
-          {% else %}
-            {% for propval in property.values %} {# loop through ConceptPropertyValue objects #}
-              {% if property.type == 'rdf:type' %}
-                <span class="versal value">{{ propval.label|trans }}</span>
-              {% endif %}
-            {% endfor %}
-          {% endif %}
-        {% endif %}
-      {% endfor %}
-    </div>
-  </div>
+  {% for property in conceptProperties %} {# loop through ConceptProperty objects #}
+    {% if property.type == 'rdf:type' %}
+      <div class="property">
+        <span class="property-click" title="{% trans "concept_types" %}">
+          <img class="property-hover" src="resource/pics/type.gif">
+        </span>
+        <div class="property-values">
+          {% for propval in property.values %} {# loop through ConceptPropertyValue objects #}
+            <span class="versal value">{{ propval.label|trans }}</span>
+          {% endfor %}
+        </div>
+      </div>
+    {% endif %}
+  {% endfor %}
   {% if concept.uri %}
     <div><span class="versal uri-input-box">{{ concept.uri }}</span></div>
   {% endif %}


### PR DESCRIPTION
This PR avoids showing an empty type field in search result list. This could happen for concepts which had only `skos:Concept` as their type.

Before:
![image](https://user-images.githubusercontent.com/1132830/78890451-5c321a00-7a6e-11ea-8179-00912d8caa50.png)

After:
![image](https://user-images.githubusercontent.com/1132830/78890413-4a507700-7a6e-11ea-9783-cc853292d4c5.png)


This isn't quite what @tfrancart requested in #942:

> I would expect to see "Concept" as the value for "Concept type".

Instead, this makes the search result list match the concept page, where a type field is not shown at all if "Concept" is the only type of a concept.

The Twig template code for this part of the search result list was simplified a lot. It had a lot of unnecessary complexity as it was adapted from the concept page in commit 89a02e291b92236dbc63951c55167b66235ee345

Fixes #942