### PR TITLE
Add REST API methods for alphabetical index

### DIFF
--- a/controller/RestController.php
+++ b/controller/RestController.php
@@ -737,13 +737,9 @@ class RestController extends Controller
         $this->setLanguageProperties($request->getLang());
 
         $offset = ($request->getQueryParam('offset') && is_numeric($request->getQueryParam('offset')) && $request->getQueryParam('offset') >= 0) ? $request->getQueryParam('offset') : 0;
-        if ($request->getQueryParam('limit')) {
-            $count = $request->getQueryParam('limit');
-        } else {
-            $count = ($offset > 0) ? null : 250;
-        }
+        $limit = ($request->getQueryParam('limit') && is_numeric($request->getQueryParam('limit')) && $request->getQueryParam('limit') >= 0) ? $request->getQueryParam('limit') : 0;
 
-        $concepts = $request->getVocab()->searchConceptsAlphabetical($letter, $count, $offset, $request->getLang());
+        $concepts = $request->getVocab()->searchConceptsAlphabetical($letter, $limit, $offset, $request->getLang());
 
         $ret = array_merge_recursive($this->context, array(
             '@context' => array(

--- a/controller/RestController.php
+++ b/controller/RestController.php
@@ -736,8 +736,10 @@ class RestController extends Controller
     {
         $this->setLanguageProperties($request->getLang());
 
-        $offset = ($request->getQueryParam('offset') && is_numeric($request->getQueryParam('offset')) && $request->getQueryParam('offset') >= 0) ? $request->getQueryParam('offset') : 0;
-        $limit = ($request->getQueryParam('limit') && is_numeric($request->getQueryParam('limit')) && $request->getQueryParam('limit') >= 0) ? $request->getQueryParam('limit') : 0;
+        $offset_param = $request->getQueryParam('offset');
+        $offset = (is_numeric($offset_param) && $offset_param >= 0) ? $offset_param : 0;
+        $limit_param = $request->getQueryParam('limit');
+        $limit = (is_numeric($limit_param) && $limit_param >= 0) ? $limit_param : 0;
 
         $concepts = $request->getVocab()->searchConceptsAlphabetical($letter, $limit, $offset, $request->getLang());
 

--- a/controller/RestController.php
+++ b/controller/RestController.php
@@ -725,6 +725,31 @@ class RestController extends Controller
         return $this->returnJson($ret);
     }
 
+    /**
+     * Query for the concepts with terms starting with a given letter in the
+     * alphabetical index.
+     * @param Request $request
+     * @return object JSON-LD wrapped list of terms/concepts
+     */
+
+    public function indexConcepts($letter, $request)
+    {
+        $this->setLanguageProperties($request->getLang());
+        $concepts = $request->getVocab()->searchConceptsAlphabetical($letter, null, null, $request->getLang());
+
+        $ret = array_merge_recursive($this->context, array(
+            '@context' => array(
+                'indexConcepts' => array(
+                    '@id' => 'skosmos:indexConcepts',
+                    '@container' => '@list'
+                )
+            ),
+            'uri' => '',
+            'indexConcepts' => $concepts)
+        );
+        return $this->returnJson($ret);
+    }
+
     private function transformPropertyResults($uri, $lang, $objects, $propname, $propuri)
     {
         $results = array();

--- a/controller/RestController.php
+++ b/controller/RestController.php
@@ -735,7 +735,15 @@ class RestController extends Controller
     public function indexConcepts($letter, $request)
     {
         $this->setLanguageProperties($request->getLang());
-        $concepts = $request->getVocab()->searchConceptsAlphabetical($letter, null, null, $request->getLang());
+
+        $offset = ($request->getQueryParam('offset') && is_numeric($request->getQueryParam('offset')) && $request->getQueryParam('offset') >= 0) ? $request->getQueryParam('offset') : 0;
+        if ($request->getQueryParam('limit')) {
+            $count = $request->getQueryParam('limit');
+        } else {
+            $count = ($offset > 0) ? null : 250;
+        }
+
+        $concepts = $request->getVocab()->searchConceptsAlphabetical($letter, $count, $offset, $request->getLang());
 
         $ret = array_merge_recursive($this->context, array(
             '@context' => array(

--- a/controller/RestController.php
+++ b/controller/RestController.php
@@ -700,6 +700,31 @@ class RestController extends Controller
         return $this->returnJson($ret);
     }
 
+    /**
+     * Query for the available letters in the alphabetical index.
+     * @param Request $request
+     * @return object JSON-LD wrapped list of letters
+     */
+
+    public function indexLetters($request)
+    {
+        $this->setLanguageProperties($request->getLang());
+        $letters = $request->getVocab()->getAlphabet($request->getLang());
+
+        $ret = array_merge_recursive($this->context, array(
+            '@context' => array(
+                'indexLetters' => array(
+                    '@id' => 'skosmos:indexLetters',
+                    '@container' => '@list',
+                    '@language' => $request->getLang()
+                )
+            ),
+            'uri' => '',
+            'indexLetters' => $letters)
+        );
+        return $this->returnJson($ret);
+    }
+
     private function transformPropertyResults($uri, $lang, $objects, $propname, $propuri)
     {
         $results = array();

--- a/rest.php
+++ b/rest.php
@@ -66,6 +66,8 @@ try {
             $controller->label($request);
         } elseif ($parts[2] == 'lookup') {
             $controller->lookup($request);
+        } elseif ($parts[2] == 'index') {
+            $controller->indexLetters($request);
         } elseif ($parts[2] == 'broader') {
             $controller->broader($request);
         } elseif ($parts[2] == 'broaderTransitive') {

--- a/rest.php
+++ b/rest.php
@@ -66,8 +66,13 @@ try {
             $controller->label($request);
         } elseif ($parts[2] == 'lookup') {
             $controller->lookup($request);
-        } elseif ($parts[2] == 'index') {
-            $controller->indexLetters($request);
+        } elseif ($parts[2] == 'index' && sizeof($parts) == 4) {
+            $letter = $parts[3];
+            if ($letter == "") {
+                $controller->indexLetters($request);
+            } else {
+                $controller->indexConcepts($letter, $request);
+            }
         } elseif ($parts[2] == 'broader') {
             $controller->broader($request);
         } elseif ($parts[2] == 'broaderTransitive') {

--- a/swagger.json
+++ b/swagger.json
@@ -636,6 +636,52 @@
         ]
       }
     },
+    "/{vocid}/index/{letter}": {
+      "get": {
+        "summary": "Concepts for a given letter in the alphabetical index",
+        "description": "Returns a list of the concepes which have a label (skos:prefLabel or skos:altLabel) starting with the given letter in the given language, or the default language of the vocabulary. The special value \"0-9\" matches labels starting with a number and the value \"!*\" matches labels starting with a special character.",
+        "parameters": [
+          {
+            "name": "vocid",
+            "in": "path",
+            "description": "a Skosmos vocabulary identifier e.g. \"stw\" or \"yso\"",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "letter",
+            "in": "path",
+            "description": "an initial letter, or one of the special values \"0-9 or \"!*\"",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "lang",
+            "in": "query",
+            "description": "language of labels, e.g. \"en\" or \"fi\"",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/ld+json"
+        ],
+        "responses": {
+          "200": {
+            "description": "concepts of the alphabetical index",
+            "schema": {
+              "$ref": "#/definitions/IndexConcepts"
+            }
+          },
+          "404": {
+            "description": "no vocabulary could be found with the requested id"
+          }
+        },
+        "tags": [
+          "Vocabulary-specific methods"
+        ]
+      }
+    },
     "/{vocid}/label": {
       "get": {
         "summary": "Preferred label for the requested concept",
@@ -1351,6 +1397,24 @@
             "0-9",
             "!*"
           ]
+        }
+      },
+      "required": [
+        "uri",
+        "indexLetters"
+      ]
+    },
+    "IndexConcepts": {
+      "type": "object",
+      "properties": {
+        "uri": {
+          "type": "string"
+        },
+        "indexConcepts": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SearchResult"
+          }
         }
       },
       "required": [

--- a/swagger.json
+++ b/swagger.json
@@ -1413,13 +1413,35 @@
         "indexConcepts": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/SearchResult"
+            "$ref": "#/definitions/IndexConcept"
           }
         }
       },
       "required": [
         "uri",
         "indexLetters"
+      ]
+    },
+    "IndexConcept": {
+      "type": "object",
+      "properties": {
+        "uri": {
+          "type": "string"
+        },
+        "prefLabel": {
+          "type": "string"
+        },
+        "altLabel": {
+          "type": "string"
+        },
+        "lang": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "uri",
+        "prefLabel",
+        "lang"
       ]
     },
     "VocabularyStatistics": {

--- a/swagger.json
+++ b/swagger.json
@@ -353,20 +353,20 @@
             "required": false,
             "type": "string"
           },
-	  {
+          {
             "name": "lang",
             "in": "query",
             "description": "RDF language code when the requested resource for the MIME type is language specific, e.g. \"fi\" or \"en\".",
             "required": false,
             "type": "string"
-	  }
+          }
         ],
         "produces": [
           "application/rdf+xml",
           "text/turtle",
           "application/ld+json",
           "application/json",
-	  "application/marcxml+xml"
+          "application/marcxml+xml"
         ],
         "responses": {
           "200": {
@@ -586,6 +586,45 @@
             "description": "the concept and group counts for the vocabulary",
             "schema": {
               "$ref": "#/definitions/LabelStatistics"
+            }
+          },
+          "404": {
+            "description": "no vocabulary could be found with the requested id"
+          }
+        },
+        "tags": [
+          "Vocabulary-specific methods"
+        ]
+      }
+    },
+    "/{vocid}/index/": {
+      "get": {
+        "summary": "Initial letters of the alphabetical index",
+        "description": "Returns a list of the initial letters of labels (skos:prefLabel, skos:altLabel) in the given language, or the default language of the vocabulary. The special value \"0-9\" indicates the presence of labels starting with a number and the value \"!*\" indicates labels starting with a special character.",
+        "parameters": [
+          {
+            "name": "vocid",
+            "in": "path",
+            "description": "a Skosmos vocabulary identifier e.g. \"stw\" or \"yso\"",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "lang",
+            "in": "query",
+            "description": "language of labels, e.g. \"en\" or \"fi\"",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/ld+json"
+        ],
+        "responses": {
+          "200": {
+            "description": "initial letters of the alphabetical index",
+            "schema": {
+              "$ref": "#/definitions/IndexLetters"
             }
           },
           "404": {
@@ -1292,6 +1331,31 @@
       },
       "required": [
         "result"
+      ]
+    },
+    "IndexLetters": {
+      "type": "object",
+      "properties": {
+        "uri": {
+          "type": "string"
+        },
+        "indexLetters": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "example": [
+            "A",
+            "B",
+            "C",
+            "0-9",
+            "!*"
+          ]
+        }
+      },
+      "required": [
+        "uri",
+        "indexLetters"
       ]
     },
     "VocabularyStatistics": {

--- a/tests/RestControllerTest.php
+++ b/tests/RestControllerTest.php
@@ -94,4 +94,50 @@ class RestControllerTest extends \PHPUnit\Framework\TestCase
     $this->assertJsonStringEqualsJsonString('{"@context":{"skos":"http:\/\/www.w3.org\/2004\/02\/skos\/core#","uri":"@id","type":"@type","indexConcepts":{"@id":"skosmos:indexConcepts","@container":"@list"}},"uri":"","indexConcepts":[{"uri":"http:\/\/www.skosmos.skos\/test\/ta116","localname":"ta116","prefLabel":"Bass","lang":"en"},{"uri":"http:\/\/www.skosmos.skos\/test\/ta122","localname":"ta122","prefLabel":"Black sea bass","lang":"en"},{"uri":"http:\/\/www.skosmos.skos\/test\/ta114","localname":"ta114","prefLabel":"Buri","lang":"en"}]}', $out);
   }
 
+  /**
+   * @covers RestController::indexConcepts
+   */
+  public function testIndexConceptsJsonLdLimit() {
+    $request = new Request($this->model);
+    $request->setVocab('test');
+    $request->setLang('en');
+    $request->setQueryParam('limit', '2');
+    $this->controller->indexConcepts("B", $request);
+
+    $out = $this->getActualOutput();
+
+    $this->assertJsonStringEqualsJsonString('{"@context":{"skos":"http:\/\/www.w3.org\/2004\/02\/skos\/core#","uri":"@id","type":"@type","indexConcepts":{"@id":"skosmos:indexConcepts","@container":"@list"}},"uri":"","indexConcepts":[{"uri":"http:\/\/www.skosmos.skos\/test\/ta116","localname":"ta116","prefLabel":"Bass","lang":"en"},{"uri":"http:\/\/www.skosmos.skos\/test\/ta122","localname":"ta122","prefLabel":"Black sea bass","lang":"en"}]}', $out);
+  }
+
+  /**
+   * @covers RestController::indexConcepts
+   */
+  public function testIndexConceptsJsonLdOffset() {
+    $request = new Request($this->model);
+    $request->setVocab('test');
+    $request->setLang('en');
+    $request->setQueryParam('offset', '1');
+    $this->controller->indexConcepts("B", $request);
+
+    $out = $this->getActualOutput();
+
+    $this->assertJsonStringEqualsJsonString('{"@context":{"skos":"http:\/\/www.w3.org\/2004\/02\/skos\/core#","uri":"@id","type":"@type","indexConcepts":{"@id":"skosmos:indexConcepts","@container":"@list"}},"uri":"","indexConcepts":[{"uri":"http:\/\/www.skosmos.skos\/test\/ta122","localname":"ta122","prefLabel":"Black sea bass","lang":"en"},{"uri":"http:\/\/www.skosmos.skos\/test\/ta114","localname":"ta114","prefLabel":"Buri","lang":"en"}]}', $out);
+  }
+
+  /**
+   * @covers RestController::indexConcepts
+   */
+  public function testIndexConceptsJsonLdLimitOffset() {
+    $request = new Request($this->model);
+    $request->setVocab('test');
+    $request->setLang('en');
+    $request->setQueryParam('limit', '1');
+    $request->setQueryParam('offset', '1');
+    $this->controller->indexConcepts("B", $request);
+
+    $out = $this->getActualOutput();
+
+    $this->assertJsonStringEqualsJsonString('{"@context":{"skos":"http:\/\/www.w3.org\/2004\/02\/skos\/core#","uri":"@id","type":"@type","indexConcepts":{"@id":"skosmos:indexConcepts","@container":"@list"}},"uri":"","indexConcepts":[{"uri":"http:\/\/www.skosmos.skos\/test\/ta122","localname":"ta122","prefLabel":"Black sea bass","lang":"en"}]}', $out);
+  }
+
 }

--- a/tests/RestControllerTest.php
+++ b/tests/RestControllerTest.php
@@ -65,4 +65,19 @@ class RestControllerTest extends \PHPUnit\Framework\TestCase
 
     $this->assertJsonStringEqualsJsonString('{"@context":{"skos":"http:\/\/www.w3.org\/2004\/02\/skos\/core#","isothes":"http:\/\/purl.org\/iso25964\/skos-thes#","onki":"http:\/\/schema.onki.fi\/onki#","uri":"@id","type":"@type","results":{"@id":"onki:results","@container":"@list"},"prefLabel":"skos:prefLabel","altLabel":"skos:altLabel","hiddenLabel":"skos:hiddenLabel","broader":"skos:broader","relatedMatch":"skos:relatedMatch"},"uri":"","results":[{"uri":"http:\/\/www.skosmos.skos\/test\/ta117","type":["skos:Concept","meta:TestClass"],"broader":[{"uri":"http:\/\/www.skosmos.skos\/test\/ta1"}],"relatedMatch":[{"uri":"http:\/\/www.skosmos.skos\/test\/ta115"}],"prefLabel":"3D Bass","lang":"en","vocab":"test"},{"uri":"http:\/\/www.skosmos.skos\/test\/ta116","type":["skos:Concept","meta:TestClass"],"broader":[{"uri":"http:\/\/www.skosmos.skos\/test\/ta1"}],"prefLabel":"Bass","lang":"en","vocab":"test"},{"uri":"http:\/\/www.skosmos.skos\/test\/ta122","type":["skos:Concept","meta:TestClass"],"broader":[{"uri":"http:\/\/www.skosmos.skos\/test\/ta116"}],"prefLabel":"Black sea bass","lang":"en","vocab":"test"}]}', $out);
   }
+
+  /**
+   * @covers RestController::indexLetters
+   */
+  public function testIndexLettersJsonLd() {
+    $request = new Request($this->model);
+    $request->setVocab('test');
+    $request->setLang('en');
+    $this->controller->indexLetters($request);
+
+    $out = $this->getActualOutput();
+
+    $this->assertJsonStringEqualsJsonString('{"@context":{"skos":"http:\/\/www.w3.org\/2004\/02\/skos\/core#","uri":"@id","type":"@type","indexLetters":{"@id":"skosmos:indexLetters","@container":"@list","@language":"en"}},"uri":"","indexLetters":["B","C","E","F","M","T","!*","0-9"]}', $out);
+  }
+
 }

--- a/tests/RestControllerTest.php
+++ b/tests/RestControllerTest.php
@@ -80,4 +80,18 @@ class RestControllerTest extends \PHPUnit\Framework\TestCase
     $this->assertJsonStringEqualsJsonString('{"@context":{"skos":"http:\/\/www.w3.org\/2004\/02\/skos\/core#","uri":"@id","type":"@type","indexLetters":{"@id":"skosmos:indexLetters","@container":"@list","@language":"en"}},"uri":"","indexLetters":["B","C","E","F","M","T","!*","0-9"]}', $out);
   }
 
+  /**
+   * @covers RestController::indexConcepts
+   */
+  public function testIndexConceptsJsonLd() {
+    $request = new Request($this->model);
+    $request->setVocab('test');
+    $request->setLang('en');
+    $this->controller->indexConcepts("B", $request);
+
+    $out = $this->getActualOutput();
+
+    $this->assertJsonStringEqualsJsonString('{"@context":{"skos":"http:\/\/www.w3.org\/2004\/02\/skos\/core#","uri":"@id","type":"@type","indexConcepts":{"@id":"skosmos:indexConcepts","@container":"@list"}},"uri":"","indexConcepts":[{"uri":"http:\/\/www.skosmos.skos\/test\/ta116","localname":"ta116","prefLabel":"Bass","lang":"en"},{"uri":"http:\/\/www.skosmos.skos\/test\/ta122","localname":"ta122","prefLabel":"Black sea bass","lang":"en"},{"uri":"http:\/\/www.skosmos.skos\/test\/ta114","localname":"ta114","prefLabel":"Buri","lang":"en"}]}', $out);
+  }
+
 }


### PR DESCRIPTION
Fixes #599 

This adds two methods to the REST API:

`/rest/v1/<vocab>/index/?lang=<language>` -> list of letters available in the vocabulary alphabetical index, in the given language
`/rest/v1/<vocab>/index/<letter>?lang=<language>` -> list of terms/concepts for that letter in the vocabulary alphabetical index

Still TODO:

- [x] implement limit and offset parameters
- [x] update Swagger / OpenAPI spec 
- [x] address QA issues, if any
