### PR TITLE
Add 304 to rest controller: all of @kinow's work on PR #869

### DIFF
--- a/controller/RestController.php
+++ b/controller/RestController.php
@@ -201,6 +201,9 @@ class RestController extends Controller
     public function vocabularyInformation($request)
     {
         $vocab = $request->getVocab();
+        if ($this->notModified($vocab)) {
+            return null;
+        }
 
         /* encode the results in a JSON-LD compatible array */
         $conceptschemes = array();
@@ -250,6 +253,9 @@ class RestController extends Controller
      */
     public function vocabularyStatistics($request)
     {
+        if ($this->notModified($request->getVocab())) {
+            return null;
+        }
         $this->setLanguageProperties($request->getLang());
         $arrayClass = $request->getVocab()->getConfig()->getArrayClassURI();
         $groupClass = $request->getVocab()->getConfig()->getGroupClassURI();
@@ -319,6 +325,9 @@ class RestController extends Controller
      */
     public function labelStatistics($request)
     {
+        if ($this->notModified($request->getVocab())) {
+            return null;
+        }
         $lang = $request->getLang();
         $this->setLanguageProperties($request->getLang());
         $vocabStats = $request->getVocab()->getLabelStatistics();
@@ -376,6 +385,10 @@ class RestController extends Controller
         if ($vocid === null && !$request->getLang()) {
             return $this->returnError(400, "Bad Request", "lang parameter missing");
         }
+        if ($this->notModified($request->getVocab())) {
+            return null;
+        }
+
         $this->setLanguageProperties($request->getLang());
 
         $queriedtypes = $this->model->getTypes($vocid, $request->getLang());
@@ -522,6 +535,9 @@ class RestController extends Controller
     public function topConcepts($request)
     {
         $vocab = $request->getVocab();
+        if ($this->notModified($vocab)) {
+            return null;
+        }
         $scheme = $request->getQueryParam('scheme');
         if (!$scheme) {
             $scheme = $vocab->getConfig()->showConceptSchemesInHierarchy() ? array_keys($vocab->getConceptSchemes()) : $vocab->getDefaultConceptScheme();
@@ -609,6 +625,9 @@ class RestController extends Controller
     public function data($request)
     {
         $vocab = $request->getVocab();
+        if ($this->notModified($request->getVocab())) {
+            return null;
+        }
 
         if ($request->getUri()) {
             $uri = $request->getUri();
@@ -641,6 +660,9 @@ class RestController extends Controller
     {
         $this->setLanguageProperties($request->getLang());
         $vocab = $request->getVocab();
+        if ($this->notModified($vocab)) {
+            return null;
+        }
 
         $uri = $request->getUri();
         if (!$uri) {
@@ -681,6 +703,10 @@ class RestController extends Controller
     {
         if (!$request->getUri()) {
             return $this->returnError(400, "Bad Request", "uri parameter missing");
+        }
+
+        if ($this->notModified($request->getVocab())) {
+            return null;
         }
 
         $results = $request->getVocab()->getConceptLabel($request->getUri(), $request->getLang());
@@ -795,6 +821,9 @@ class RestController extends Controller
      */
     public function broader($request)
     {
+        if ($this->notModified($request->getVocab())) {
+            return null;
+        }
         $broaders = $request->getVocab()->getConceptBroaders($request->getUri(), $request->getLang());
         if ($broaders === null) {
             return $this->returnError('404', 'Not Found', "Could not find concept <{$request->getUri()}>");
@@ -810,6 +839,9 @@ class RestController extends Controller
      */
     public function broaderTransitive($request)
     {
+        if ($this->notModified($request->getVocab())) {
+            return null;
+        }
         $broaders = $request->getVocab()->getConceptTransitiveBroaders($request->getUri(), $this->parseLimit(), false, $request->getLang());
         if (empty($broaders)) {
             return $this->returnError('404', 'Not Found', "Could not find concept <{$request->getUri()}>");
@@ -825,6 +857,9 @@ class RestController extends Controller
      */
     public function narrower($request)
     {
+        if ($this->notModified($request->getVocab())) {
+            return null;
+        }
         $narrowers = $request->getVocab()->getConceptNarrowers($request->getUri(), $request->getLang());
         if ($narrowers === null) {
             return $this->returnError('404', 'Not Found', "Could not find concept <{$request->getUri()}>");
@@ -840,6 +875,9 @@ class RestController extends Controller
      */
     public function narrowerTransitive($request)
     {
+        if ($this->notModified($request->getVocab())) {
+            return null;
+        }
         $narrowers = $request->getVocab()->getConceptTransitiveNarrowers($request->getUri(), $this->parseLimit(), $request->getLang());
         if (empty($narrowers)) {
             return $this->returnError('404', 'Not Found', "Could not find concept <{$request->getUri()}>");
@@ -856,11 +894,13 @@ class RestController extends Controller
      */
     public function hierarchy($request)
     {
+        if ($this->notModified($request->getVocab())) {
+            return null;
+        }
         $results = $request->getVocab()->getConceptHierarchy($request->getUri(), $request->getLang());
         if (empty($results)) {
             return $this->returnError('404', 'Not Found', "Could not find concept <{$request->getUri()}>");
         }
-
 
         // set the "top" key from the "tops" key
         foreach ($results as $value) {
@@ -935,6 +975,9 @@ class RestController extends Controller
      */
     public function groups($request)
     {
+        if ($this->notModified($request->getVocab())) {
+            return null;
+        }
         $results = $request->getVocab()->listConceptGroups($request->getLang());
 
         $ret = array_merge_recursive($this->context, array(
@@ -953,6 +996,9 @@ class RestController extends Controller
      */
     public function groupMembers($request)
     {
+        if ($this->notModified($request->getVocab())) {
+            return null;
+        }
         $children = $request->getVocab()->listConceptGroupContents($request->getUri(), $request->getLang());
         if (empty($children)) {
             return $this->returnError('404', 'Not Found', "Could not find group <{$request->getUri()}>");
@@ -974,6 +1020,9 @@ class RestController extends Controller
      */
     public function children($request)
     {
+        if ($this->notModified($request->getVocab())) {
+            return null;
+        }
         $children = $request->getVocab()->getConceptChildren($request->getUri(), $request->getLang());
         if ($children === null) {
             return $this->returnError('404', 'Not Found', "Could not find concept <{$request->getUri()}>");
@@ -995,6 +1044,9 @@ class RestController extends Controller
      */
     public function related($request)
     {
+        if ($this->notModified($request->getVocab())) {
+            return null;
+        }
         $related = $request->getVocab()->getConceptRelateds($request->getUri(), $request->getLang());
         if ($related === null) {
             return $this->returnError('404', 'Not Found', "Could not find concept <{$request->getUri()}>");

--- a/controller/WebController.php
+++ b/controller/WebController.php
@@ -12,11 +12,6 @@ use \Punic\Language;
 class WebController extends Controller
 {
     /**
-     * How long to store retrieved disk configuration for HTTP 304 header
-     * from git information.
-     */
-    const GIT_MODIFIED_CONFIG_TTL = 600; // 10 minutes
-    /**
      * Provides access to the templating engine.
      * @property object $twig the twig templating engine.
      */
@@ -180,13 +175,8 @@ class WebController extends Controller
             $this->invokeGenericErrorPage($request);
             return;
         }
-        $useModifiedDate = $vocab->getConfig()->getUseModifiedDate();
-        if ($useModifiedDate) {
-            $modifiedDate = $this->getModifiedDate($results[0], $vocab);
-            // return if the controller sends the not modified header
-            if ($this->sendNotModifiedHeader($modifiedDate)) {
-                return;
-            }
+        if ($this->notModified($results[0])) {
+            return;
         }
         $pluginParameters = $vocab->getConfig()->getPluginParameters();
         /** @var \Twig\Template $template */
@@ -203,124 +193,6 @@ class WebController extends Controller
             'request' => $request,
             'plugin_params' => $pluginParameters)
         );
-    }
-
-    /**
-     * Return the modified date. First try to get the modified date from the concept. If found, return this
-     * date.
-     *
-     * Then try to get the modified date from the vocabulary's main concept scheme. If found, then return this
-     * date.
-     *
-     * Finally, if no date found, return null.
-     *
-     * @param Concept $concept
-     * @param Vocabulary $vocab
-     * @return DateTime|null
-     */
-    protected function getModifiedDate(Concept $concept, Vocabulary $vocab)
-    {
-        $modifiedDate = null;
-
-        $conceptModifiedDate = $this->getConceptModifiedDate($concept, $vocab);
-        $gitModifiedDate = $this->getGitModifiedDate();
-        $configModifiedDate = $this->getConfigModifiedDate();
-
-        // max with an empty list raises an error and returns bool
-        if ($conceptModifiedDate || $gitModifiedDate || $configModifiedDate) {
-            $modifiedDate = max($conceptModifiedDate, $gitModifiedDate, $configModifiedDate);
-        }
-        return $modifiedDate;
-    }
-
-    /**
-     * Get the concept modified date. Returns the concept modified date if available. Otherwise,
-     * reverts to the modified date of the default concept scheme if available. Lastly, if it could
-     * not get the modified date from the concept nor from the concept scheme, it returns null.
-     *
-     * @param Concept $concept concept used to retrieve modified date
-     * @param Vocabulary $vocab vocabulary used to retrieve modified date
-     * @return DateTime|null|string
-     */
-    protected function getConceptModifiedDate(Concept $concept, Vocabulary $vocab)
-    {
-        $modifiedDate = $concept->getModifiedDate();
-        if (!$modifiedDate) {
-            $conceptSchemeURI = $vocab->getDefaultConceptScheme();
-            if ($conceptSchemeURI) {
-                $conceptSchemeGraph = $vocab->getConceptScheme($conceptSchemeURI);
-                if (!$conceptSchemeGraph->isEmpty()) {
-                    $literal = $conceptSchemeGraph->getLiteral($conceptSchemeURI, "dc:modified");
-                    if ($literal) {
-                        $modifiedDate = $literal->getValue();
-                    }
-                }
-            }
-        }
-
-        return $modifiedDate;
-    }
-
-    /**
-     * Return the datetime of the latest commit, or null if git is not available or if the command failed
-     * to execute.
-     *
-     * @see https://stackoverflow.com/a/33986403
-     * @return DateTime|null
-     */
-    protected function getGitModifiedDate()
-    {
-        $commitDate = null;
-        $cache = $this->model->getConfig()->getCache();
-        $cacheKey = "git:modified_date";
-        $gitCommand = 'git log -1 --date=iso --pretty=format:%cd';
-        if ($cache->isAvailable()) {
-            $commitDate = $cache->fetch($cacheKey);
-            if (!$commitDate) {
-                $commitDate = $this->executeGitModifiedDateCommand($gitCommand);
-                if ($commitDate) {
-                    $cache->store($cacheKey, $commitDate, static::GIT_MODIFIED_CONFIG_TTL);
-                }
-            }
-        } else {
-            $commitDate = $this->executeGitModifiedDateCommand($gitCommand);
-        }
-        return $commitDate;
-    }
-
-    /**
-     * Execute the git command and return a parsed date time, or null if the command failed.
-     *
-     * @param string $gitCommand git command line that returns a formatted date time
-     * @return DateTime|null
-     */
-    protected function executeGitModifiedDateCommand($gitCommand)
-    {
-        $commitDate = null;
-        $commandOutput = @exec($gitCommand);
-        if ($commandOutput) {
-            $commitDate = new \DateTime(trim($commandOutput));
-            $commitDate->setTimezone(new \DateTimeZone('UTC'));
-        }
-        return $commitDate;
-    }
-
-    /**
-     * Return the datetime of the modified time of the config file. This value is read in the GlobalConfig
-     * for every request, so we simply access that value and if not null, we will return a datetime. Otherwise,
-     * we return a null value.
-     *
-     * @see http://php.net/manual/en/function.filemtime.php
-     * @return DateTime|null
-     */
-    protected function getConfigModifiedDate()
-    {
-        $dateTime = null;
-        $configModifiedTime = $this->model->getConfig()->getConfigModifiedTime();
-        if (!is_null($configModifiedTime)) {
-            $dateTime = (new DateTime())->setTimestamp($configModifiedTime);
-        }
-        return $dateTime;
     }
 
     /**

--- a/model/Modifiable.php
+++ b/model/Modifiable.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * Interface Modifiable.
+ */
+interface Modifiable {
+
+    /**
+     * @return DateTime|null the modified date, or null if not available
+     */
+    public function getModifiedDate();
+
+    /**
+     * @return boolean
+     */
+    public function isUseModifiedDate();
+
+}

--- a/model/Vocabulary.php
+++ b/model/Vocabulary.php
@@ -3,7 +3,7 @@
 /**
  * Vocabulary dataobjects provide access to the vocabularies on the SPARQL endpoint.
  */
-class Vocabulary extends DataObject
+class Vocabulary extends DataObject implements Modifiable
 {
     /** cached value of URI space */
     private $urispace = null;
@@ -632,4 +632,20 @@ class Vocabulary extends DataObject
       return $this->config->getId();
     }
 
+    public function getModifiedDate()
+    {
+        $modified = null;
+        // finding the modified properties
+        /** @var \EasyRdf\Resource $modifiedResource */
+        $modifiedResource = $this->resource->get('dc:modified');
+        if ($modifiedResource) {
+            $modified = $modifiedResource->getValue();
+        }
+        return $modified;
+    }
+
+    public function isUseModifiedDate()
+    {
+        return $this->getConfig()->isUseModifiedDate();
+    }
 }

--- a/model/VocabularyConfig.php
+++ b/model/VocabularyConfig.php
@@ -528,10 +528,9 @@ class VocabularyConfig extends BaseConfig
     }
 
     /**
-     * Returns a boolean value set in the config.ttl config.
      * @return boolean
      */
-    public function getUseModifiedDate(): bool
+    public function isUseModifiedDate()
     {
         return $this->getBoolean('skosmos:useModifiedDate', false);
     }

--- a/tests/ConceptTest.php
+++ b/tests/ConceptTest.php
@@ -2,6 +2,9 @@
 
 class ConceptTest extends PHPUnit\Framework\TestCase
 {
+  /**
+   * @var Model
+   */
   private $model;
   private $concept;
   private $cbdVocab;
@@ -507,7 +510,7 @@ class ConceptTest extends PHPUnit\Framework\TestCase
   public function modifiedDateDataProvider() {
     return [
       ["cat", "2018-12-13T06:28:14", "+00:00"],  # set #0
-      ["dog", null, null],  # set #1
+      ["dog", "2018-12-13T06:28:14", "+00:00"],  # set #1
       ["owl", "2018-10-22T00:00:00", "+00:00"],  # set #2
       ["parrot", "2018-10-22T00:00:00", "+00:00"],  # set #3
       ["macaw", "2018-10-22T12:34:45", "+00:00"],  # set #4
@@ -518,6 +521,7 @@ class ConceptTest extends PHPUnit\Framework\TestCase
   /**
    * @covers Concept::getModifiedDate
    * @dataProvider modifiedDateDataProvider
+   * @throws Exception if it fails to load the vocabulary
    */
   public function testGetModifiedDate($animal, $expected_time, $expected_timezone) {
     $vocab = $this->model->getVocabulary('http304');

--- a/tests/Http304Test.php
+++ b/tests/Http304Test.php
@@ -85,6 +85,8 @@ class Http304Test extends TestCase
         $concept->allows([
             "getType" => ["skos:Concept"]
         ]);
+        $concept->shouldReceive("getVocab")
+            ->andReturn($this->vocab);
         $concepts[] = $concept;
         $this->vocab
             ->shouldReceive("getConceptInfo")
@@ -129,6 +131,8 @@ class Http304Test extends TestCase
         $concept->allows([
             "getType" => ["skos:Concept"]
         ]);
+        $concept->shouldReceive("getVocab")
+            ->andReturn($this->vocab);
         $concepts[] = $concept;
         $this->vocab
             ->shouldReceive("getConceptInfo")
@@ -181,6 +185,8 @@ class Http304Test extends TestCase
         $concept->allows([
             "getType" => ["skos:Concept"]
         ]);
+        $concept->shouldReceive("getVocab")
+            ->andReturn($this->vocab);
         $concepts[] = $concept;
         $this->vocab
             ->shouldReceive("getConceptInfo")

--- a/tests/RestControllerTest.php
+++ b/tests/RestControllerTest.php
@@ -7,6 +7,14 @@ require_once('controller/RestController.php');
 
 class RestControllerTest extends \PHPUnit\Framework\TestCase
 {
+  /**
+   * @var Model
+   */
+  private $model;
+  /**
+   * @var RestController
+   */
+  private $controller;
   protected function setUp() {
     putenv("LANGUAGE=en_GB.utf8");
     putenv("LC_ALL=en_GB.utf8");
@@ -15,7 +23,8 @@ class RestControllerTest extends \PHPUnit\Framework\TestCase
     bind_textdomain_codeset('skosmos', 'UTF-8');
     textdomain('skosmos');
 
-    $this->model = new Model(new GlobalConfig('/../tests/testconfig.ttl'));
+    $globalConfig = new GlobalConfig('/../tests/testconfig.ttl');
+    $this->model = Mockery::mock(new Model($globalConfig));
     $this->controller = new RestController($this->model);
   }
 
@@ -30,6 +39,7 @@ class RestControllerTest extends \PHPUnit\Framework\TestCase
     $request = new Request($this->model);
     $request->setQueryParam('format', 'application/json');
     $request->setURI('http://www.skosmos.skos/test/ta117');
+    $request->setVocab("test");
     $this->controller->data($request);
 
     $out = $this->getActualOutput();

--- a/tests/VocabularyConfigTest.php
+++ b/tests/VocabularyConfigTest.php
@@ -484,13 +484,13 @@ class VocabularyConfigTest extends PHPUnit\Framework\TestCase
   }
 
   /**
-   * @covers VocabularyConfig::getUseModifiedDate
+   * @covers VocabularyConfig::isUseModifiedDate
    */
   public function testGetVocabularyUseModifiedDate() {
     $vocab = $this->model->getVocabulary('http304');
-    $this->assertEquals(true , $vocab->getConfig()->getUseModifiedDate());
+    $this->assertEquals(true , $vocab->getConfig()->isUseModifiedDate());
     $vocab = $this->model->getVocabulary('http304disabled');
-    $this->assertEquals(false , $vocab->getConfig()->getUseModifiedDate());
+    $this->assertEquals(false , $vocab->getConfig()->isUseModifiedDate());
   }
 
   /**
@@ -501,5 +501,4 @@ class VocabularyConfigTest extends PHPUnit\Framework\TestCase
     $params = $vocab->getConfig()->getPluginParameters();
     $this->assertEquals(json_encode(array('imaginaryPlugin' => array('poem_fi' => "Roses are red", 'poem' => "Violets are blue", 'color' => "#800000")),true), $params);
   }
-
 }

--- a/tests/WebControllerTest.php
+++ b/tests/WebControllerTest.php
@@ -241,15 +241,16 @@ class WebControllerTest extends TestCase
         $controller = Mockery::mock('WebController')
             ->shouldAllowMockingProtectedMethods()
             ->makePartial();
-        $controller->shouldReceive('getConceptModifiedDate')
+        $modifiable = Mockery::mock('Modifiable')
+            ->shouldAllowMockingProtectedMethods()
+            ->makePartial();
+        $modifiable->shouldReceive('getModifiedDate')
             ->andReturn($concept);
         $controller->shouldReceive('getGitModifiedDate')
             ->andReturn($git);
         $controller->shouldReceive('getConfigModifiedDate')
             ->andReturn($config);
-        $concept = Mockery::mock('Concept');
-        $vocabulary = Mockery::mock('Vocabulary');
-        $returnedValue = $controller->getModifiedDate($concept, $vocabulary);
+        $returnedValue = $controller->getModifiedDate($modifiable);
         $this->assertEquals($modifiedDate, $returnedValue);
     }
 
@@ -267,6 +268,9 @@ class WebControllerTest extends TestCase
             ->shouldReceive("getModifiedDate")
             ->andReturn($conceptDate);
         $vocab = Mockery::mock("Vocabulary");
+        $concept
+            ->shouldReceive('getVocab')
+            ->andReturn($vocab);
         // if no scheme date, we return that same value as default concept scheme to stop the flow
         $defaultScheme = (isset($schemeDate) ? "http://test/" : null);
         $vocab


### PR DESCRIPTION
The original PR #869 by @kinow has been open so long that it became impossible to review. I decided to squash all the commits in it into this new PR, so that it's again possible to see what actually changes related to the current `master` branch.

Squashed commit of the following:

commit b696c80be1e7fb863995906b0d51d6ebf6075113
Merge: e821af0 c7b9c6f
Author: Osma Suominen <osma.suominen@helsinki.fi>
Date:   Wed May 6 09:21:12 2020 +0300

    Merge branch 'add-304-to-rest-controller' of https://github.com/kinow/Skosmos into kinow-add-304-to-rest-controller

commit c7b9c6f9e5da308084cec5c18aabcd7663768c67
Author: Bruno P. Kinoshita <kinow@users.noreply.github.com>
Date:   Sun May 19 22:21:29 2019 +1200

    Fix scrutinizer errors

commit 30baf0a953732fad4016b53fc898f272ad9f8a74
Author: Bruno P. Kinoshita <kinow@users.noreply.github.com>
Date:   Sun May 19 18:25:13 2019 +1200

    Updating tests for latest changes

commit 14d44369fd98bc6a469759152b01b6a8ea34f8c6
Author: Bruno P. Kinoshita <kinow@users.noreply.github.com>
Date:   Sun May 19 01:29:12 2019 +1200

    Move flag for enabling 304 back to VocabularyConfig, and make it available to Modifiables

commit ef1526f71d75537f041750032ee1cf5ea93d1b79
Author: Bruno P. Kinoshita <kinow@users.noreply.github.com>
Date:   Sun May 19 01:09:23 2019 +1200

    Use vocabulary modified date

commit 5a155443c5579ebb96cba8c649b335c0eabd32b2
Author: Bruno P. Kinoshita <kinow@users.noreply.github.com>
Date:   Sun May 19 00:48:39 2019 +1200

    Make Vocabulary and Concept Modifiables

commit f70a71a8d0690962f7bd4b877c8ad6c38531b086
Author: Bruno P. Kinoshita <kinow@users.noreply.github.com>
Date:   Thu Apr 25 00:27:26 2019 +1200

    Update tests for the new code

commit 04900fe70841aff441fc8605be3bbfca6e3db56f
Author: Bruno P. Kinoshita <kinow@users.noreply.github.com>
Date:   Wed Apr 24 22:07:56 2019 +1200

    Add 304 for global and concept methods

commit cd9a3fd5f5e5649a1588557e6b7afcdef87396ac
Author: Bruno P. Kinoshita <kinow@users.noreply.github.com>
Date:   Wed Apr 24 21:26:44 2019 +1200

    Add 304 for global and vocabulary methods

commit 9416610c063aa01416cf0917e9654b7f3c973667
Author: Bruno P. Kinoshita <kinow@users.noreply.github.com>
Date:   Wed Apr 24 21:08:48 2019 +1200

    Add helper method notModified in Controller class

commit 1527588c1068ae2583d1beb71e7bef337adc7c18
Author: Bruno P. Kinoshita <kinow@users.noreply.github.com>
Date:   Wed Apr 24 19:59:32 2019 +1200

    Simplify signature of GlobalConfiguration::getUseModifiedDate

commit e4ddf9de981c2219c3dc1ca160130b47be4784e2
Author: Bruno P. Kinoshita <kinow@users.noreply.github.com>
Date:   Wed Apr 24 19:41:32 2019 +1200

    Move skosmos:useModifiedDate to global configuration, instead of per vocabulary

commit e4c10ab393ae793346695169df5f7fb0e1d42a16
Author: Bruno P. Kinoshita <kinow@users.noreply.github.com>
Date:   Wed Apr 24 19:03:34 2019 +1200

    Move modified date related methods to Controller