### PR TITLE
HTTP date format fixes

### DIFF
--- a/controller/Controller.php
+++ b/controller/Controller.php
@@ -293,7 +293,7 @@ class Controller
     {
         if ($modifiedDate) {
             $ifModifiedSince = $this->getIfModifiedSince();
-            $this->sendHeader("Last-Modified: " . $modifiedDate->format('Y-m-d H:i:s'));
+            $this->sendHeader("Last-Modified: " . $modifiedDate->format('D, d M Y H:i:s \G\M\T'));
             if ($ifModifiedSince !== null && $ifModifiedSince >= $modifiedDate) {
                 $this->sendHeader("HTTP/1.0 304 Not Modified");
                 return true;
@@ -308,9 +308,10 @@ class Controller
     protected function getIfModifiedSince()
     {
         $ifModifiedSince = null;
-        if (isset($_SERVER["HTTP_IF_MODIFIED_SINCE"])) {
-            // example value set by a browser: "2019-04-13 08:28:23"
-            $ifModifiedSince = DateTime::createFromFormat("Y-m-d H:i:s", $_SERVER["HTTP_IF_MODIFIED_SINCE"]);
+        $ifModSinceHeader = filter_input(INPUT_SERVER, 'HTTP_IF_MODIFIED_SINCE', FILTER_SANITIZE_STRING);
+        if ($ifModSinceHeader) {
+            // example value set by a browser: "Mon, 11 May 2020 10:46:57 GMT"
+            $ifModifiedSince = new DateTime($ifModSinceHeader);
         }
         return $ifModifiedSince;
     }

--- a/tests/Http304Test.php
+++ b/tests/Http304Test.php
@@ -149,10 +149,12 @@ class Http304Test extends TestCase
             $modifiedDate = DateTime::createFromFormat('j-M-Y', '15-Feb-2009');
             $this->controller
                 ->shouldReceive("getModifiedDate")
+                ->once()
                 ->andReturn($modifiedDate);
             $this->controller
                 ->shouldReceive("sendHeader")
-                ->withArgs(["Last-Modified: " . $modifiedDate->format('Y-m-d H:i:s')])
+                ->once()
+                ->withArgs(["Last-Modified: " . $modifiedDate->format('D, d M Y H:i:s \G\M\T')])
                 ->andReturn(true);
         }
 
@@ -204,16 +206,20 @@ class Http304Test extends TestCase
             $ifModifiedSince = DateTime::createFromFormat('j-M-Y', '15-Feb-2019');
             $this->controller
                 ->shouldReceive("getModifiedDate")
+                ->once()
                 ->andReturn($modifiedDate);
             $this->controller
                 ->shouldReceive("getIfModifiedSince")
+                ->once()
                 ->andReturn($ifModifiedSince);
             $this->controller
                 ->shouldReceive("sendHeader")
-                ->withArgs(["Last-Modified: " . $modifiedDate->format('Y-m-d H:i:s')])
+                ->once()
+                ->withArgs(["Last-Modified: " . $modifiedDate->format('D, d M Y H:i:s \G\M\T')])
                 ->andReturn(true);
             $this->controller
                 ->shouldReceive("sendHeader")
+                ->once()
                 ->withArgs(["HTTP/1.0 304 Not Modified"])
                 ->andReturn(true);
         }
@@ -222,5 +228,11 @@ class Http304Test extends TestCase
         $this->controller->invokeVocabularyConcept($this->request);
         $content = ob_get_clean();
         $this->assertEquals("", $content);
+    }
+
+    public function tearDown()
+    {
+        parent::tearDown();
+        \Mockery::close();
     }
 }


### PR DESCRIPTION
While testing HTTP 304 / If-Modified-Since functionality, recently implemented in PR #869 by @kinow, I noticed that the date formats expected by Skosmos in If-Modified-Since headers and produced in Last-Modified headers are not actually compliant with the relevant RFCs (RFC 7231 / 2616 / 1123). I also noticed other problems related to that functionality. This PR fixes:

- Read the If-Modified-Since header using the `filter_input` function instead of `$_SERVER` (possibly more secure, and in line with other places in the codebase where HTTP headers are accessed)
- Change to RFC 1123 date format for HTTP 304 functionality
- Improve the Http304Test unit tests so that they verify that the mocked methods are actually called exactly once with the expected arguments (otherwise they couldn't detect invalid date formats)

Any comments @kinow before I merge this?