### PR TITLE
Make property order configurable on concept page

### DIFF
--- a/model/Concept.php
+++ b/model/Concept.php
@@ -78,7 +78,11 @@ class Concept extends VocabularyDataObject implements Modifiable
     public function __construct($model, $vocab, $resource, $graph, $clang)
     {
         parent::__construct($model, $vocab, $resource);
-        $this->order = $vocab->getConfig()->getPropertyOrder();
+        if ($vocab !== null) {
+            $this->order = $vocab->getConfig()->getPropertyOrder();
+        } else {
+            $this->order = VocabularyConfig::DEFAULT_PROPERTY_ORDER;
+        }
         $this->graph = $graph;
         $this->clang = $clang;
         // setting the Punic plugins locale for localized datetime conversions

--- a/model/Concept.php
+++ b/model/Concept.php
@@ -78,7 +78,7 @@ class Concept extends VocabularyDataObject implements Modifiable
     public function __construct($model, $vocab, $resource, $graph, $clang)
     {
         parent::__construct($model, $vocab, $resource);
-        $this->order = array("rdf:type", "dc:isReplacedBy", "skos:definition", "skos:broader", "isothes:broaderGeneric", "isothes:broaderPartitive", "isothes:broaderInstantial", "skos:narrower", "isothes:narrowerGeneric", "isothes:narrowerPartitive", "isothes:narrowerInstantial", "skos:related", "skos:altLabel", "skosmos:memberOf", "skos:note", "skos:scopeNote", "skos:historyNote", "rdfs:comment", "dc11:source", "dc:source", "skos:prefLabel");
+        $this->order = $vocab->getConfig()->getPropertyOrder();
         $this->graph = $graph;
         $this->clang = $clang;
         // setting the Punic plugins locale for localized datetime conversions

--- a/model/Concept.php
+++ b/model/Concept.php
@@ -612,6 +612,22 @@ class Concept extends VocabularyDataObject implements Modifiable
             }
         }
 
+        $groupPropObj = new ConceptProperty('skosmos:memberOf', null);
+        foreach ($this->getGroupProperties() as $propVals) {
+            foreach ($propVals as $propVal) {
+                $groupPropObj->addValue($propVal, $this->clang);
+            }
+        }
+        $ret['skosmos:memberOf'] = $groupPropObj;
+
+        $arrayPropObj = new ConceptProperty('skosmos:memberOfArray', null);
+        foreach ($this->getArrayProperties() as $propVals) {
+            foreach ($propVals as $propVal) {
+                $arrayPropObj->addValue($propVal, $this->clang);
+            }
+        }
+        $ret['skosmos:memberOfArray'] = $arrayPropObj;
+
         foreach ($ret as $key => $prop) {
             if (sizeof($prop->getValues()) === 0) {
                 unset($ret[$key]);

--- a/model/VocabularyConfig.php
+++ b/model/VocabularyConfig.php
@@ -9,6 +9,14 @@ class VocabularyConfig extends BaseConfig
     private $pluginParameters;
     private $languageOrderCache = array();
 
+    private $DEFAULT_PROPERTY_ORDER = array("rdf:type", "dc:isReplacedBy",
+    "skos:definition", "skos:broader", "isothes:broaderGeneric",
+    "isothes:broaderPartitive", "isothes:broaderInstantial",
+    "skos:narrower", "isothes:narrowerGeneric", "isothes:narrowerPartitive",
+    "isothes:narrowerInstantial", "skos:related", "skos:altLabel",
+    "skosmos:memberOf", "skos:note", "skos:scopeNote", "skos:historyNote",
+    "rdfs:comment", "dc11:source", "dc:source", "skos:prefLabel");
+
     public function __construct($resource, $globalPlugins=array())
     {
         $this->resource = $resource;
@@ -533,5 +541,14 @@ class VocabularyConfig extends BaseConfig
     public function isUseModifiedDate()
     {
         return $this->getBoolean('skosmos:useModifiedDate', false);
+    }
+
+    /**
+     * @return array
+     */
+    public function getPropertyOrder()
+    {
+        //return $this->getResources('skosmos:propertyOrder');
+        return $this->DEFAULT_PROPERTY_ORDER;
     }
 }

--- a/model/VocabularyConfig.php
+++ b/model/VocabularyConfig.php
@@ -17,6 +17,13 @@ class VocabularyConfig extends BaseConfig
     "skosmos:memberOf", "skos:note", "skos:scopeNote", "skos:historyNote",
     "rdfs:comment", "dc11:source", "dc:source", "skos:prefLabel");
 
+    private $ISO25964_PROPERTY_ORDER = array("rdf:type", "skos:scopeNote",
+    "skos:altLabel", "skos:broader", "isothes:broaderGeneric",
+    "isothes:broaderPartitive", "isothes:broaderInstantial",
+    "skos:narrower", "isothes:narrowerGeneric", "isothes:narrowerPartitive",
+    "isothes:narrowerInstantial", "skos:related", "skos:definition",
+    "skos:historyNote", "skosmos:memberOf");
+
     public function __construct($resource, $globalPlugins=array())
     {
         $this->resource = $resource;
@@ -548,7 +555,15 @@ class VocabularyConfig extends BaseConfig
      */
     public function getPropertyOrder()
     {
-        //return $this->getResources('skosmos:propertyOrder');
+        foreach($this->getResources('skosmos:propertyOrder') as $order) {
+            $short = EasyRdf\RdfNamespace::shorten($order);
+            if ($short == 'skosmos:iso25964PropertyOrder') {
+                return $this->ISO25964_PROPERTY_ORDER;
+            } elseif ($short == 'skosmos:defaultPropertyOrder') {
+                return $this->DEFAULT_PROPERTY_ORDER;
+            }
+            // TODO handle custom order here
+        }
         return $this->DEFAULT_PROPERTY_ORDER;
     }
 }

--- a/model/VocabularyConfig.php
+++ b/model/VocabularyConfig.php
@@ -9,7 +9,7 @@ class VocabularyConfig extends BaseConfig
     private $pluginParameters;
     private $languageOrderCache = array();
 
-    private $DEFAULT_PROPERTY_ORDER = array("rdf:type", "dc:isReplacedBy",
+    const DEFAULT_PROPERTY_ORDER = array("rdf:type", "dc:isReplacedBy",
     "skos:definition", "skos:broader", "isothes:broaderGeneric",
     "isothes:broaderPartitive", "isothes:broaderInstantial",
     "skos:narrower", "isothes:narrowerGeneric", "isothes:narrowerPartitive",
@@ -18,7 +18,7 @@ class VocabularyConfig extends BaseConfig
     "dc11:source", "dc:source", "skos:prefLabel", "skosmos:memberOf",
     "skosmos:memberOfArray");
 
-    private $ISO25964_PROPERTY_ORDER = array("rdf:type", "skos:scopeNote",
+    const ISO25964_PROPERTY_ORDER = array("rdf:type", "skos:scopeNote",
     "skos:altLabel", "skos:broader", "isothes:broaderGeneric",
     "isothes:broaderPartitive", "isothes:broaderInstantial",
     "skos:narrower", "isothes:narrowerGeneric", "isothes:narrowerPartitive",
@@ -558,14 +558,14 @@ class VocabularyConfig extends BaseConfig
     {
         $order = $this->getResource()->getResource('skosmos:propertyOrder');
         if ($order === null) {
-            return $this->DEFAULT_PROPERTY_ORDER;
+            return self::DEFAULT_PROPERTY_ORDER;
         }
 
         $short = EasyRdf\RdfNamespace::shorten($order);
         if ($short == 'skosmos:iso25964PropertyOrder') {
-            return $this->ISO25964_PROPERTY_ORDER;
+            return self::ISO25964_PROPERTY_ORDER;
         } elseif ($short == 'skosmos:defaultPropertyOrder') {
-            return $this->DEFAULT_PROPERTY_ORDER;
+            return self::DEFAULT_PROPERTY_ORDER;
         }
         
         // check for custom order definition
@@ -579,6 +579,6 @@ class VocabularyConfig extends BaseConfig
             return $ret;
         }
         
-        return $this->DEFAULT_PROPERTY_ORDER;
+        self::DEFAULT_PROPERTY_ORDER;
     }
 }

--- a/model/VocabularyConfig.php
+++ b/model/VocabularyConfig.php
@@ -579,6 +579,7 @@ class VocabularyConfig extends BaseConfig
             return $ret;
         }
         
-        self::DEFAULT_PROPERTY_ORDER;
+        trigger_error("Property order for vocabulary '{$this->getShortName()}' unknown, using default order", E_USER_WARNING);
+        return self::DEFAULT_PROPERTY_ORDER;
     }
 }

--- a/model/VocabularyConfig.php
+++ b/model/VocabularyConfig.php
@@ -573,7 +573,8 @@ class VocabularyConfig extends BaseConfig
         if ($orderList !== null && $orderList instanceof EasyRdf\Collection) {
             $ret = array();
             foreach ($orderList as $prop) {
-                $ret[] = $prop->shorten(); // FIXME what about unknown namespaces?
+                $short = $prop->shorten();
+                $ret[] = ($short !== null) ? $short : $prop->getURI();
             }
             return $ret;
         }

--- a/model/VocabularyConfig.php
+++ b/model/VocabularyConfig.php
@@ -15,15 +15,18 @@ class VocabularyConfig extends BaseConfig
     "skos:narrower", "isothes:narrowerGeneric", "isothes:narrowerPartitive",
     "isothes:narrowerInstantial", "skos:related", "skos:altLabel",
     "skos:note", "skos:scopeNote", "skos:historyNote", "rdfs:comment",
-    "dc11:source", "dc:source", "skos:prefLabel", "skosmos:memberOf",
-    "skosmos:memberOfArray");
+    "dc11:source", "dc:source", "skosmos:memberOf", "skosmos:memberOfArray");
 
-    const ISO25964_PROPERTY_ORDER = array("rdf:type", "skos:scopeNote",
-    "skos:altLabel", "skos:broader", "isothes:broaderGeneric",
-    "isothes:broaderPartitive", "isothes:broaderInstantial",
-    "skos:narrower", "isothes:narrowerGeneric", "isothes:narrowerPartitive",
-    "isothes:narrowerInstantial", "skos:related", "skos:definition",
-    "skos:historyNote", "skosmos:memberOf", "skosmos:memberOfArray");
+    const ISO25964_PROPERTY_ORDER = array("rdf:type", "dc:isReplacedBy",
+    // ISO 25964 allows placing all text fields (inc. SN and DEF) together
+    // so we will do that, except for HN, which is clearly administrative
+    "skos:note", "skos:scopeNote", "skos:definition", "rdfs:comment",
+    "dc11:source", "dc:source", "skos:altLabel", "skos:broader",
+    "isothes:broaderGeneric", "isothes:broaderPartitive",
+    "isothes:broaderInstantial", "skos:narrower", "isothes:narrowerGeneric",
+    "isothes:narrowerPartitive", "isothes:narrowerInstantial",
+    "skos:related", "skos:historyNote", "skosmos:memberOf",
+    "skosmos:memberOfArray");
 
     public function __construct($resource, $globalPlugins=array())
     {

--- a/model/VocabularyConfig.php
+++ b/model/VocabularyConfig.php
@@ -14,15 +14,16 @@ class VocabularyConfig extends BaseConfig
     "isothes:broaderPartitive", "isothes:broaderInstantial",
     "skos:narrower", "isothes:narrowerGeneric", "isothes:narrowerPartitive",
     "isothes:narrowerInstantial", "skos:related", "skos:altLabel",
-    "skosmos:memberOf", "skos:note", "skos:scopeNote", "skos:historyNote",
-    "rdfs:comment", "dc11:source", "dc:source", "skos:prefLabel");
+    "skos:note", "skos:scopeNote", "skos:historyNote", "rdfs:comment",
+    "dc11:source", "dc:source", "skos:prefLabel", "skosmos:memberOf",
+    "skosmos:memberOfArray");
 
     private $ISO25964_PROPERTY_ORDER = array("rdf:type", "skos:scopeNote",
     "skos:altLabel", "skos:broader", "isothes:broaderGeneric",
     "isothes:broaderPartitive", "isothes:broaderInstantial",
     "skos:narrower", "isothes:narrowerGeneric", "isothes:narrowerPartitive",
     "isothes:narrowerInstantial", "skos:related", "skos:definition",
-    "skos:historyNote", "skosmos:memberOf");
+    "skos:historyNote", "skosmos:memberOf", "skosmos:memberOfArray");
 
     public function __construct($resource, $globalPlugins=array())
     {

--- a/model/VocabularyConfig.php
+++ b/model/VocabularyConfig.php
@@ -555,15 +555,28 @@ class VocabularyConfig extends BaseConfig
      */
     public function getPropertyOrder()
     {
-        foreach($this->getResources('skosmos:propertyOrder') as $order) {
-            $short = EasyRdf\RdfNamespace::shorten($order);
-            if ($short == 'skosmos:iso25964PropertyOrder') {
-                return $this->ISO25964_PROPERTY_ORDER;
-            } elseif ($short == 'skosmos:defaultPropertyOrder') {
-                return $this->DEFAULT_PROPERTY_ORDER;
-            }
-            // TODO handle custom order here
+        $order = $this->getResource()->getResource('skosmos:propertyOrder');
+        if ($order === null) {
+            return $this->DEFAULT_PROPERTY_ORDER;
         }
+
+        $short = EasyRdf\RdfNamespace::shorten($order);
+        if ($short == 'skosmos:iso25964PropertyOrder') {
+            return $this->ISO25964_PROPERTY_ORDER;
+        } elseif ($short == 'skosmos:defaultPropertyOrder') {
+            return $this->DEFAULT_PROPERTY_ORDER;
+        }
+        
+        // check for custom order definition
+        $orderList = $order->getResource('rdf:value');
+        if ($orderList !== null && $orderList instanceof EasyRdf\Collection) {
+            $ret = array();
+            foreach ($orderList as $prop) {
+                $ret[] = $prop->shorten(); // FIXME what about unknown namespaces?
+            }
+            return $ret;
+        }
+        
         return $this->DEFAULT_PROPERTY_ORDER;
     }
 }

--- a/tests/VocabularyConfigTest.php
+++ b/tests/VocabularyConfigTest.php
@@ -508,13 +508,7 @@ class VocabularyConfigTest extends PHPUnit\Framework\TestCase
   public function testGetPropertyOrderNotSet() {
     $vocab = $this->model->getVocabulary('test');
     $params = $vocab->getConfig()->getPropertyOrder();
-
-    // need to use reflection to make the private property accessible
-    $reflector = new ReflectionClass('VocabularyConfig');
-    $property = $reflector->getProperty('DEFAULT_PROPERTY_ORDER');
-    $property->setAccessible(true);
-
-    $this->assertEquals($property->getValue($vocab->getConfig()), $params);
+    $this->assertEquals(VocabularyConfig::DEFAULT_PROPERTY_ORDER, $params);
   }
 
   /**
@@ -523,13 +517,7 @@ class VocabularyConfigTest extends PHPUnit\Framework\TestCase
   public function testGetPropertyOrderDefault() {
     $vocab = $this->model->getVocabulary('testDefaultPropertyOrder');
     $params = $vocab->getConfig()->getPropertyOrder();
-
-    // need to use reflection to make the private property accessible
-    $reflector = new ReflectionClass('VocabularyConfig');
-    $property = $reflector->getProperty('DEFAULT_PROPERTY_ORDER');
-    $property->setAccessible(true);
-
-    $this->assertEquals($property->getValue($vocab->getConfig()), $params);
+    $this->assertEquals(VocabularyConfig::DEFAULT_PROPERTY_ORDER, $params);
   }
 
   /**
@@ -538,13 +526,7 @@ class VocabularyConfigTest extends PHPUnit\Framework\TestCase
   public function testGetPropertyOrderISO() {
     $vocab = $this->model->getVocabulary('testISOPropertyOrder');
     $params = $vocab->getConfig()->getPropertyOrder();
-
-    // need to use reflection to make the private property accessible
-    $reflector = new ReflectionClass('VocabularyConfig');
-    $property = $reflector->getProperty('ISO25964_PROPERTY_ORDER');
-    $property->setAccessible(true);
-
-    $this->assertEquals($property->getValue($vocab->getConfig()), $params);
+    $this->assertEquals(VocabularyConfig::ISO25964_PROPERTY_ORDER, $params);
   }
 
 

--- a/tests/VocabularyConfigTest.php
+++ b/tests/VocabularyConfigTest.php
@@ -502,4 +502,19 @@ class VocabularyConfigTest extends PHPUnit\Framework\TestCase
     $this->assertEquals(json_encode(array('imaginaryPlugin' => array('poem_fi' => "Roses are red", 'poem' => "Violets are blue", 'color' => "#800000")),true), $params);
   }
 
+  /**
+   * @covers VocabularyConfig::getPropertyOrder
+   */
+  public function testGetPropertyOrderNotSet() {
+    $vocab = $this->model->getVocabulary('test');
+    $params = $vocab->getConfig()->getPropertyOrder();
+
+    // need to use reflection to make the private property accessible
+    $reflector = new ReflectionClass('VocabularyConfig');
+    $property = $reflector->getProperty('DEFAULT_PROPERTY_ORDER');
+    $property->setAccessible(true);
+
+    $this->assertEquals($property->getValue($vocab->getConfig()), $params);
+  }
+
 }

--- a/tests/VocabularyConfigTest.php
+++ b/tests/VocabularyConfigTest.php
@@ -522,6 +522,16 @@ class VocabularyConfigTest extends PHPUnit\Framework\TestCase
 
   /**
    * @covers VocabularyConfig::getPropertyOrder
+   * @expectedException PHPUnit\Framework\Error\Error
+   */
+  public function testGetPropertyOrderUnknown() {
+    $vocab = $this->model->getVocabulary('testUnknownPropertyOrder');
+    $params = $vocab->getConfig()->getPropertyOrder();
+    $this->assertEquals(VocabularyConfig::DEFAULT_PROPERTY_ORDER, $params);
+  }
+
+  /**
+   * @covers VocabularyConfig::getPropertyOrder
    */
   public function testGetPropertyOrderISO() {
     $vocab = $this->model->getVocabulary('testISOPropertyOrder');

--- a/tests/VocabularyConfigTest.php
+++ b/tests/VocabularyConfigTest.php
@@ -517,4 +517,34 @@ class VocabularyConfigTest extends PHPUnit\Framework\TestCase
     $this->assertEquals($property->getValue($vocab->getConfig()), $params);
   }
 
+  /**
+   * @covers VocabularyConfig::getPropertyOrder
+   */
+  public function testGetPropertyOrderDefault() {
+    $vocab = $this->model->getVocabulary('testDefaultPropertyOrder');
+    $params = $vocab->getConfig()->getPropertyOrder();
+
+    // need to use reflection to make the private property accessible
+    $reflector = new ReflectionClass('VocabularyConfig');
+    $property = $reflector->getProperty('DEFAULT_PROPERTY_ORDER');
+    $property->setAccessible(true);
+
+    $this->assertEquals($property->getValue($vocab->getConfig()), $params);
+  }
+
+  /**
+   * @covers VocabularyConfig::getPropertyOrder
+   */
+  public function testGetPropertyOrderISO() {
+    $vocab = $this->model->getVocabulary('testISOPropertyOrder');
+    $params = $vocab->getConfig()->getPropertyOrder();
+
+    // need to use reflection to make the private property accessible
+    $reflector = new ReflectionClass('VocabularyConfig');
+    $property = $reflector->getProperty('ISO25964_PROPERTY_ORDER');
+    $property->setAccessible(true);
+
+    $this->assertEquals($property->getValue($vocab->getConfig()), $params);
+  }
+
 }

--- a/tests/VocabularyConfigTest.php
+++ b/tests/VocabularyConfigTest.php
@@ -547,4 +547,19 @@ class VocabularyConfigTest extends PHPUnit\Framework\TestCase
     $this->assertEquals($property->getValue($vocab->getConfig()), $params);
   }
 
+
+  /**
+   * @covers VocabularyConfig::getPropertyOrder
+   */
+  public function testGetPropertyOrderCustom() {
+    $vocab = $this->model->getVocabulary('testCustomPropertyOrder');
+    $params = $vocab->getConfig()->getPropertyOrder();
+
+    $order = array('rdf:type', 'skos:definition', 'skos:broader',
+    'skos:narrower', 'skos:related', 'skos:altLabel', 'skos:note',
+    'skos:scopeNote', 'skos:historyNote', 'skos:prefLabel');
+
+    $this->assertEquals($order, $params);
+  }
+
 }

--- a/tests/testconfig.ttl
+++ b/tests/testconfig.ttl
@@ -402,6 +402,40 @@
         schema:value    "#800000" ;
     ] .
 
+:testISOPropertyOrder a skosmos:Vocabulary, void:Dataset ;
+	dc:title "ISO 25964 property order"@en ;
+	dc:subject :cat_science ;
+	skosmos:propertyOrder skosmos:iso25964PropertyOrder ;
+	void:dataDump <http://skosmos.skos/dump/test/> ;
+	void:sparqlEndpoint <http://localhost:13030/skosmos-test/sparql> ;
+	void:uriSpace "http://www.skosmos.skos/testOrder/";
+	skosmos:language "en";
+	skosmos:sparqlGraph <http://www.skosmos.skos/testOrder/> .
+
+:testDefaultPropertyOrder a skosmos:Vocabulary, void:Dataset ;
+	dc:title "Default property order"@en ;
+	dc:subject :cat_science ;
+	skosmos:propertyOrder skosmos:defaultPropertyOrder ;
+	void:dataDump <http://skosmos.skos/dump/test/> ;
+	void:sparqlEndpoint <http://localhost:13030/skosmos-test/sparql> ;
+	void:uriSpace "http://www.skosmos.skos/testOrder/";
+	skosmos:language "en";
+	skosmos:sparqlGraph <http://www.skosmos.skos/testOrder/> .
+
+:testCustomPropertyOrder a skosmos:Vocabulary, void:Dataset ;
+	dc:title "Custom property order"@en ;
+	dc:subject :cat_science ;
+	skosmos:propertyOrder [a skosmos:PropertyOrder; rdf:value (
+		rdf:type skos:definition skos:broader skos:narrower
+		skos:related skos:altLabel skos:note skos:scopeNote
+		skos:historyNote skos:prefLabel
+	) ] ;
+	void:dataDump <http://skosmos.skos/dump/test/> ;
+	void:sparqlEndpoint <http://localhost:13030/skosmos-test/sparql> ;
+	void:uriSpace "http://www.skosmos.skos/testOrder/";
+	skosmos:language "en";
+	skosmos:sparqlGraph <http://www.skosmos.skos/testOrder/> .
+
 <http://skosmos.skos/dump/test/groups> dc:format "application/rdf+xml" .
 
 :cat_science a skos:Concept ;

--- a/tests/testconfig.ttl
+++ b/tests/testconfig.ttl
@@ -436,6 +436,16 @@
 	skosmos:language "en";
 	skosmos:sparqlGraph <http://www.skosmos.skos/testOrder/> .
 
+:testUnknownPropertyOrder a skosmos:Vocabulary, void:Dataset ;
+	dc:title "Custom property order"@en ;
+	dc:subject :cat_science ;
+	skosmos:propertyOrder skosmos:unknown ;
+	void:dataDump <http://skosmos.skos/dump/test/> ;
+	void:sparqlEndpoint <http://localhost:13030/skosmos-test/sparql> ;
+	void:uriSpace "http://www.skosmos.skos/testOrder/";
+	skosmos:language "en";
+	skosmos:sparqlGraph <http://www.skosmos.skos/testOrder/> .
+
 <http://skosmos.skos/dump/test/groups> dc:format "application/rdf+xml" .
 
 :cat_science a skos:Concept ;

--- a/view/concept-shared.twig
+++ b/view/concept-shared.twig
@@ -111,40 +111,6 @@
         </div></div></div>
         {% endif %}
       {% endfor %}
-      {% if concept.groupProperties %}
-      <div class="row">
-        <div class="property-label"><span class="versal property-click" title="{% trans "skosmos:memberOf_help" %}" >{{ 'skosmos:memberOf'|trans|upper }}</span></div>
-        <div class="property-value-column"><div class="property-value-wrapper">
-          <ul>
-          {% for grouppath in concept.groupProperties %}
-              <li>
-              {% for group in grouppath %}
-                <a class="versal" href="{{ group.uri | link_url(group.vocab,request.lang,'page',request.contentLang) }}">{% if group.notation %}<span class="versal">{{ group.notation }}</span>{% endif %}{{ group.label(request.contentLang) }}</a>{% if group.label.lang and (group.label.lang != request.contentLang or explicit_langcodes) %} <span class="versal">({{ group.label.lang }})</span>{% endif %}
-                {% if not loop.last %}<span class="versal"> &#62; </span>{% endif %}
-              {% endfor %}
-              </li>
-          {% endfor %}
-          </ul>
-        </div></div>
-      </div>
-      {% endif %}
-      {% if concept.arrayProperties %}
-      <div class="row">
-        <div class="property-label"><span class="versal property-click" title="{% trans "skosmos:memberOfArray_help" %}" >{{ 'skosmos:memberOfArray'|trans|upper }}</span></div>
-        <div class="property-value-column"><div class="property-value-wrapper">
-          <ul>
-          {% for grouppath in concept.arrayProperties %}
-            {% for group in grouppath %}
-              {% if group.type == 'skosmos:memberOfArray' %}
-                <li><a href="{{ group.uri | link_url(group.vocab,request.lang,'page',request.contentLang) }}">{% if group.notation %}<span class="versal">{{ group.notation }}</span>{% endif %}{{ group.label(request.contentLang) }}</a></li>
-              {% else %}
-              {% endif %}
-            {% endfor %}
-          {% endfor %}
-          </ul>
-        </div></div>
-      </div>
-      {% endif %}
       {% if concept.foreignLabels %}
       <div class="row">
         <div class="property-label"><span class="versal property-click" title="{% trans "foreign prefLabel help" %}" >{{ 'foreign prefLabels'|trans|upper }}</span></div>


### PR DESCRIPTION
This draft PR implements the first steps of making the property order configurable on concept pages, defined in #554.

Three sorts of property order can be selected using the new, vocabulary-specific configuration setting `skosmos:propertyOrder`:

1. Default/traditional property order, used in previous Skosmos releases
2. ISO 25964 property order
3. Custom property order

There are still several unresolved problems with this PR:

- [x] one unit test is failing, apparently because of a concept that doesn't know its vocabulary
- [x] the property order only affects the "core" properties in the middle of the concept page; it is not possible to adjust the order of "belongs to group", "in other languages" and "URI" properties near the bottom since their position is currently hardwired in the Twig templates
- [x] ISO 25964 only defines the order for some concept properties, not all of the common ones (e.g. `dc:source`); it's unclear what to do with these (try to find a sensible slot? leave them all at the bottom?)
- [x] the current code probably doesn't work too well when a custom order is given with URIs from namespaces not known to EasyRdf (e.g. RDA properties)

Opening a draft PR to get early feedback from QA tools.

Fixes #554