### PR TITLE
Show tooltips (rdfs:comment or skos:definition) for custom properties

### DIFF
--- a/model/Concept.php
+++ b/model/Concept.php
@@ -514,6 +514,12 @@ class Concept extends VocabularyDataObject implements Modifiable
                 $propres = new EasyRdf\Resource($prop, $this->graph);
                 $proplabel = $propres->label($this->getEnvLang()) ? $propres->label($this->getEnvLang()) : $propres->label();
 
+                $prophelp = $propres->getLiteral('rdfs:comment|skos:definition', $this->getEnvLang());
+                if ($prophelp === null) {
+                    // try again without language restriction
+                    $prophelp = $propres->getLiteral('rdfs:comment|skos:definition');
+                }
+
                 // check if the property is one of the well-known properties for which we have a gettext translation
                 // if it is then we can skip the additional lookups in the default graph
                 $propkey = (substr($prop, 0, 5) == 'dc11:') ?
@@ -554,7 +560,7 @@ class Concept extends VocabularyDataObject implements Modifiable
                     $superprop = EasyRdf\RdfNamespace::shorten($superprop) ? EasyRdf\RdfNamespace::shorten($superprop) : $superprop;
                 }
                 $sort_by_notation = $this->vocab->getConfig()->sortByNotation();
-                $propobj = new ConceptProperty($prop, $proplabel, $superprop, $sort_by_notation);
+                $propobj = new ConceptProperty($prop, $proplabel, $prophelp, $superprop, $sort_by_notation);
 
                 if ($propobj->getLabel() !== null) {
                     // only display properties for which we have a label

--- a/model/ConceptProperty.php
+++ b/model/ConceptProperty.php
@@ -11,6 +11,8 @@ class ConceptProperty
     private $super;
     /** stores the property label */
     private $label;
+    /** stores the property tooltip */
+    private $tooltip;
     /** stores the property values */
     private $values;
     /** flag whether the values are sorted, as we do lazy sorting */
@@ -22,11 +24,11 @@ class ConceptProperty
      * @param string $prop property type eg. 'rdf:type'.
      * @param string $label
      */
-    public function __construct($prop, $label, $help=null, $super=null, $sort_by_notation=false)
+    public function __construct($prop, $label, $tooltip=null, $super=null, $sort_by_notation=false)
     {
         $this->prop = $prop;
         $this->label = $label;
-        $this->help = $help;
+        $this->tooltip = $tooltip;
         $this->values = array();
         $this->is_sorted = true;
         $this->super = $super;
@@ -71,11 +73,11 @@ class ConceptProperty
         }
 
        // if not, see if there was a comment/definition for the property in the graph
-        if ($this->help !== null) {
-            return $this->help;
+        if ($this->tooltip !== null) {
+            return $this->tooltip;
         }
 
-        // when nothing is found, don't show the help text at all
+        // when nothing is found, don't show the tooltip at all
         return null;
     }
 

--- a/model/ConceptProperty.php
+++ b/model/ConceptProperty.php
@@ -22,7 +22,10 @@ class ConceptProperty
     /**
      * Label parameter seems to be optional in this phase.
      * @param string $prop property type eg. 'rdf:type'.
-     * @param string $label
+     * @param string $label property label
+     * @param string $tooltip property tooltip/description
+     * @param string $super URI of superproperty
+     * @param boolean $sort_by_notation whether to sort the property values by their notation code
      */
     public function __construct($prop, $label, $tooltip=null, $super=null, $sort_by_notation=false)
     {

--- a/model/ConceptProperty.php
+++ b/model/ConceptProperty.php
@@ -22,10 +22,11 @@ class ConceptProperty
      * @param string $prop property type eg. 'rdf:type'.
      * @param string $label
      */
-    public function __construct($prop, $label, $super=null, $sort_by_notation=false)
+    public function __construct($prop, $label, $help=null, $super=null, $sort_by_notation=false)
     {
         $this->prop = $prop;
         $this->label = $label;
+        $this->help = $help;
         $this->values = array();
         $this->is_sorted = true;
         $this->super = $super;
@@ -47,7 +48,7 @@ class ConceptProperty
         }
 
         // if not, see if there was a label for the property in the graph
-        if ($this->label) {
+        if ($this->label !== null) {
             return $this->label;
         }
 
@@ -56,14 +57,26 @@ class ConceptProperty
     }
 
     /**
-     * Returns a gettext translation for the property tooltip.
+     * Returns text for the property tooltip.
      * @return string
      */
     public function getDescription()
     {
         $helpprop = $this->prop . "_help";
 
-        return gettext($helpprop); // can't use string constant, it'd be picked up by xgettext
+        // see if we have a translation with the help text
+        $help = gettext($helpprop);
+        if ($help != $helpprop) {
+            return $help;
+        }
+
+       // if not, see if there was a comment/definition for the property in the graph
+        if ($this->help !== null) {
+            return $this->help;
+        }
+
+        // when nothing is found, don't show the help text at all
+        return null;
     }
 
     /**

--- a/model/sparql/GenericSparql.php
+++ b/model/sparql/GenericSparql.php
@@ -374,6 +374,8 @@ CONSTRUCT {
  ?sp ?uri ?op .
  ?uri ?p ?o .
  ?p rdfs:label ?proplabel .
+ ?p rdfs:comment ?propcomm .
+ ?p skos:definition ?propdef .
  ?p rdfs:subPropertyOf ?pp .
  ?pp rdfs:label ?plabel .
  ?o a ?ot .
@@ -421,6 +423,10 @@ CONSTRUCT {
    }
    OPTIONAL {
      { ?p rdfs:label ?proplabel . }
+     UNION
+     { ?p rdfs:comment ?propcomm . }
+     UNION
+     { ?p skos:definition ?propdef . }
      UNION
      { ?p rdfs:subPropertyOf ?pp . }
    }

--- a/tests/ConceptPropertyTest.php
+++ b/tests/ConceptPropertyTest.php
@@ -61,6 +61,20 @@ class ConceptPropertyTest extends PHPUnit\Framework\TestCase
   }
 
   /**
+   * @covers ConceptProperty::getLabel
+   * @covers ConceptProperty::getDescription
+   */
+  public function testGetDescriptionAndLabelForCustomProperty() {
+    $vocab = $this->model->getVocabulary('test');
+    $concepts = $vocab->getConceptInfo('http://www.skosmos.skos/test/ta112', 'en');
+    $concept = $concepts[0];
+    $props = $concept->getProperties();
+    $prop = $props["http://www.skosmos.skos/testprop"];
+    $this->assertEquals('Skosmos test property', $prop->getLabel());
+    $this->assertEquals('description for Skosmos test property', $prop->getDescription());
+  }
+
+  /**
    * @covers Concept::getProperties
    * @covers ConceptProperty::getType
    */

--- a/tests/ConceptPropertyTest.php
+++ b/tests/ConceptPropertyTest.php
@@ -75,6 +75,20 @@ class ConceptPropertyTest extends PHPUnit\Framework\TestCase
   }
 
   /**
+   * @covers ConceptProperty::getLabel
+   * @covers ConceptProperty::getDescription
+   */
+  public function testGetDescriptionAndLabelForCustomPropertyMissingDesc() {
+    $vocab = $this->model->getVocabulary('test-notation-sort');
+    $concepts = $vocab->getConceptInfo('http://www.skosmos.skos/test/ta0112', 'en');
+    $concept = $concepts[0];
+    $props = $concept->getProperties();
+    $prop = $props["http://www.skosmos.skos/testprop"];
+    $this->assertEquals('Skosmos test property', $prop->getLabel());
+    $this->assertEquals(null, $prop->getDescription());
+  }
+
+  /**
    * @covers Concept::getProperties
    * @covers ConceptProperty::getType
    */

--- a/tests/test-vocab-data/test.ttl
+++ b/tests/test-vocab-data/test.ttl
@@ -17,7 +17,8 @@ meta:TestClass a owl:Class ;
     rdfs:label "Test class"@en .
 
 skosmos:testprop a rdf:Property ;
-    rdfs:label "Skosmos test property"@en .
+    rdfs:label "Skosmos test property"@en ;
+    rdfs:comment "description for Skosmos test property"@en .
 
 skos:prefLabel a rdf:Property ;
     rdfs:label "preferred label"@en .

--- a/view/concept-shared.twig
+++ b/view/concept-shared.twig
@@ -62,7 +62,7 @@
         {% if property.getSubPropertyOf != 'skos:hiddenLabel' %}
         <div class="row{% if property.type == 'dc:isReplacedBy' %} replaced-by{% endif%}">
           <div class="property-label">
-            <span class="versal{% if property.type == 'rdf:type' %}-bold{% endif %}{% if property.description %} property-click" title="{{ property.description }}"{% else %}"{% endif %}>{{ property.label|upper }}</span>
+            <span class="versal{% if property.type == 'rdf:type' %}-bold{% endif %}{% if property.description %} property-click" title="{{ property.description }}{% endif %}">{{ property.label|upper }}</span>
           </div>
           <div class="property-value-column"><div class="property-value-wrapper">
         {% if request.vocab.config.hasMultiLingualProperty(property.type) %}

--- a/view/concept-shared.twig
+++ b/view/concept-shared.twig
@@ -62,7 +62,7 @@
         {% if property.getSubPropertyOf != 'skos:hiddenLabel' %}
         <div class="row{% if property.type == 'dc:isReplacedBy' %} replaced-by{% endif%}">
           <div class="property-label">
-            <span class="versal{% if property.type == 'rdf:type' %}-bold{% endif %}{% if not (property.type in property.description and '_help' in property.description) %} property-click" title="{{ property.description }}"{% else %}"{% endif %}>{{ property.label|upper }}</span>
+            <span class="versal{% if property.type == 'rdf:type' %}-bold{% endif %}{% if property.description %} property-click" title="{{ property.description }}"{% else %}"{% endif %}>{{ property.label|upper }}</span>
           </div>
           <div class="property-value-column"><div class="property-value-wrapper">
         {% if request.vocab.config.hasMultiLingualProperty(property.type) %}


### PR DESCRIPTION
The tooltip content is read from `rdfs:comment` or `skos:definition` values of the property URI.

Example of Finnish Corporate Names showing RDA property definition as a tooltip:

![kuva](https://user-images.githubusercontent.com/1132830/84490736-429a9200-acac-11ea-9119-a9bdd59803ce.png)

Fixes #824
