### PR TITLE
fixes #990 via introducting new global js variable

### DIFF
--- a/resource/js/scripts.js
+++ b/resource/js/scripts.js
@@ -370,12 +370,9 @@ function renderPropertyMappings(concept, contentLang, properties) {
     }
     return opts.fn(this);
   });
-  Handlebars.registerHelper('ifDifferentLabelLang', function(labelLang, explicitLangCodes, opts) {
+  Handlebars.registerHelper('ifDifferentLabelLang', function(labelLang, opts) {
     if (labelLang !== undefined && labelLang !== '' && labelLang !== null) {
-      if (explicitLangCodes !== undefined && typeof explicitLangCodes === "boolean") {
-        return opts.fn(explicitLangCodes);
-      }
-      if (labelLang !== contentLang) {
+      if (explicitLangCodes || labelLang !== contentLang) {
         return opts.fn(this);
       }
     }

--- a/view/concept-shared.twig
+++ b/view/concept-shared.twig
@@ -174,7 +174,7 @@
             <div class="row">
                 <div class="col-xs-5">
                     <a class="versal" href="{{hrefLink}}">{{#if notation }}<span class="versal">{{ notation }}</span>{{/if}}{{ prefLabel }}</a>
-                    {{#ifDifferentLabelLang lang explicitLangCodes}}<span class="propertyvalue"> ({{ lang }})</span>{{/ifDifferentLabelLang}}
+                    {{#ifDifferentLabelLang lang }}<span class="propertyvalue"> ({{ lang }})</span>{{/ifDifferentLabelLang}}
                 </div>
                 {{#if vocabName }}
                     <span class="appendix-vocab-label col-xs-7">{{ vocabName }}</span>

--- a/view/scripts.twig
+++ b/view/scripts.twig
@@ -29,6 +29,7 @@ var showNotation = {% if request.vocab and request.vocab.config.showNotation == 
 {% if request.vocab  %}
 var languageOrder = [{% for lang in request.vocab.config.languageOrder(request.contentLang) %}"{{ lang }}"{% if not loop.last %},{% endif %}{% endfor %}];
 {% endif %}
+var explicitLangCodes = {{ explicit_langcodes ? 'true' : 'false' }};
 {% if plugin_params%}
 var pluginParameters = {{ plugin_params|raw }};
 {% endif %}


### PR DESCRIPTION
This resolves #990 via the second method.

It would also be possible to use the `json_encode()` filter function to check out for (cast) the value of `explicit_langcodes` variable into a JS variable but in this PR I relied on Twig's direct interpretation of the firstly mentioned variable combined with a boolean-casting ternary operator.