### PR TITLE
Fix loading spinner that broke in refactoring

### DIFF
--- a/resource/js/docready.js
+++ b/resource/js/docready.js
@@ -292,7 +292,7 @@ $(function() { // DOCUMENT READY
         $.ajax({
             url : targetUrl,
             data: parameters,
-            complete: clearTimeout(loading),
+            complete: function() { clearTimeout(loading); },
             success : function(data) {
               $content.empty();
               var response = $('.content', data).html();
@@ -321,7 +321,7 @@ $(function() { // DOCUMENT READY
         var loading = delaySpinner();
         $.ajax({
             url : event.target.href,
-            complete: clearTimeout(loading),
+            complete: function() { clearTimeout(loading); },
             success : function(data) {
               if (window.history.pushState) { window.history.pushState({}, null, event.target.href); }
               $content.empty().append($('.content', data).html());


### PR DESCRIPTION
During refactoring in commit 4fbfdce0053b7bb17f2209de1ded331f44e30c8e, the loading spinner for concept pages broke. This PR fixes it. The problem was that the clearTimeout function was called too early.

Thanks to @kouralex for spotting this