### PR TITLE
mappings: fix issue with explicitLanguageTags set to true and label i…

### DIFF
--- a/model/ConceptMappingPropertyValue.php
+++ b/model/ConceptMappingPropertyValue.php
@@ -192,12 +192,18 @@ class ConceptMappingPropertyValue extends VocabularyDataObject
                 ]
             ],
             // EXTRA
-            'description' => gettext($this->type . "_help"), // pop-up text
             'hrefLink' => $hrefLink, // link to resource as displayed in the UI
             'lang' => $propertyLang, // TBD: could it be part of the prefLabel?
             'vocabName' => (string) $this->getVocabName(), // vocabulary as displayed in the UI
             'typeLabel' => gettext($this->type), // a text used in the UI instead of, for example, skos:closeMatch
         ];
+
+        $helpprop = $this->type . "_help";
+        // see if we have a translation for the property help text
+        $help = gettext($helpprop);
+        if ($help != $helpprop) {
+            $ret['description'] = $help;
+        }
 
         $fromScheme = $this->vocab->getDefaultConceptScheme();
         if (isset($fromScheme)) {
@@ -221,10 +227,13 @@ class ConceptMappingPropertyValue extends VocabularyDataObject
         $label = $this->getLabel($lang, $queryExVocabs);
         if (isset($label)) {
             if (is_string($label)) {
-                list($labelLang, $labelValue) = ['-', $label];
+                list($labelLang, $labelValue) = ['', $label];
             } else {
                 list($labelLang, $labelValue) = [$label->getLang(), $label->getValue()];
             }
+            // set the language of the preferred label to be whatever returned
+            $ret['lang'] = $labelLang;
+
             if ($labelValue != $this->getUri()) {
                 // The `queryLabel()` method above will fallback to returning the URI
                 // if no label was found. We don't want that here.


### PR DESCRIPTION
…s just shortened property; fix property text help

There was an unidentified case of #990 which was tried to be fixed with #998.
Fixes #990 for good.

For testing, see  http://dev.finto.fi/gfdc/en/page/C861 and http://www.yso.fi/onto/yso/p105695.

Also, fixes an issue where a help text (tooltip) for property is shown even though there is no translation for it. See for example http://dev.finto.fi/gfdc/en/page/C861 -> tooltip of 'Related Matching Concepts'.