### PR TITLE
Issue724 group tab shorten uris

### DIFF
--- a/resource/js/docready.js
+++ b/resource/js/docready.js
@@ -284,19 +284,16 @@ $(function() { // DOCUMENT READY
       function(event) {
         event.preventDefault();
         var targetUrl = event.target.href;
-        var parameters = (clang !== lang) ? $.param({'clang' : clang}) : $.param({});
-        var historyUrl = (clang !== lang) ? targetUrl + '?' + parameters : targetUrl;
         $('#hier-trigger').attr('href', targetUrl);
         var $content = $('.content').empty().append($delayedSpinner.hide());
         var loading = delaySpinner();
         $.ajax({
             url : targetUrl,
-            data: parameters,
             complete: function() { clearTimeout(loading); },
             success : function(data) {
               $content.empty();
               var response = $('.content', data).html();
-              if (window.history.pushState) { window.history.pushState({url: historyUrl}, '', historyUrl); }
+              if (window.history.pushState) { window.history.pushState({url: targetUrl}, '', targetUrl); }
               $content.append(response);
 
               updateJsonLD(data);

--- a/resource/js/groups.js
+++ b/resource/js/groups.js
@@ -68,7 +68,7 @@ function invokeGroupTree() {
                 var children = [];
                 for (var i in response.members) {
                   var member = response.members[i];
-                  var child = {'text' : member.prefLabel,'parent' : node.a_attr['data-uri'], children : false, a_attr : { 'data-uri' : member.uri, "href" : vocab + '/' + lang + '/page/?uri=' + encodeURIComponent(member.uri)}};
+                  var child = {'text' : member.prefLabel,'parent' : node.a_attr['data-uri'], children : false, a_attr : { 'data-uri' : member.uri, "href" : getHrefForUri(member.uri, true) }};
                   if (member.hasMembers || member.isSuper) {
                     child.children = true;
                   }
@@ -90,18 +90,7 @@ function invokeGroupTree() {
 }
 
 function createGroupNode(uri, groupObject) {
-	var groupPage;
-	if (uri.indexOf(uriSpace) !== -1) {	
-		groupPage = uri.substr(uriSpace.length);
-		if (/[^a-zA-Z0-9\.]/.test(groupPage) || groupPage.indexOf("/") > -1 ) {
-	      // contains special characters or contains an additional '/' - fall back to full URI
-		  groupPage = '?uri=' + encodeURIComponent(uri);
-	    }
-	} else {
-		groupPage = '?uri=' + encodeURIComponent(uri);
-	}
-  
-  var node = {children : [], a_attr : {'data-uri' : uri, "href" : vocab + '/' + lang + '/page/' + groupPage, "class" : "group" }};
+  var node = {children : [], a_attr : {'data-uri' : uri, "href" : getHrefForUri(uri, true), "class" : "group" }};
   node.text = groupObject.prefLabel;
   if (groupObject.hasMembers || groupObject.isSuper)
     node.children = true;

--- a/resource/js/hierarchy.js
+++ b/resource/js/hierarchy.js
@@ -79,7 +79,7 @@ function createObjectsFromChildren(conceptData, conceptUri) {
   for (var i = 0; i < conceptData.narrower.length; i++) {
     var childObject = {
       text: getLabel(conceptData.narrower[i]), 
-      a_attr: getConceptHref(conceptData.narrower[i]),
+      a_attr: getHrefForUri(conceptData.narrower[i].uri),
       uri: conceptData.narrower[i].uri,
       notation: conceptData.narrower[i].notation,
       parents: conceptUri,
@@ -105,7 +105,7 @@ function createObjectsFromChildren(conceptData, conceptUri) {
 function createConceptObject(conceptUri, conceptData) {
   var newNode = { 
     text: getLabel(conceptData), 
-    a_attr: getConceptHref(conceptData),
+    a_attr: getHrefForUri(conceptData.uri),
     uri: conceptUri,
     notation: conceptData.notation,
     parents: conceptData.broader,
@@ -201,27 +201,13 @@ function buildParentTree(uri, parentData, schemes) {
   return JSON.parse(JSON.stringify(rootArray));
 }
 
-function getConceptHref(conceptData) {
-  if (conceptData.uri.indexOf(window.uriSpace) !== -1) {
-    var page = conceptData.uri.substr(window.uriSpace.length);
-    if (/[^a-zA-Z0-9\.]/.test(page) || page.indexOf("/") > -1 ) {
-      // contains special characters or contains an additional '/' - fall back to full URI
-      page = '?uri=' + encodeURIComponent(conceptData.uri);
-    }
-  } else {
-    // not within URI space - fall back to full URI
-    page = '?uri=' + encodeURIComponent(conceptData.uri);
-  }
-  return { "href" : vocab + '/' + lang + '/page/' + page };
-}
-
 function vocabRoot(topConcepts) {
   var topArray = [];
   for (var i = 0; i < topConcepts.length; i++) {
     var conceptData = topConcepts[i];
     var childObject = {
       text: conceptData.label, 
-      a_attr : getConceptHref(conceptData),
+      a_attr : getHrefForUri(conceptData.uri),
       uri: conceptData.uri,
       notation: conceptData.notation,
       state: { opened: false } 
@@ -269,7 +255,7 @@ function createObjectsFromNarrowers(narrowerResponse) {
     var conceptObject = narrowerResponse.narrower[i];
     var childObject = {
       text : getLabel(conceptObject), 
-      a_attr : getConceptHref(conceptObject),
+      a_attr : getHrefForUri(conceptObject.uri),
       uri: conceptObject.uri,
       notation: conceptObject.notation,
       parents: narrowerResponse.uri,
@@ -340,7 +326,7 @@ function topConceptsToSchemes(topConcepts, schemes) {
     var hasChildren = topConcept.hasChildren; 
     var childObject = {
       text : getLabel(topConcept), 
-      a_attr : { "href" : vocab + '/' + lang + '/page/?uri=' + encodeURIComponent(topConcept.uri) },
+      a_attr: getHrefForUri(topConcept.uri),
       uri: topConcept.uri,
       notation: topConcept.notation,
       state: { opened: false, disabled: false, selected: false }

--- a/resource/js/scripts.js
+++ b/resource/js/scripts.js
@@ -47,18 +47,22 @@ function getUrlParams() {
  *
  */
 function getHrefForUri(uri, plainReturnValue) {
+  var clangParam = (content_lang !== lang) ? "clang=" + content_lang : "";
+  var clangSeparator = "?";
   if (uri.indexOf(window.uriSpace) !== -1) {
     var page = uri.substr(window.uriSpace.length);
-    if (/[^a-zA-Z0-9\.]/.test(page) || page.indexOf("/") > -1 ) {
+    if (/[^a-zA-Z0-9-_\.~]/.test(page) || page.indexOf("/") > -1 ) {
       // contains special characters or contains an additional '/' - fall back to full URI
       page = '?uri=' + encodeURIComponent(uri);
+      clangSeparator = "&";
     }
   } else {
     // not within URI space - fall back to full URI
     page = '?uri=' + encodeURIComponent(uri);
+    clangSeparator = "&";
   }
 
-  var href = window.vocab + '/' + window.lang + '/page/' + page;
+  var href = window.vocab + '/' + window.lang + '/page/' + page + (clangParam !== "" ? clangSeparator + clangParam : "");
 
   return plainReturnValue ? href : { "href" : href };
 }

--- a/resource/js/scripts.js
+++ b/resource/js/scripts.js
@@ -1,4 +1,4 @@
-/* exported getUrlParams, readCookie, createCookie, getUrlParams, debounce, updateContent, updateTopbarLang, updateTitle, updateSidebar, setLangCookie, loadLimitations, loadPage, hideCrumbs, shortenProperties, countAndSetOffset, combineStatistics, loadLimitedResults, naturalCompare, escapeHtml */
+/* exported getUrlParams, getConceptHref, readCookie, createCookie, getUrlParams, debounce, updateContent, updateTopbarLang, updateTitle, updateSidebar, setLangCookie, loadLimitations, loadPage, hideCrumbs, shortenProperties, countAndSetOffset, combineStatistics, loadLimitedResults, naturalCompare, escapeHtml, getConceptHref, renderPropertyMappings, loadMappingProperties /*
 
 /* 
  * Creates a cookie value and stores it for the user. Takes the given
@@ -36,6 +36,31 @@ function getUrlParams() {
     params[key] = value;
   });
   return params;
+}
+
+/**
+ * Get a href value for a concept URI in current vocab urispace
+ *
+ * @param uri string concept URI
+ * @param plainReturnValue boolean indicates whether to return a plain string or a href-key key-value-pair
+ * @return string|object Plain href link (string) or href-key key-value-pair if parameter plainReturnValue evaluates to false
+ *
+ */
+function getHrefForUri(uri, plainReturnValue) {
+  if (uri.indexOf(window.uriSpace) !== -1) {
+    var page = uri.substr(window.uriSpace.length);
+    if (/[^a-zA-Z0-9\.]/.test(page) || page.indexOf("/") > -1 ) {
+      // contains special characters or contains an additional '/' - fall back to full URI
+      page = '?uri=' + encodeURIComponent(uri);
+    }
+  } else {
+    // not within URI space - fall back to full URI
+    page = '?uri=' + encodeURIComponent(uri);
+  }
+
+  var href = window.vocab + '/' + window.lang + '/page/' + page;
+
+  return plainReturnValue ? href : { "href" : href };
 }
 
 // Debounce function from underscore.js
@@ -327,20 +352,6 @@ function escapeHtml(string) {
   return String(string).replace(/[&<>"'\/]/g, function (s) {
     return entityMap[s];
   });
-}
-
-function renderPropertyMappingValues(groupedByType) {
-  var propertyMappingValues = [];
-  var source = document.getElementById("property-mapping-values-template").innerHTML;
-  var template = Handlebars.compile(source);
-  var context = {
-    property: {
-      uri: conceptMappingPropertyValue.uri,
-      label: conceptMappingPropertyValue.prefLabel,
-    }
-  };
-  propertyMappingValues.push({'body': template(context)});
-  return propertyMappingValues;
 }
 
 function renderPropertyMappings(concept, contentLang, properties) {


### PR DESCRIPTION
Fixes #724 .

Additionally addresses the following issues:
1) Adds support for characters `-_~` in shortened URIs (see https://en.wikipedia.org/wiki/Percent-encoding#Types_of_URI_characters for more information)
2) Standardizes behavior between `groups` and `hierarchy` tabs (use same code).
3) Removes a previously unnoticed error that happened to set the parameters in some cases as `?uri=xxx?clang=yy` instead of the correct `?uri=xxx&clang=yy` way.