### PR TITLE
Issue908 fix jenatext language matching

### DIFF
--- a/model/sparql/GenericSparql.php
+++ b/model/sparql/GenericSparql.php
@@ -852,9 +852,10 @@ EOF;
      * Generate condition for matching labels in SPARQL
      * @param string $term search term
      * @param string $searchLang language code used for matching labels (null means any language)
+     * @param string $lang language code of the returned labels (not needed in GenericSparql; see #908)
      * @return string sparql query snippet
      */
-    protected function generateConceptSearchQueryCondition($term, $searchLang)
+    protected function generateConceptSearchQueryCondition($term, $searchLang, $lang)
     {
         # use appropriate matching function depending on query type: =, strstarts, strends or full regex
         if (preg_match('/^[^\*]+$/', $term)) { // exact query
@@ -897,7 +898,7 @@ EOF;
     protected function generateConceptSearchQueryInner($term, $lang, $searchLang, $props, $unique, $filterGraph)
     {
         $valuesProp = $this->formatValues('?prop', $props);
-        $textcond = $this->generateConceptSearchQueryCondition($term, $searchLang);
+        $textcond = $this->generateConceptSearchQueryCondition($term, $searchLang, $lang);
 
         $rawterm = str_replace(array('\\', '*', '"'), array('\\\\', '', '\"'), $term);
         // graph clause, if necessary

--- a/model/sparql/JenaTextSparql.php
+++ b/model/sparql/JenaTextSparql.php
@@ -58,9 +58,10 @@ class JenaTextSparql extends GenericSparql
      * Generate jena-text search condition for matching labels in SPARQL
      * @param string $term search term
      * @param string $searchLang language code used for matching labels (null means any language)
+     * @param string $lang language code of the returned labels
      * @return string sparql query snippet
      */
-    protected function generateConceptSearchQueryCondition($term, $searchLang)
+    protected function generateConceptSearchQueryCondition($term, $searchLang, $lang)
     {
         # make text query clauses
         $langClause = $searchLang ? '?langParam' : '';
@@ -71,7 +72,10 @@ class JenaTextSparql extends GenericSparql
             $textcond = "GRAPH <urn:x-arq:UnionGraph> { $textcond }";
         }
 
-        return $textcond;
+        // required to fix #908
+        $extraLangTest = ($searchLang) ? " FILTER (langMatches(LANG(?match), '$lang'))" : ' ';
+
+        return $textcond . $extraLangTest;
     }
 
     /**

--- a/model/sparql/JenaTextSparql.php
+++ b/model/sparql/JenaTextSparql.php
@@ -147,6 +147,7 @@ WHERE {
   $gc {
     {
       $textcondPref
+      FILTER (langMatches(LANG(?match), '$lang'))
       FILTER(STRSTARTS(LCASE(STR(?match)), '$lcletter'))
       FILTER EXISTS { ?s skos:prefLabel ?match }
       BIND(?match as ?label)
@@ -154,6 +155,7 @@ WHERE {
     UNION
     {
       $textcondAlt
+      FILTER (langMatches(LANG(?match), '$lang'))
       FILTER(STRSTARTS(LCASE(STR(?match)), '$lcletter'))
       FILTER EXISTS { ?s skos:altLabel ?match }
       BIND(?match as ?alabel)


### PR DESCRIPTION
This PR fixes the issue mentioned in #908 by adding an extra filtering as per https://github.com/NatLibFi/Skosmos/issues/908#issuecomment-561156986.

After inspecting the issue a bit further, I noticed that it could probably be fixed with https://jena.apache.org/documentation/query/text-query.html#multilingual-enhancements-for-multi-encoding-searches `text:searchFor` setting (+ removing the * wildcard mentioned in https://github.com/NatLibFi/Skosmos/issues/908#issuecomment-560328669), however, that might be a bit too much to be asked from every Fuseki installation to have an exhaustive listing of all the (sub) language codes.

After solving the problem like it is solved in this PR, I noticed that it could also be solved by a single introduction of the necessary filter in `createTextQueryCondition`. I leave it for the reviewers to decide which way is the best, hence the Draft PR.

A sad part of this is that it is required to change the signature of the `generateConceptSearchQueryCondition` function in `GenericSparql.php`, possibly rendering the user made `skosmos:sparqlDialect` inoperable but I guess that is unavoidable in any case.