### PR TITLE
fix #1018 by explicitly declaring the UI locale in getDate()

### DIFF
--- a/model/Concept.php
+++ b/model/Concept.php
@@ -85,11 +85,6 @@ class Concept extends VocabularyDataObject implements Modifiable
         }
         $this->graph = $graph;
         $this->clang = $clang;
-        // setting the Punic plugins locale for localized datetime conversions
-        if ($this->clang && $this->clang !== '') {
-            Punic\Data::setDefaultLocale($clang);
-        }
-
     }
 
     /**
@@ -734,14 +729,14 @@ class Concept extends VocabularyDataObject implements Modifiable
 
             // making a human readable string from the timestamps
             if ($created != '') {
-                $ret = gettext('skosmos:created') . ' ' . (Punic\Calendar::formatDate($created, 'short'));
+                $ret = gettext('skosmos:created') . ' ' . (Punic\Calendar::formatDate($created, 'short', $this->getEnvLang()));
             }
 
             if ($modified != '') {
                 if ($created != '') {
-                    $ret .= ', ' . gettext('skosmos:modified') . ' ' . (Punic\Calendar::formatDate($modified, 'short'));
+                    $ret .= ', ' . gettext('skosmos:modified') . ' ' . (Punic\Calendar::formatDate($modified, 'short', $this->getEnvLang()));
                 } else {
-                    $ret .= ' ' . ucfirst(gettext('skosmos:modified')) . ' ' . (Punic\Calendar::formatDate($modified, 'short'));
+                    $ret .= ' ' . ucfirst(gettext('skosmos:modified')) . ' ' . (Punic\Calendar::formatDate($modified, 'short', $this->getEnvLang()));
                 }
 
             }


### PR DESCRIPTION
This PR fixes #1018 by declaring the UI locale in the getDate() method. This could, however, also be fixed by changing the signature of the method and passing the UI language parameter from the Twig template and, thus, making it more versatile, but because the method is not in use in anywhere else it can be fixed straightaway in code.