### PR TITLE
Fixes #1027 by commenting out css file path

### DIFF
--- a/config.ttl.dist
+++ b/config.ttl.dist
@@ -52,7 +52,7 @@
     # a default location for Twig template rendering
     skosmos:templateCache "/tmp/skosmos-template-cache" ;
     # customize the css by adding your own stylesheet
-    skosmos:customCss "resource/css/stylesheet.css" ;
+    # skosmos:customCss "resource/css/stylesheet.css" ;
     # default email address where to send the feedback
     skosmos:feedbackAddress "" ;
     # email address to set as the sender for feedback messages


### PR DESCRIPTION
Comments out config.ttl.dist Skosmos custom CSS file path, which does not exist by default.