### PR TITLE
Issue717 fallback language array in hierarchy + issue906 missing explicit language tags in hierarchy

### DIFF
--- a/model/Vocabulary.php
+++ b/model/Vocabulary.php
@@ -274,7 +274,7 @@ class Vocabulary extends DataObject implements Modifiable
         if ($lang === '') {
             $lang = $this->getEnvLang();
         }
-        $fallback = $this->config->getDefaultLanguage();
+        $languageOrder = $this->config->getLanguageOrder($lang);
 
         if ($conceptScheme === null || $conceptScheme == '') {
             $conceptScheme = $this->getDefaultConceptScheme();
@@ -282,7 +282,7 @@ class Vocabulary extends DataObject implements Modifiable
 
         $explicitLanguageTags = $this->config->getShowLangCodes();
 
-        return $this->getSparql()->queryTopConcepts($conceptScheme, $lang, $fallback, $explicitLanguageTags);
+        return $this->getSparql()->queryTopConcepts($conceptScheme, $lang, $languageOrder, $explicitLanguageTags);
     }
 
     /**
@@ -336,10 +336,10 @@ class Vocabulary extends DataObject implements Modifiable
     public function getConceptHierarchy($uri, $lang)
     {
         $lang = $lang ? $lang : $this->getEnvLang();
-        $fallback = count($this->config->getLanguageOrder($lang)) > 1 ? $this->config->getLanguageOrder($lang)[1] : $this->config->getDefaultLanguage();
+        $languageOrder = $this->config->getLanguageOrder($lang);
         $props = $this->config->getHierarchyProperty();
         $explicitLanguageTags = $this->config->getShowLangCodes();
-        return $this->getSparql()->queryParentList($uri, $lang, $fallback, $props, $explicitLanguageTags);
+        return $this->getSparql()->queryParentList($uri, $lang, $languageOrder, $props, $explicitLanguageTags);
     }
 
     /**
@@ -349,10 +349,10 @@ class Vocabulary extends DataObject implements Modifiable
     public function getConceptChildren($uri, $lang)
     {
         $lang = $lang ? $lang : $this->getEnvLang();
-        $fallback = count($this->config->getLanguageOrder($lang)) > 1 ? $this->config->getLanguageOrder($lang)[1] : $this->config->getDefaultLanguage();
+        $languageOrder = $this->config->getLanguageOrder($lang);
         $props = $this->config->getHierarchyProperty();
         $explicitLanguageTags = $this->config->getShowLangCodes();
-        return $this->getSparql()->queryChildren($uri, $lang, $fallback, $props, $explicitLanguageTags);
+        return $this->getSparql()->queryChildren($uri, $lang, $languageOrder, $props, $explicitLanguageTags);
     }
 
     /**

--- a/model/Vocabulary.php
+++ b/model/Vocabulary.php
@@ -280,7 +280,9 @@ class Vocabulary extends DataObject implements Modifiable
             $conceptScheme = $this->getDefaultConceptScheme();
         }
 
-        return $this->getSparql()->queryTopConcepts($conceptScheme, $lang, $fallback);
+        $explicitLanguageTags = $this->config->getShowLangCodes();
+
+        return $this->getSparql()->queryTopConcepts($conceptScheme, $lang, $fallback, $explicitLanguageTags);
     }
 
     /**
@@ -336,7 +338,8 @@ class Vocabulary extends DataObject implements Modifiable
         $lang = $lang ? $lang : $this->getEnvLang();
         $fallback = count($this->config->getLanguageOrder($lang)) > 1 ? $this->config->getLanguageOrder($lang)[1] : $this->config->getDefaultLanguage();
         $props = $this->config->getHierarchyProperty();
-        return $this->getSparql()->queryParentList($uri, $lang, $fallback, $props);
+        $explicitLanguageTags = $this->config->getShowLangCodes();
+        return $this->getSparql()->queryParentList($uri, $lang, $fallback, $props, $explicitLanguageTags);
     }
 
     /**
@@ -348,7 +351,8 @@ class Vocabulary extends DataObject implements Modifiable
         $lang = $lang ? $lang : $this->getEnvLang();
         $fallback = count($this->config->getLanguageOrder($lang)) > 1 ? $this->config->getLanguageOrder($lang)[1] : $this->config->getDefaultLanguage();
         $props = $this->config->getHierarchyProperty();
-        return $this->getSparql()->queryChildren($uri, $lang, $fallback, $props);
+        $explicitLanguageTags = $this->config->getShowLangCodes();
+        return $this->getSparql()->queryChildren($uri, $lang, $fallback, $props, $explicitLanguageTags);
     }
 
     /**

--- a/model/sparql/GenericSparql.php
+++ b/model/sparql/GenericSparql.php
@@ -171,7 +171,6 @@ class GenericSparql {
         return $this->qnamecache[$uri];
     }
 
-
     /**
      * Generates the sparql query for retrieving concept and collection counts in a vocabulary.
      * @return string sparql query
@@ -777,6 +776,46 @@ EOQ;
         }
 
         return implode(' UNION ', $typePatterns);
+    }
+
+    /**
+     * Formats sparql query to give results in the language order.
+     * @param string[] $languageOrder An ordered list of languages
+     * @param string $before The query before the language filter
+     * @param string $filterObj The sparql variable name to be used in matching languages
+     * @param string $before The query after the language filter
+     * @param boolean $addWithoutFilter Whether or not to add a general language matching pattern
+     * @return string sparql query clause
+     */
+    protected function formatLanguageOrder($languageOrder, $before, $filterObj, $after = '', $addWithoutFilter = false) {
+        $ret = '';
+        $ltrimmedBefore = ltrim($before);
+        $trimmedBefore = rtrim($ltrimmedBefore);
+        $newLinedBlockIndent = PHP_EOL . substr($before, 0, strlen($before) - strlen($ltrimmedBefore));
+        $newLinedAfterBlockIndent = substr($newLinedBlockIndent, 0, -2);
+        $trimmedAfter = $after ? $newLinedBlockIndent . trim($after) : '';
+        $langClause = 'FILTER (langMatches(lang(' . $filterObj .'), "%s"))';
+
+        foreach ($languageOrder as $lang) {
+            $ret .=
+                'OPTIONAL { ' .
+                $newLinedBlockIndent . $trimmedBefore .
+                $newLinedBlockIndent . sprintf($langClause, $lang) .
+                $trimmedAfter .
+                $newLinedAfterBlockIndent . '}' .
+                $newLinedAfterBlockIndent;
+        }
+
+        if ($addWithoutFilter) {
+            $ret .=
+                'OPTIONAL { ' .
+                $newLinedBlockIndent . $trimmedBefore .
+                $trimmedAfter .
+                $newLinedAfterBlockIndent . '}' .
+                $newLinedAfterBlockIndent;
+        }
+
+        return $ret;
     }
 
     /**
@@ -1753,30 +1792,24 @@ EOQ;
     /**
      * Generates the query for a concepts skos:narrowers.
      * @param string $uri
-     * @param string $lang
-     * @param string $fallback
+     * @param string[] $languageOrder An ordered list of languages
      * @return string sparql query
      */
-    private function generateChildQuery($uri, $lang, $fallback, $props) {
+    private function generateChildQuery($uri, $languageOrder, $props) {
         $uri = is_array($uri) ? $uri[0] : $uri;
         $fcl = $this->generateFromClause();
         $propertyClause = implode('|', $props);
+        $prefLanguageBefore = <<<EOQ
+      ?child skos:prefLabel ?label .
+EOQ;
+        $prefLanguageClause = $this->formatLanguageOrder($languageOrder, $prefLanguageBefore, '?label', '', true);
+
         $query = <<<EOQ
 SELECT ?child ?label ?child ?grandchildren ?notation $fcl WHERE {
   <$uri> a skos:Concept .
   OPTIONAL {
     ?child $propertyClause <$uri> .
-    OPTIONAL {
-      ?child skos:prefLabel ?label .
-      FILTER (langMatches(lang(?label), "$lang"))
-    }
-    OPTIONAL {
-      ?child skos:prefLabel ?label .
-      FILTER (langMatches(lang(?label), "$fallback"))
-    }
-    OPTIONAL { # other language case
-      ?child skos:prefLabel ?label .
-    }
+    $prefLanguageClause
     OPTIONAL {
       ?child skos:notation ?notation .
     }
@@ -1836,12 +1869,12 @@ EOQ;
      * Query the narrower concepts of a concept.
      * @param string $uri
      * @param string $lang
-     * @param string $fallback
+     * @param string[] $languageOrder An ordered list of languages
      * @param boolean $explicitLanguageTags Explicitly show language tag
      * @return array array of arrays describing each child concept, or null if concept doesn't exist
      */
-    public function queryChildren($uri, $lang, $fallback, $props, $explicitLanguageTags = false) {
-        $query = $this->generateChildQuery($uri, $lang, $fallback, $props);
+    public function queryChildren($uri, $lang, $languageOrder, $props, $explicitLanguageTags = false) {
+        $query = $this->generateChildQuery($uri, $languageOrder, $props);
         $result = $this->query($query);
         return $this->transformNarrowerResults($result, $lang, $explicitLanguageTags);
     }
@@ -1850,10 +1883,10 @@ EOQ;
      * Query the top concepts of a vocabulary.
      * @param string $conceptSchemes concept schemes whose top concepts to query for
      * @param string $lang language of labels
-     * @param string $fallback language to use if label is not available in the preferred language
+     * @param string[] $languageOrder An ordered list of languages
      * @param boolean $explicitLanguageTags Explicitly show (add to label) language tag
      */
-    public function queryTopConcepts($conceptSchemes, $lang, $fallback, $explicitLanguageTags = false) {
+    public function queryTopConcepts($conceptSchemes, $lang, $languageOrder, $explicitLanguageTags = false) {
         if (!is_array($conceptSchemes)) {
             $conceptSchemes = array($conceptSchemes);
         }
@@ -1861,20 +1894,14 @@ EOQ;
         $values = $this->formatValues('?topuri', $conceptSchemes, 'uri');
 
         $fcl = $this->generateFromClause();
+        $prefLanguageBefore = <<<EOQ
+    ?top skos:prefLabel ?label .
+EOQ;
+        $prefLanguageClause = $this->formatLanguageOrder($languageOrder, $prefLanguageBefore, '?label', '', true);
         $query = <<<EOQ
 SELECT DISTINCT ?top ?topuri ?label ?notation ?children $fcl WHERE {
   ?top skos:topConceptOf ?topuri .
-  OPTIONAL {
-    ?top skos:prefLabel ?label .
-    FILTER (langMatches(lang(?label), "$lang"))
-  }
-  OPTIONAL {
-    ?top skos:prefLabel ?label .
-    FILTER (langMatches(lang(?label), "$fallback"))
-  }
-  OPTIONAL { # fallback - other language case
-    ?top skos:prefLabel ?label .
-  }
+  $prefLanguageClause
   OPTIONAL { ?top skos:notation ?notation . }
   BIND ( EXISTS { ?top skos:narrower ?a . } AS ?children )
   $values
@@ -1904,13 +1931,20 @@ EOQ;
      * Generates a sparql query for finding the hierarchy for a concept.
 	 * A concept may be a top concept in multiple schemes, returned as a single whitespace-separated literal.
      * @param string $uri concept uri.
-     * @param string $lang
-     * @param string $fallback language to use if label is not available in the preferred language
+     * @param string[] $languageOrder An ordered list of languages
      * @return string sparql query
      */
-    private function generateParentListQuery($uri, $lang, $fallback, $props) {
+    private function generateParentListQuery($uri, $languageOrder, $props) {
         $fcl = $this->generateFromClause();
         $propertyClause = implode('|', $props);
+        $prefLanguageBefore = <<<EOQ
+      ?broad skos:prefLabel ?lab .
+EOQ;
+        $cPrefLanguageBefore = <<<EOQ
+        ?children skos:prefLabel ?childlab .
+EOQ;
+        $prefLanguageClause = $this->formatLanguageOrder($languageOrder, $prefLanguageBefore, '?lab', '', true);
+        $cPrefLanguageClause = $this->formatLanguageOrder($languageOrder,  $cPrefLanguageBefore, '?childlab', '', true);
         $query = <<<EOQ
 SELECT ?broad ?parent ?children ?grandchildren
 (SAMPLE(?lab) as ?label) (SAMPLE(?childlab) as ?childlabel) (GROUP_CONCAT(?topcs; separator=" ") as ?tops) 
@@ -1919,31 +1953,11 @@ WHERE {
   <$uri> a skos:Concept .
   OPTIONAL {
     <$uri> $propertyClause* ?broad .
-    OPTIONAL {
-      ?broad skos:prefLabel ?lab .
-      FILTER (langMatches(lang(?lab), "$lang"))
-    }
-    OPTIONAL {
-      ?broad skos:prefLabel ?lab .
-      FILTER (langMatches(lang(?lab), "$fallback"))
-    }
-    OPTIONAL { # fallback - other language case
-      ?broad skos:prefLabel ?lab .
-    }
+    $prefLanguageClause
     OPTIONAL { ?broad skos:notation ?nota . }
     OPTIONAL { ?broad $propertyClause ?parent . }
     OPTIONAL { ?broad skos:narrower ?children .
-      OPTIONAL {
-        ?children skos:prefLabel ?childlab .
-        FILTER (langMatches(lang(?childlab), "$lang"))
-      }
-      OPTIONAL {
-        ?children skos:prefLabel ?childlab .
-        FILTER (langMatches(lang(?childlab), "$fallback"))
-      }
-      OPTIONAL { # fallback - other language case
-        ?children skos:prefLabel ?childlab .
-      }
+      $cPrefLanguageClause
       OPTIONAL {
         ?children skos:notation ?childnota .
       }
@@ -2045,13 +2059,13 @@ EOQ;
      * Query for finding the hierarchy for a concept.
      * @param string $uri concept uri.
      * @param string $lang
-     * @param string $fallback language to use if label is not available in the preferred language
+     * @param string[] $languageOrder An ordered list of languages
      * @param boolean $explicitLanguageTags Explicitly show language tag
      * @param array $props the hierarchy property/properties to use
      * @return an array for the REST controller to encode.
      */
-    public function queryParentList($uri, $lang, $fallback, $props, $explicitLanguageTags = false) {
-        $query = $this->generateParentListQuery($uri, $lang, $fallback, $props);
+    public function queryParentList($uri, $lang, $languageOrder, $props, $explicitLanguageTags = false) {
+        $query = $this->generateParentListQuery($uri, $languageOrder, $props);
         $result = $this->query($query);
         return $this->transformParentListResults($result, $lang, $explicitLanguageTags);
     }


### PR DESCRIPTION
This PR was build on top of #906 fix as it touches the same parts in code.

Fixes #717, #906.

I release this as a draft PR as tests are not yet adjusted to the changes. Also, I would appreciate any feedback/comments on the proposed solution as changes are still possible. I know, for example, that calling the `query*` functions could be changed (simply dropping out the `lang` parameter) as the required knowledge is already in `languageOrder` array. Additionally, if one could pass or pick the information from the `VocabularyConfig` straightaway there would be no need for similar functions... Or then there could be a single handler at the `Vocalary.php` level for similar functions.