### PR TITLE
Issuexxxx improve http error handling

### DIFF
--- a/controller/WebController.php
+++ b/controller/WebController.php
@@ -386,7 +386,7 @@ class WebController extends Controller
         try {
             $vocabTypes = $this->model->getTypes($request->getVocabid(), $request->getLang());
         } catch (Exception $e) {
-            header("HTTP/1.0 206 Partial Content");
+            header("HTTP/1.0 500 Internal Server Error");
             if ($this->model->getConfig()->getLogCaughtExceptions()) {
                 error_log('Caught exception: ' . $e->getMessage());
             }

--- a/controller/WebController.php
+++ b/controller/WebController.php
@@ -386,7 +386,7 @@ class WebController extends Controller
         try {
             $vocabTypes = $this->model->getTypes($request->getVocabid(), $request->getLang());
         } catch (Exception $e) {
-            header("HTTP/1.0 404 Not Found");
+            header("HTTP/1.0 206 Partial Content");
             if ($this->model->getConfig()->getLogCaughtExceptions()) {
                 error_log('Caught exception: ' . $e->getMessage());
             }
@@ -394,6 +394,8 @@ class WebController extends Controller
             echo $template->render(
                 array(
                     'languages' => $this->languages,
+                    'vocab' => $vocab,
+                    'request' => $request,
                 ));
 
             return;

--- a/controller/WebController.php
+++ b/controller/WebController.php
@@ -550,6 +550,7 @@ class WebController extends Controller
             array(
                 'languages' => $this->languages,
                 'request' => $request,
+                'vocab' => $request->getVocab(),
                 'message' => $message,
                 'requested_page' => filter_input(INPUT_SERVER, 'REQUEST_URI', FILTER_SANITIZE_STRING),
             ));

--- a/model/DataObject.php
+++ b/model/DataObject.php
@@ -46,10 +46,15 @@ class DataObject
     protected function getExternalLabel($exvoc, $exuri, $lang)
     {
         if ($exvoc) {
-            $exsparql = $exvoc->getSparql();
-            $results = $exsparql->queryLabel($exuri, $lang);
-
-            return isset($results[$lang]) ? $results[$lang] : null;
+            try {
+                $exsparql = $exvoc->getSparql();
+                $results = $exsparql->queryLabel($exuri, $lang);
+                return isset($results[$lang]) ? $results[$lang] : null;
+            } catch (EasyRdf\Http\Exception | EasyRdf\Exception | Throwable $e) {
+                if ($this->model->getConfig()->getLogCaughtExceptions()) {
+                    error_log('Caught exception: ' . $e->getMessage());
+                }
+            }
         }
         return null;
     }
@@ -63,9 +68,15 @@ class DataObject
     protected function getExternalNotation($exvoc, $exuri)
     {
         if ($exvoc) {
-            $exsparql = $exvoc->getSparql();
-            $results = $exsparql->queryNotation($exuri);
-            return isset($results) ? $results : null;
+            try {
+                $exsparql = $exvoc->getSparql();
+                $results = $exsparql->queryNotation($exuri);
+                return isset($results) ? $results : null;
+            } catch (EasyRdf\Http\Exception | EasyRdf\Exception | Throwable $e) {
+                if ($this->model->getConfig()->getLogCaughtExceptions()) {
+                    error_log('Caught exception: ' . $e->getMessage());
+                }
+            }
         }
         return null;
     }

--- a/model/Model.php
+++ b/model/Model.php
@@ -470,11 +470,18 @@ class Model
         if($preferredVocabId != null) {
             foreach ($vocabs as $vocab) {
                 if($vocab->getId() == $preferredVocabId) {
-                    // double check that a label exists in the preferred vocabulary
-                    if ($vocab->getConceptLabel($uri, null) !== null) {
-                        return $vocab;
-                    } else {
-                        // not found in preferred vocabulary, fall back to next method
+                    try {
+                        // double check that a label exists in the preferred vocabulary
+                        if ($vocab->getConceptLabel($uri, null) !== null) {
+                            return $vocab;
+                        } else {
+                            // not found in preferred vocabulary, fall back to next method
+                            break;
+                        }
+                    } catch (EasyRdf\Http\Exception | EasyRdf\Exception | Throwable $e) {
+                        if ($this->getConfig()->getLogCaughtExceptions()) {
+                            error_log('Caught exception: ' . $e->getMessage());
+                        }
                         break;
                     }
                 }
@@ -483,8 +490,16 @@ class Model
 
         // no preferred vocabulary, or it was not found, search in which vocabulary the concept has a label
         foreach ($vocabs as $vocab) {
-            if ($vocab->getConceptLabel($uri, null) !== null)
-                return $vocab;
+            try {
+                if ($vocab->getConceptLabel($uri, null) !== null) {
+                    return $vocab;
+                }
+            } catch (EasyRdf\Http\Exception | EasyRdf\Exception | Throwable $e) {
+                if ($this->getConfig()->getLogCaughtExceptions()) {
+                    error_log('Caught exception: ' . $e->getMessage());
+                }
+                break;
+            }
         }
 
         // if the URI couldn't be found, fall back to the first vocabulary

--- a/model/Vocabulary.php
+++ b/model/Vocabulary.php
@@ -164,7 +164,7 @@ class Vocabulary extends DataObject implements Modifiable
             // query everything the endpoint knows about the ConceptScheme
             $sparql = $this->getSparql();
             $result = $sparql->queryConceptScheme($defaultcs);
-        } catch (EasyRdf\Http\Exception | EasyRdf\Exception $e) {
+        } catch (EasyRdf\Http\Exception | EasyRdf\Exception | Throwable $e) {
              if ($this->model->getConfig()->getLogCaughtExceptions()) {
                  error_log('Caught exception: ' . $e->getMessage());
              }
@@ -234,8 +234,15 @@ class Vocabulary extends DataObject implements Modifiable
         if ($lang === '') {
             $lang = $this->getEnvLang();
         }
-
-        return $this->getSparql()->queryConceptSchemes($lang);
+        $conceptSchemes = null;
+        try {
+            $conceptSchemes = $this->getSparql()->queryConceptSchemes($lang);
+        } catch (EasyRdf\Http\Exception | EasyRdf\Exception | Exception | Throwable $e) {
+             if ($this->model->getConfig()->getLogCaughtExceptions()) {
+                 error_log('Caught exception: ' . $e->getMessage());
+             }
+        }
+        return $conceptSchemes;
     }
 
     /**

--- a/model/Vocabulary.php
+++ b/model/Vocabulary.php
@@ -432,8 +432,15 @@ class Vocabulary extends DataObject implements Modifiable
     public function getConceptInfo($uri, $clang)
     {
         $sparql = $this->getSparql();
-
-        return $sparql->queryConceptInfo($uri, $this->config->getArrayClassURI(), array($this), $clang);
+        $conceptInfo = null;
+        try {
+            $conceptInfo = $sparql->queryConceptInfo($uri, $this->config->getArrayClassURI(), array($this), $clang);
+        } catch (EasyRdf\Http\Exception | EasyRdf\Exception | Exception | Throwable $e) {
+             if ($this->model->getConfig()->getLogCaughtExceptions()) {
+                 error_log('Caught exception: ' . $e->getMessage());
+             }
+        }
+        return $conceptInfo;
     }
 
     /**

--- a/model/Vocabulary.php
+++ b/model/Vocabulary.php
@@ -157,12 +157,19 @@ class Vocabulary extends DataObject implements Modifiable
             }
         }
 
-        // also include ConceptScheme metadata from SPARQL endpoint
-        $defaultcs = $this->getDefaultConceptScheme();
+        try {
+            // also include ConceptScheme metadata from SPARQL endpoint
+            $defaultcs = $this->getDefaultConceptScheme();
 
-        // query everything the endpoint knows about the ConceptScheme
-        $sparql = $this->getSparql();
-        $result = $sparql->queryConceptScheme($defaultcs);
+            // query everything the endpoint knows about the ConceptScheme
+            $sparql = $this->getSparql();
+            $result = $sparql->queryConceptScheme($defaultcs);
+        } catch (EasyRdf\Http\Exception | EasyRdf\Exception $e) {
+             if ($this->model->getConfig()->getLogCaughtExceptions()) {
+                 error_log('Caught exception: ' . $e->getMessage());
+             }
+             return null;
+        }
         $conceptscheme = $result->resource($defaultcs);
         $this->order = array("dc:title", "dc11:title", "skos:prefLabel", "rdfs:label", "dc:subject", "dc11:subject", "dc:description", "dc11:description", "dc:publisher", "dc11:publisher", "dc:creator", "dc11:creator", "dc:contributor", "dc:language", "dc11:language", "owl:versionInfo", "dc:source", "dc11:source");
 

--- a/model/Vocabulary.php
+++ b/model/Vocabulary.php
@@ -237,7 +237,7 @@ class Vocabulary extends DataObject implements Modifiable
         $conceptSchemes = null;
         try {
             $conceptSchemes = $this->getSparql()->queryConceptSchemes($lang);
-        } catch (EasyRdf\Http\Exception | EasyRdf\Exception | Exception | Throwable $e) {
+        } catch (EasyRdf\Http\Exception | EasyRdf\Exception | Throwable $e) {
              if ($this->model->getConfig()->getLogCaughtExceptions()) {
                  error_log('Caught exception: ' . $e->getMessage());
              }
@@ -435,7 +435,7 @@ class Vocabulary extends DataObject implements Modifiable
         $conceptInfo = null;
         try {
             $conceptInfo = $sparql->queryConceptInfo($uri, $this->config->getArrayClassURI(), array($this), $clang);
-        } catch (EasyRdf\Http\Exception | EasyRdf\Exception | Exception | Throwable $e) {
+        } catch (EasyRdf\Http\Exception | EasyRdf\Exception | Throwable $e) {
              if ($this->model->getConfig()->getLogCaughtExceptions()) {
                  error_log('Caught exception: ' . $e->getMessage());
              }

--- a/resource/css/styles.css
+++ b/resource/css/styles.css
@@ -1074,7 +1074,7 @@ li.sub-group {
   right: 0;
 }
 
-.page-alert > h3 {
+.frontpage-alert > h3, .page-alert > h3 {
   margin: 10px 0px;
 }
 

--- a/resource/css/styles.css
+++ b/resource/css/styles.css
@@ -422,6 +422,10 @@ ul.dropdown-menu > li:last-child > input {
   margin: 10px 15px;
 }
 
+.search-result-listing > .alert > h4 {
+  margin: 10px 0px;
+}
+
 .search-result-listing .search-count {
   text-align: left;
   margin-left: 15px;
@@ -1068,6 +1072,10 @@ li.sub-group {
   display: inline-block;
   position: absolute;
   right: 0;
+}
+
+.page-alert > h3 {
+  margin: 10px 0px;
 }
 
 .alert h2 {

--- a/resource/css/styles.css
+++ b/resource/css/styles.css
@@ -943,6 +943,21 @@ div#sidebar-grey > div > div > form.search-options {
   top: 10px;
 }
 
+.search-result-listing .alert .btn-default {
+  position: unset;
+  vertical-align: unset;
+  margin-left: 15px;
+  font-size: 18px;
+}
+
+.alert h4, .alert h3  {
+  display: inline;
+}
+
+.search-result-listing .alert-warning h4 {
+  display: block;
+}
+
 .search-options .mCSB_container > li > a > .radio {
   margin: 0;
   padding-left: 25px;

--- a/resource/css/styles.css
+++ b/resource/css/styles.css
@@ -418,6 +418,10 @@ ul.dropdown-menu > li:last-child > input {
   margin: 15px;
 }
 
+.search-result-listing > .alert {
+  margin: 10px 15px;
+}
+
 .search-result-listing .search-count {
   text-align: left;
   margin-left: 15px;

--- a/resource/js/docready.js
+++ b/resource/js/docready.js
@@ -835,7 +835,7 @@ $(function() { // DOCUMENT READY
       $('.search-result-listing').append($ready);
     }
     else {
-      $trigger.waypoint(function() { waypointCallback(); }, options);
+      $trigger.waypoint(function() { waypointCallback(this); }, options);
     }
   }
 
@@ -881,9 +881,13 @@ $(function() { // DOCUMENT READY
     changeOffset += 200;
   }
 
-  function waypointCallback() {
+  function waypointCallback(waypoint) {
+    if ($('.search-result-listing > p .spinner,.search-result-listing .alert-danger').length > 0) {
+      return false;
+    }
     var number_of_hits = $(".search-result").length;
-    if (number_of_hits < parseInt($('.search-count p').text().substr(0, $('.search-count p').text().indexOf(' ')), 10)) { $('.search-result-listing').append($loading);
+    if (number_of_hits < parseInt($('.search-count p').text().substr(0, $('.search-count p').text().indexOf(' ')), 10)) {
+      $('.search-result-listing').append($loading);
       var typeLimit = $('#type-limit').val();
       var schemeLimit = $('#scheme-limit').val();
       var groupLimit = $('#group-limit').val();
@@ -903,7 +907,20 @@ $(function() { // DOCUMENT READY
             $('.search-result-listing').append($ready);
             return false;
           }
-          $('.search-result:nth-last-of-type(4)').waypoint(function() { waypointCallback(); }, options );
+          waypoint.destroy();
+          $('.search-result:nth-last-of-type(4)').waypoint(function() { waypointCallback(this); }, options );
+        },
+        error: function(jqXHR, textStatus, errorThrown) {
+          $loading.detach();
+          var $failedSearch = $('<div class="alert alert-danger"><h4>Error: Loading for more items failed!</h4></div>');
+          var $retryButton = $('<button class="btn btn-default" type="button">Retry</button>');
+          $retryButton.on('click', function () {
+            $failedSearch.remove();
+            waypointCallback(waypoint);
+            return false;
+          });
+          $failedSearch.append($retryButton)
+          $('.search-result-listing').append($failedSearch);
         }
       });
     }

--- a/resource/js/docready.js
+++ b/resource/js/docready.js
@@ -1042,9 +1042,9 @@ $(function() { // DOCUMENT READY
   }
 
   /* makes an AJAX query for the alphabetical index contents when landing on
-   * the vocabulary home page.
+   * the vocabulary home page or on the vocabulary concept error page.
    */
-  if ($('#alpha').hasClass('active') && $('#vocab-info').length === 1 && $('.alphabetical-search-results').length === 0) {
+  if ($('#alpha').hasClass('active') && $('#vocab-info,.page-alert').length == 1 && $('.alphabetical-search-results').length == 0) {
     // taking into account the possibility that the lang parameter has been changed by the WebController.
     var urlLangCorrected = vocab + '/' + lang + '/index?limit=250&offset=0&clang=' + clang;
     $('.sidebar-grey').empty().append('<div class="loading-spinner"><span class="spinner-text">'+ loading_text + '</span><span class="spinner" /></div>');

--- a/resource/js/scripts.js
+++ b/resource/js/scripts.js
@@ -157,7 +157,8 @@ function loadLimitedResults(parameters) {
   clearResultsAndAddSpinner();
   $.ajax({
     data: parameters,
-    success : function(data) {
+    complete : function(jqXHR, textStatus) {
+      var data = jqXHR.responseText;
       var response = $('.search-result-listing', data).html();
       if (window.history.pushState) { window.history.pushState({url: this.url}, '', this.url); }
       $('.search-result-listing').append(response);

--- a/view/error-page.twig
+++ b/view/error-page.twig
@@ -1,11 +1,18 @@
 {% extends "light.twig" %}
 {% block title %}: Error page{% endblock %}
 {% block error %}
+{% spaceless %}
+{% set pageError = request.vocabid != '' and request.page == 'page' %}
+{% if pageError %}
 <div id="maincontent">
   <div class="content">
+{% endif %}
     <div class="alert {% if request.vocabid != '' or request.page == 'feedback' or request.page == 'about' %}page-alert{% else %}frontpage-alert{% endif %}">
       <h3>{% if not message %}{% trans %}404 Error: The page {{ requested_page }} cannot be found.{% endtrans %}{% else %}{{ message }}{% endif %}</h3>
     </div>
+{% if pageError %}
   </div>
 </div>
+{% endif %}
+{% endspaceless %}
 {% endblock %}

--- a/view/error-page.twig
+++ b/view/error-page.twig
@@ -1,7 +1,11 @@
 {% extends "light.twig" %}
 {% block title %}: Error page{% endblock %}
 {% block error %}
-  <div class="alert {% if request.vocabid != '' or request.page == 'feedback' or request.page == 'about' %}page-alert{% else %}frontpage-alert{% endif %}">
-    <h3>{% if not message %}{% trans %}404 Error: The page {{ requested_page }} cannot be found.{% endtrans %}{% else %}{{ message }}{% endif %}</h3>
+<div id="maincontent">
+  <div class="content">
+    <div class="alert {% if request.vocabid != '' or request.page == 'feedback' or request.page == 'about' %}page-alert{% else %}frontpage-alert{% endif %}">
+      <h3>{% if not message %}{% trans %}404 Error: The page {{ requested_page }} cannot be found.{% endtrans %}{% else %}{{ message }}{% endif %}</h3>
+    </div>
   </div>
+</div>
 {% endblock %}

--- a/view/headerbar.twig
+++ b/view/headerbar.twig
@@ -7,7 +7,7 @@
 <div class="header-float">
 {% if request.page != 'About' and request.page != 'Feedback' %}
 
-  {% if request.page != '' %}<div class="search-vocab-text"><p>{% trans "Content language" %}</p></div>{% endif %}
+  {% if request.page != '' and not global_search %}<div class="search-vocab-text"><p>{% trans "Content language" %}</p></div>{% endif %}
   {% if sorted_vocabs is defined %}
     <label class="sr-only" for="multiselect">{% trans "Search from vocabulary" %}</label>
     <select class="multiselect" id="multiselect" multiple="multiple">

--- a/view/search-result.twig
+++ b/view/search-result.twig
@@ -2,7 +2,15 @@
 <div class="search-count{% if limit_type or limit_parent or limit_group or limit_scheme %} search-limited{% endif %}"><p>{% trans %}{{ search_count }} results for '{{ term }}'{% endtrans %}{% if limit_type %}, {% trans "limited to type" %} '{% for type in limit_type %}{{ type }}{% if loop.last == false %}, {% endif %}{% endfor %}'{% endif %}{% if limit_parent %}, {% trans "limited to parent" %} '{{ limit_parent }}'{% endif %}{% if limit_group %}, {% trans "limited to group" %} '{{ limit_group }}'{% endif %}{% if limit_scheme %}, {% trans "limited to scheme" %} '{% for scheme in limit_scheme %}{{ scheme }}{% if loop.last == false %}, {% endif %}{% endfor %}'{% endif %}</p>
 </div>{% if limit_type or limit_parent or limit_group or limit_scheme %}<button type="button" class="btn btn-default" id="remove-limits">{% trans "Clear limitations" %}</button>{% endif %}
 {% endif %}
-{% if search_results is defined and search_results|length == 0 %}<p class="no-results">{% trans 'The search provided no results.' %}</p>{% endif %}
+{% if global_search and not search_failed and skipped_vocabs|length > 0 %}
+<div class="alert alert-warning">
+{% for voc in skipped_vocabs %}
+{% set vocTitle = voc.title %}
+<h4>{% trans %}Warning: Skipped searching from '{{vocTitle}}' vocabulary!{% endtrans %}</h4>
+{% endfor %}
+</div>
+{% endif %}
+{% if search_results is not null and search_results|length == 0 %}<p class="no-results">{% trans 'The search provided no results.' %}</p>{% endif %}
 {% for concept in search_results %} {# loop through the hits #}
 <div class="search-result">
   {% spaceless %}

--- a/view/search-result.twig
+++ b/view/search-result.twig
@@ -2,7 +2,7 @@
 <div class="search-count{% if limit_type or limit_parent or limit_group or limit_scheme %} search-limited{% endif %}"><p>{% trans %}{{ search_count }} results for '{{ term }}'{% endtrans %}{% if limit_type %}, {% trans "limited to type" %} '{% for type in limit_type %}{{ type }}{% if loop.last == false %}, {% endif %}{% endfor %}'{% endif %}{% if limit_parent %}, {% trans "limited to parent" %} '{{ limit_parent }}'{% endif %}{% if limit_group %}, {% trans "limited to group" %} '{{ limit_group }}'{% endif %}{% if limit_scheme %}, {% trans "limited to scheme" %} '{% for scheme in limit_scheme %}{{ scheme }}{% if loop.last == false %}, {% endif %}{% endfor %}'{% endif %}</p>
 </div>{% if limit_type or limit_parent or limit_group or limit_scheme %}<button type="button" class="btn btn-default" id="remove-limits">{% trans "Clear limitations" %}</button>{% endif %}
 {% endif %}
-{% if search_results and search_results|length == 0 %}<p class="no-results">{% trans 'The search provided no results.' %}</p>{% endif %}
+{% if search_results is defined and search_results|length == 0 %}<p class="no-results">{% trans 'The search provided no results.' %}</p>{% endif %}
 {% for concept in search_results %} {# loop through the hits #}
 <div class="search-result">
   {% spaceless %}

--- a/view/search-result.twig
+++ b/view/search-result.twig
@@ -2,7 +2,7 @@
 <div class="search-count{% if limit_type or limit_parent or limit_group or limit_scheme %} search-limited{% endif %}"><p>{% trans %}{{ search_count }} results for '{{ term }}'{% endtrans %}{% if limit_type %}, {% trans "limited to type" %} '{% for type in limit_type %}{{ type }}{% if loop.last == false %}, {% endif %}{% endfor %}'{% endif %}{% if limit_parent %}, {% trans "limited to parent" %} '{{ limit_parent }}'{% endif %}{% if limit_group %}, {% trans "limited to group" %} '{{ limit_group }}'{% endif %}{% if limit_scheme %}, {% trans "limited to scheme" %} '{% for scheme in limit_scheme %}{{ scheme }}{% if loop.last == false %}, {% endif %}{% endfor %}'{% endif %}</p>
 </div>{% if limit_type or limit_parent or limit_group or limit_scheme %}<button type="button" class="btn btn-default" id="remove-limits">{% trans "Clear limitations" %}</button>{% endif %}
 {% endif %}
-{% if search_results|length == 0 %}<p class="no-results">{% trans 'The search provided no results.' %}</p>{% endif %}
+{% if search_results and search_results|length == 0 %}<p class="no-results">{% trans 'The search provided no results.' %}</p>{% endif %}
 {% for concept in search_results %} {# loop through the hits #}
 <div class="search-result">
   {% spaceless %}

--- a/view/vocab-search-listing.twig
+++ b/view/vocab-search-listing.twig
@@ -5,12 +5,12 @@
 {% block content %}
 <div class="search-result-listing">
   {% include 'search-result.twig' %}
-  {% if search_results is not defined and not global_search %}
+  {% if search_results is null %}
   <div class="alert alert-danger">
-    {% if request.vocabid == 'null' %}
+    {% if request.vocabid == 'null' and not global_search %}
     <h4>{% trans %}Error: Requested vocabulary not found!{% endtrans %}</h4>
     {% else %}
-    <h4>{% trans %}Error: Search failed for vocabulary!{% endtrans %}</h4>
+    <h4>{% trans %}Error: Search failed!{% endtrans %}</h4>
     {% endif %}
   </div>
   {% endif %}

--- a/view/vocab-search-listing.twig
+++ b/view/vocab-search-listing.twig
@@ -5,9 +5,13 @@
 {% block content %}
 <div class="search-result-listing">
   {% include 'search-result.twig' %}
-  {% if request.vocabid == 'null' and not global_search %}
+  {% if not search_results and request.vocabid == 'null' and not global_search %}
   <div class="alert alert-danger">
     <h4>{% trans %}Error: Requested vocabulary not found!{% endtrans %}</h4>
+  </div>
+  {% elseif not search_results and request.vocabid and not global_search %}
+  <div class="alert alert-danger">
+    <h4>{% trans %}Error: Search failed for vocabulary!{% endtrans %}</h4>
   </div>
   {% endif %}
 </div>

--- a/view/vocab-search-listing.twig
+++ b/view/vocab-search-listing.twig
@@ -5,13 +5,13 @@
 {% block content %}
 <div class="search-result-listing">
   {% include 'search-result.twig' %}
-  {% if not search_results and request.vocabid == 'null' and not global_search %}
+  {% if search_results is not defined and not global_search %}
   <div class="alert alert-danger">
+    {% if request.vocabid == 'null' %}
     <h4>{% trans %}Error: Requested vocabulary not found!{% endtrans %}</h4>
-  </div>
-  {% elseif not search_results and request.vocabid and not global_search %}
-  <div class="alert alert-danger">
+    {% else %}
     <h4>{% trans %}Error: Search failed for vocabulary!{% endtrans %}</h4>
+    {% endif %}
   </div>
   {% endif %}
 </div>

--- a/view/vocab-shared.twig
+++ b/view/vocab-shared.twig
@@ -7,7 +7,7 @@
     {% set vocabInfo = vocab.info(request.contentLang) %}
     {% if not vocabInfo %}
     <div class="alert alert-danger" role="alert">
-        {% trans "Failed to retrieve vocabulary information" %}
+        {% trans "Error: Failed to retrieve vocabulary information!" %}
     </div>
     {% else %}
     <div class="vocab-info-literals">

--- a/view/vocab-shared.twig
+++ b/view/vocab-shared.twig
@@ -4,9 +4,15 @@
       <h1>{% trans "Vocabulary information" %}</h1>
       <hr />
     </div>
+    {% set vocabInfo = vocab.info(request.contentLang) %}
+    {% if not vocabInfo %}
+    <div class="alert alert-danger" role="alert">
+        {% trans "Failed to retrieve vocabulary information" %}
+    </div>
+    {% else %}
     <div class="vocab-info-literals">
       <table class="table">
-        {% for key, values in vocab.info(request.contentLang) %}
+        {% for key, values in vocabInfo %}
         {% set keytrans = key %}
         <tr>
           <th class="versal">{{ keytrans|trans|upper }}</th>
@@ -24,6 +30,7 @@
         </tr>
       </table>
     </div>
+    {% endif %}
     {% if vocab.config.showStatistics %}
     <div>
       <h2>{% trans "Resource counts by type" %}</h2>


### PR DESCRIPTION
This PR fixes a bunch or problems in current code.

Fixes the following listed issues:
Fixes #693
Fixes #721
Fixes #722
Fixes #723
Fixes #1011 

Addresses #759 in the sense that it could be implemented in a similar way (add a retry button/handle ajax failure)

Adds PHP fatal error checks for various easyrdf http client induced errors. E.g., doesn't crash the UI in the usual cases for a non-responding SPARQL endpoint (some may still exist).
Global search: adds a warning for every selected, non-default endpoint vocabularies.

Searches may now return 500 Internal Server Error, which on turn is utilized by Ajax queries. Please note that not every failure results in an HTTP 500 Error.
Waypoint system in searches is fixed; no more extra requests.

TODO/open questions:
* Should global search warnings lie above the number of results?
* Translations for various new JS and Twig template variables
* Tests? (and for which part)
* Is the way errors are handled here the best possible?
* Add a retry button to other parts of UI?
* Is the usage of HTTP 500 good as it is?
* Sidebar could be separated for good from the content area, this PR only has started the process.
* Also, it is possible to merge the functionality of Skosmos into a single page app by developing this a bit further.
