### PR TITLE
Fix error in swagger spec for search method return value

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -1458,7 +1458,7 @@
         "uri": {
           "type": "string"
         },
-        "vocabularies": {
+        "results": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/SearchResult"
@@ -1467,7 +1467,7 @@
       },
       "required": [
         "uri",
-        "vocabularies"
+        "results"
       ]
     },
     "SearchResult": {


### PR DESCRIPTION
The `results` field, which contains the search results, was incorrectly called `vocabularies` in the swagger spec - looks like a copy-paste error.