### PR TITLE
Add HTML classes for properties so they can be targeted in JS and CSS

### DIFF
--- a/model/ConceptProperty.php
+++ b/model/ConceptProperty.php
@@ -62,6 +62,14 @@ class ConceptProperty
     }
 
     /**
+     * Returns an alphanumeric ID for the property, suitable for use as a CSS identifier.
+     */
+    public function getID()
+    {
+        return preg_replace('/[^A-Za-z0-9-]/', '_', $this->prop);
+    }
+
+    /**
      * Returns text for the property tooltip.
      * @return string
      */

--- a/resource/js/scripts.js
+++ b/resource/js/scripts.js
@@ -433,6 +433,7 @@ function loadMappingProperties(concept, lang, contentLang, $htmlElement, concept
         if (!found) {
           conceptProperty = {
             'type': conceptMappingPropertyValue.type[0],
+            'id': conceptMappingPropertyValue.type[0].replace(/[^A-Za-z-]/g, '_'),
             'label': conceptMappingPropertyValue.typeLabel,
             'notation': conceptMappingPropertyValue.notation,
             'description': conceptMappingPropertyValue.description,

--- a/tests/ConceptPropertyTest.php
+++ b/tests/ConceptPropertyTest.php
@@ -147,4 +147,23 @@ class ConceptPropertyTest extends PHPUnit\Framework\TestCase
     $props = $concept->getProperties();
     $this->assertEquals('skos:hiddenLabel', $props['subclass:prop1']->getSubPropertyOf());
   }
+
+  /**
+   * @covers ConceptProperty::getID
+   */
+  public function testGetIDShortenedURI()
+  {
+    $prop = new ConceptProperty('skosmos:testLabel', 'Test label');
+    $this->assertEquals('skosmos_testLabel', $prop->getID());
+  }
+
+  /**
+   * @covers ConceptProperty::getID
+   */
+  public function testGetIDFullURI()
+  {
+    $prop = new ConceptProperty('http://rdaregistry.info/Elements/a/P50008', 'has hierarchical superior');
+    $this->assertEquals('http___rdaregistry_info_Elements_a_P50008', $prop->getID());
+  }
+
 }

--- a/view/concept-shared.twig
+++ b/view/concept-shared.twig
@@ -166,7 +166,7 @@
 {% verbatim %}
 <template id="property-mappings-template">
     {{#each properties}}
-    <div class="row{{#ifDeprecated concept.type 'skosext:DeprecatedConcept'}} deprecated{{/ifDeprecated}} property prop-mapping">
+    <div class="row{{#ifDeprecated concept.type 'skosext:DeprecatedConcept'}} deprecated{{/ifDeprecated}} property prop-{{ id }}">
         <div class="property-label"><span class="versal{{#ifNotInDescription type description}} property-click" title="{{ description }}{{/ifNotInDescription}}">{{toUpperCase label}}</span></div>
         <div class="property-value-column">
             {{#each values }} {{! loop through ConceptPropertyValue objects }}

--- a/view/concept-shared.twig
+++ b/view/concept-shared.twig
@@ -39,7 +39,7 @@
         </div>
       {% endif %}
       {% spaceless %}
-      <div class="row{% if concept.type == 'skosext:DeprecatedConcept' %} deprecated{% endif %}">
+      <div class="row{% if concept.type == 'skosext:DeprecatedConcept' %} deprecated{% endif %} property prop-preflabel">
         <div class="property-label property-label-pref">
           <span class="versal">{% set subPrefLabelTranslation = concept.preferredSubpropertyLabelTranslation(request.lang) %}{% if subPrefLabelTranslation %}{{ subPrefLabelTranslation|upper }}{% else %}{{ 'skos:prefLabel'|trans|upper }}{% endif %}</span>
         </div>
@@ -60,7 +60,7 @@
       {% endspaceless %}
       {% for property in concept.properties %} {# loop through ConceptProperty objects #}
         {% if property.getSubPropertyOf != 'skos:hiddenLabel' %}
-        <div class="row{% if property.type == 'dc:isReplacedBy' %} replaced-by{% endif%}">
+        <div class="row{% if property.type == 'dc:isReplacedBy' %} replaced-by{% endif%} property prop-{{property.ID}}">
           <div class="property-label">
             <span class="versal{% if property.type == 'rdf:type' %}-bold{% endif %}{% if property.description %} property-click" title="{{ property.description }}{% endif %}">{{ property.label|upper }}</span>
           </div>
@@ -113,7 +113,7 @@
       {% endfor %}
       {% set foreignLabels = concept.foreignLabels %}
       {% if foreignLabels %}
-      <div class="row">
+      <div class="row property prop-other-languages">
         <div class="property-label"><span class="versal property-click" title="{% trans "foreign prefLabel help" %}" >{{ 'foreign prefLabels'|trans|upper }}</span></div>
         <div class="property-value-column"><div class="property-value-wrapper">
           {% for language,labels in foreignLabels %}
@@ -127,7 +127,7 @@
           </div>
         </div></div>
       {% endif %}
-        <div class="row">
+        <div class="row property prop-uri">
             <div class="property-label"><span class="versal">URI</span></div>
             <div class="property-value-column"><div class="property-value-wrapper"><span class="versal uri-input-box" id="uri-input-box">{{ concept.uri }}</span> <button type="button" data-toggle="tooltip" data-placement="button" title="Copy to clipboard" class="btn btn-default btn-xs copy-clipboard" for="#uri-input-box"><span class="glyphicon glyphicon-copy" aria-hidden="true"></span></button></div></div>
         </div>
@@ -166,7 +166,7 @@
 {% verbatim %}
 <template id="property-mappings-template">
     {{#each properties}}
-    <div class="row{{#ifDeprecated concept.type 'skosext:DeprecatedConcept'}} deprecated{{/ifDeprecated}}">
+    <div class="row{{#ifDeprecated concept.type 'skosext:DeprecatedConcept'}} deprecated{{/ifDeprecated}} property prop-mapping">
         <div class="property-label"><span class="versal{{#ifNotInDescription type description}} property-click" title="{{ description }}{{/ifNotInDescription}}">{{toUpperCase label}}</span></div>
         <div class="property-value-column">
             {{#each values }} {{! loop through ConceptPropertyValue objects }}


### PR DESCRIPTION
Fixes #1034

All the `div` blocks which represent properties will get a HTML class `property`.

Additionally, those `div`s will get a specific class identifying the property in question. Usually, the class identifier is generated from the property URI:

1. For known property URIs that can be shortened, the class will be e.g. `prop-dc_identifier` or `prop-skos_broader`
2. For unknown URI namespaces that cannot be shortened, the class will be derived from the full URI, e.g. `prop-http___rdaregistry_info_Elements_a_P50008` (for [rdaa:P50008](http://rdaregistry.info/Elements/a/P50008) - but the `rdaa` prefix is not known by Skosmos)

There are a few special cases for some `div` blocks representing special purpose properties:

* preferred label property: `prop-preflabel`
* other languages property: `prop-other-languages`
* URI "property": `prop-uri`
* mapping properties: `prop-mapping`

Any comments @CaptSolo @kinow?