### PR TITLE
update twig; references #918

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,7 @@
     "davidstutz/bootstrap-multiselect": "v0.9.13",
     "easyrdf/easyrdf": "0.10.0-alpha.1",
     "etdsolutions/waypoints": "4.0.0",
-    "twig/twig": "2.4.*",
+    "twig/twig": "2.13.*",
     "twig/extensions": "1.5.*",
     "twitter/bootstrap": "3.3.*",
     "twitter/typeahead.js": "v0.10.5",


### PR DESCRIPTION
This PR will update Twig to the latest 2.13.x series. This will enable one to use any new features added to Twig after 2.4.x, including better whitespace control, see https://twig.symfony.com/doc/2.x/templates.html#whitespace-control for more information. This makes it possible to, in the future, cut one-liners into multiple lines.

This PR will not, however, correct any newly deprecated Twig features used in code. This will be left for future 3.x upgrade.