### PR TITLE
Accessibility improvements for keyboard / tab key navigation

### DIFF
--- a/resource/css/styles.css
+++ b/resource/css/styles.css
@@ -1424,8 +1424,8 @@ ul.nav-tabs > li {
 }
 
 #skiptocontent:focus {
-  top: auto;
-  left: 1.5em;
+  top: 0.5em;
+  left: 0.5em;
   height: auto;
   width: auto;
   background-color: white;

--- a/resource/css/styles.css
+++ b/resource/css/styles.css
@@ -254,8 +254,9 @@ ul {
   border-top-color: #ffffff;
 }
 
-#lang-dropdown-toggle:focus, .multiselect:focus {
+#lang-dropdown-toggle:focus, .multiselect:focus, #search-all-button:focus {
   outline: 3px solid white;
+  background-color: #00748f;
 }
 
 .navbar-form .dropdown-menu {

--- a/resource/css/styles.css
+++ b/resource/css/styles.css
@@ -342,7 +342,6 @@ ul.dropdown-menu > li:last-child > input {
 
 .header-left > h1 > a {
   color: #ffffff;
-  display: block;
   height: 50px;
 }
 

--- a/resource/css/styles.css
+++ b/resource/css/styles.css
@@ -254,6 +254,10 @@ ul {
   border-top-color: #ffffff;
 }
 
+#lang-dropdown-toggle:focus {
+  outline: 3px solid white;
+}
+
 .navbar-form .dropdown-menu {
   border-radius: 0;
   margin-top: 0;

--- a/resource/css/styles.css
+++ b/resource/css/styles.css
@@ -88,10 +88,7 @@ a, a.versal, .jstree-node > .jstree-anchor {
 }
 
 a:link,a:visited,a:active,a:hover,a:focus {
-  /* Improves link handling by removing focus borders. Sorry keyboard users! */
-  border: 0;
-  outline: none;
-  text-decoration: none !important;
+  text-decoration: none;
 }
 
 a:hover {

--- a/resource/css/styles.css
+++ b/resource/css/styles.css
@@ -89,6 +89,7 @@ a, a.versal, .jstree-node > .jstree-anchor {
 
 a:link,a:visited,a:active,a:hover,a:focus {
   text-decoration: none;
+  outline-offset: 2px;
 }
 
 a:hover {

--- a/resource/css/styles.css
+++ b/resource/css/styles.css
@@ -254,7 +254,7 @@ ul {
   border-top-color: #ffffff;
 }
 
-#lang-dropdown-toggle:focus {
+#lang-dropdown-toggle:focus, .multiselect:focus {
   outline: 3px solid white;
 }
 

--- a/resource/css/styles.css
+++ b/resource/css/styles.css
@@ -92,6 +92,10 @@ a:link,a:visited,a:active,a:hover,a:focus {
   outline-offset: 2px;
 }
 
+:focus {
+  outline: 2px solid black;
+}
+
 a:hover {
   text-decoration: underline;
   /* All text links have underlining when hovered. */

--- a/resource/css/styles.css
+++ b/resource/css/styles.css
@@ -1339,7 +1339,6 @@ tr.replaced-by > td > ul > li > a {
 
 ul.nav-tabs > li {
   margin-bottom: 0;
-  outline: none;
 }
 
 .nav-tabs > li > a, .nav-tabs > li > p, .nav-tabs > li.active > a, .nav-tabs > li.active > a:hover {
@@ -1347,7 +1346,6 @@ ul.nav-tabs > li {
   border-radius: 0;
   border: 0;
   margin: 0;
-  outline: none;
   padding: 10px;
   text-align: center;
 }
@@ -1463,7 +1461,6 @@ span.date-info {
   border: 2px solid #ccc;
   font-size: 14px;
   line-height: 20px;
-  outline: none;
   width: 396px;
 }
 

--- a/resource/css/styles.css
+++ b/resource/css/styles.css
@@ -1415,7 +1415,17 @@ ul.nav-tabs > li {
   width: 1px;
   position: absolute;
   overflow: hidden;
-  top: -10px;
+  top: -100px;
+}
+
+#skiptocontent:focus {
+  top: auto;
+  left: 1.5em;
+  height: auto;
+  width: auto;
+  background-color: white;
+  display: block;
+  z-index: 1;
 }
 
 span.date-info {

--- a/resource/js/docready.js
+++ b/resource/js/docready.js
@@ -505,7 +505,13 @@ $(function() { // DOCUMENT READY
 
   var qtip_skosmos = {
     position: { my: 'top center', at: 'bottom center' },
-    style: { classes: 'qtip-tipsy qtip-skosmos' }
+    style: { classes: 'qtip-tipsy qtip-skosmos' },
+    show: {
+      event: 'mouseenter focusin'
+    },
+    hide: {
+      event: 'mouseleave focusout'
+    }
   };
 
   var qtip_skosmos_hierarchy = {

--- a/view/light.twig
+++ b/view/light.twig
@@ -20,9 +20,7 @@
 <title>{{ ServiceName }}{% block title %}{% endblock %}</title>
 </head>
 <body{% if request.vocabid == '' and request.page != 'feedback' and request.page != 'about' %} class="frontpage-logo"{% else %} class="vocab-{{ request.vocabid }}"{% endif %}>
-  <div id="skiptocontent">
-    <a href="{{ request.langurl }}#maincontent">{% trans "Skip to main" %}</a>
-  </div>
+  <a id="skiptocontent" href="{{ request.langurl }}#maincontent">{% trans "Skip to main" %}</a>
   {% if request.vocabid != '' or request.page == 'feedback' or request.page == 'about' %}<div class="topbar-white">{% endif %}
     <div class="topbar{% if request.vocabid != '' or request.vocabid == 'feedback' or request.vocabid == 'about' %} topbar-white{% else %} frontpage{% endif %}">
       {% include 'topbar.twig' %}

--- a/view/light.twig
+++ b/view/light.twig
@@ -132,7 +132,7 @@
       {% include 'left.inc' ignore missing %}
     {% endif %}
     {% block error %}
-    <main id="maincontent">
+    <main id="maincontent" tabindex="-1">
       {% if request.vocabid == '' and request.page != 'feedback' and request.page != 'about' and not global_search %}
         {% include 'vocabularylist.twig' %}
       {% endif %}

--- a/view/topbar.twig
+++ b/view/topbar.twig
@@ -30,7 +30,7 @@
   <a href="{% if request.vocabid and vocab.title%}{{ request.vocabid }}/{% endif %}{{ request.lang }}/feedback{% if request.contentLang and request.contentLang != request.lang %}?clang={{ request.contentLang }}{% endif %}{% if request.queryParam('anylang') == 'on' %}{% if request.contentLang == request.lang %}?{% else %}&{% endif %}anylang=on{% endif %}" id="navi3" class="navigation-font">
   {% trans "Feedback" %}
   </a>
-  <span id="navi4" title="{% trans "helper_help" %}<br /><br />{% trans "search_example_text" %}">
+  <span id="navi4" tabindex="0" title="{% trans "helper_help" %}<br /><br />{% trans "search_example_text" %}">
     <span class="navigation-font">{% trans "Help" %}</span>
   </span>
 </div>


### PR DESCRIPTION
This PR contains accessibility improvements that aim to enable keyboard navigation, especially tabbing through links.

1. The **Skip to main content** link has been enhanced so that it now becomes visible when the user presses the Tab key. The layout isn't ideal as it partially obscures the logo in the corner - ideas for improvement welcome!
2. The **Help** link in the top bar can now be activated with the keyboard just like it were a normal link.
3. Previously outlines for focused links were completely disabled. They are now enabled, with a crude but functional black outline displayed for the currently active link.

Still TODO:

- when tabbing to the search form in the top bar, the current element isn't highlighted in any way

Visible "Skip to content" link:

![image](https://user-images.githubusercontent.com/1132830/92229981-ff1e8100-eeb2-11ea-89d4-581d11925ec3.png)

Tabbing to the Help "link":

![image](https://user-images.githubusercontent.com/1132830/92230050-1c534f80-eeb3-11ea-8204-1da4ddd7bc89.png)

All links are now outlined when active:

![image](https://user-images.githubusercontent.com/1132830/92230155-4c025780-eeb3-11ea-828c-aa692a92dbf4.png)

(screenshots taken using Chromium; the look is similar in Firefox except outline borders are not rounded)


Fixes #1049