### PR TITLE
Topbar wcag focus improvements

### DIFF
--- a/resource/css/styles.css
+++ b/resource/css/styles.css
@@ -103,6 +103,8 @@ a:hover {
 
 #service-logo {
   max-width: 450px;
+  display: inline-block;
+  margin: 4px;
 }
 
 /* basics
@@ -167,10 +169,10 @@ ul {
 }
 
 #service-name {
-  left: 30px;
   line-height: 50px;
   margin: 0;
-  position: absolute;
+  left: 50px;
+  position: relative;
 }
 
 .topbar-white > #language, .topbar-white > #navigation {
@@ -1870,7 +1872,6 @@ body, .versal, h1, h2, p, .versal-bold {
 
   #navigation > a, #language > a, #navi4 > span {
     font-weight: 500;
-    margin: 2px;
   }
 
   .frontpage #language {
@@ -1881,9 +1882,15 @@ body, .versal, h1, h2, p, .versal-bold {
   }
 
   #service-logo {
-    height: 200px;
     position: absolute;
-    right: 3%;
+    left: 100%;
+    outline-offset: -2px;
+  }
+
+  #service-name {
+    left: 0;
+    padding-right: 4px;
+    padding-left: 4px;
   }
 
   .frontpage-spacing .header-float {
@@ -1924,10 +1931,6 @@ body, .versal, h1, h2, p, .versal-bold {
 }
 
 @media (min-width: 640px) {
-  #service-logo {
-    display: inline;
-  }
-
   .right-box {
     display: inline;
   }
@@ -1972,11 +1975,6 @@ body, .versal, h1, h2, p, .versal-bold {
 
   #navigation > a {
     margin: auto 10px;
-  }
-
-  #service-logo {
-    display: inline;
-    position: absolute;
   }
 
   .content > .feedback-box, .content > #about {

--- a/resource/css/styles.css
+++ b/resource/css/styles.css
@@ -94,6 +94,7 @@ a:link,a:visited,a:active,a:hover,a:focus {
 
 :focus {
   outline: 2px solid black;
+  z-index: 1;
 }
 
 a:hover {
@@ -164,15 +165,20 @@ ul {
   margin-bottom: 20px;
 }
 
+.topbar > a {
+  display: inline-block;
+  margin: 4px;
+  left: 2.5%;
+  position: sticky;
+}
+
 .topbar-white {
   background-color: #ffffff;
 }
 
 #service-name {
-  line-height: 50px;
+  line-height: 42px;
   margin: 0;
-  left: 50px;
-  position: relative;
 }
 
 .topbar-white > #language, .topbar-white > #navigation {
@@ -184,7 +190,7 @@ ul {
   height: 50px;
   line-height: 70px;
   padding-left: 0;
-  padding-right: 2%;
+  padding-right: 2.5%;
   text-align: right;
   width: auto;
 }
@@ -192,12 +198,12 @@ ul {
 #language > .dropdown-menu {
   z-index: 9002;
   position: fixed;
-  padding-right: 2%;
+  padding-right: 2.5%;
   border-radius: 0;
   margin-top: 0;
   padding: 0;
   top: 45px;
-  right: 2%;
+  right: 2.5%;
 }
 
 #language > .dropdown-menu > li, #language > .dropdown-menu > li > a {
@@ -1436,7 +1442,6 @@ ul.nav-tabs > li {
   width: auto;
   background-color: white;
   display: block;
-  z-index: 1;
 }
 
 span.date-info {
@@ -1853,7 +1858,9 @@ body, .versal, h1, h2, p, .versal-bold {
 @media (max-width: 700px) {
 
   .topbar > a {
-    display: none;
+    position: absolute;
+    left: 100%;
+    outline-offset: -2px;
   }
 
   .topbar {
@@ -2041,10 +2048,6 @@ body, .versal, h1, h2, p, .versal-bold {
 @media (min-width: 1260px) {
   .main-container, .headerbar, .topbar {
     width: 1190px;
-  }
-
-  #service-name {
-    left: 0 !important;
   }
 
   .frontpage-alert {


### PR DESCRIPTION
This PR fixes some issues concerning the new focusing outline that were introduced by #1056 (namely, introducing a positive z-index to all focused elements).

Extra work was done in order to make topbar elements (excluding the #1058-related element) behave as one would expect. However, there is one old quirk still left: sizing the window to some 700px will push the `Skosmos` out of the main column and on the right side. I adjusted the ontology page so that it behaves the same now both for ontology and front page (previously it just disappeared completely (display: none) for ontology page, making it completely unreachable for any keyboard/screen reader user).

Tested with Firefox.