### PR TITLE
CSS fix: Make sure concept info area extends to the full available width

### DIFF
--- a/resource/css/styles.css
+++ b/resource/css/styles.css
@@ -1257,6 +1257,7 @@ li.sub-group {
 
 .concept-main {
   padding: 15px;
+  width: 100%;
 }
 
 .appendix-vocab-label {


### PR DESCRIPTION
This is a minor CSS fix that ensures that there is no extra margin on the right side of the concept info display. For some concepts the info area didn't extend all the way to the right.