### PR TITLE
Fix position of concept spinner, which was broken by a -moz-fit-width rule.

### DIFF
--- a/resource/css/styles.css
+++ b/resource/css/styles.css
@@ -1549,7 +1549,6 @@ ul.nav-tabs > li {
 
 .content {
   margin-left: 350px;
-  width: -moz-fit-content;
 }
 
 #sidebar + main .content {


### PR DESCRIPTION
This was broken by a CSS rule introduced in #1067:

```css
 .content {
   width: -moz-fit-content;
 }
```

I couldn't find any reason for this rule, as dropping it didn't seem to have any adverse effects but removing it fixes the position of the spinner displayed when loading a concept page takes a long time.