### PR TITLE
Show short name of vocabulary for property values from another vocab

### DIFF
--- a/model/ConceptPropertyValue.php
+++ b/model/ConceptPropertyValue.php
@@ -115,7 +115,7 @@ class ConceptPropertyValue extends VocabularyDataObject
 
     public function getVocabName()
     {
-        return $this->vocab->getTitle();
+        return $this->vocab->getShortName();
     }
 
     public function addSubMember($member, $lang = '')

--- a/tests/ConceptPropertyValueTest.php
+++ b/tests/ConceptPropertyValueTest.php
@@ -94,7 +94,7 @@ class ConceptPropertyValueTest extends PHPUnit\Framework\TestCase
   public function testGetVocabName() {
     $props = $this->concept->getProperties();
     $propvals = $props['skos:narrower']->getValues();
-    $this->assertEquals('Test ontology', $propvals['Crucian carp http://www.skosmos.skos/test/ta121']->getVocabName());
+    $this->assertEquals('Test short', $propvals['Crucian carp http://www.skosmos.skos/test/ta121']->getVocabName());
   }
 
   /**


### PR DESCRIPTION
This one-line (plus test) PR will change the vocabulary names that are shown on the concept page next to property values that come from another vocabulary known to Skosmos. This change was requested by the Kanto/finaf project. The long vocabulary names clutter the display of property values. Using the short names instead makes the display a bit cleaner.

Before this PR:

![image](https://user-images.githubusercontent.com/1132830/96551576-31e1d480-12bb-11eb-9c28-2706ad2e4dfb.png)

After:

![image](https://user-images.githubusercontent.com/1132830/96551649-4de57600-12bb-11eb-88e3-dde656448170.png)
