### PR TITLE
add treatment for JSON-LD vocabulary data dump; fixes #1096

### DIFF
--- a/view/vocab-shared.twig
+++ b/view/vocab-shared.twig
@@ -63,6 +63,9 @@
         {% if 'text/turtle' in vocab.config.dataURLs|keys %}
           <a href="rest/v1/{{ request.vocabid }}/data?format=text/turtle">TURTLE</a>
         {% endif %}
+        {% if 'application/ld+json' in vocab.config.dataURLs|keys %}
+          <a href="rest/v1/{{ request.vocabid }}/data?format=application%2Fld%2Bjson">JSON-LD</a>
+        {% endif %}
         {% if 'application/marcxml+xml' in vocab.config.dataURLs|keys %}
             {% if vocab.config.dataURLs['application/marcxml+xml'] is iterable %}
                 {% for key, values in vocab.config.dataURLs['application/marcxml+xml'] %}


### PR DESCRIPTION
This PR fixes #1096 via adding treatment for JSON-LD data dump.

After mergeing it might be a good idea to update https://github.com/NatLibFi/Skosmos/wiki/ServingLinkedData wiki page accordingly.