### PR TITLE
Optimize alphabet letter query: use GRAPH instead of FROM

### DIFF
--- a/model/sparql/GenericSparql.php
+++ b/model/sparql/GenericSparql.php
@@ -1337,15 +1337,17 @@ EOQ;
      * @return string sparql query
      */
     private function generateFirstCharactersQuery($lang, $classes) {
-        $fcl = $this->generateFromClause();
+        $gcl = $this->graphClause;
         $classes = (isset($classes) && sizeof($classes) > 0) ? $classes : array('http://www.w3.org/2004/02/skos/core#Concept');
         $values = $this->formatValues('?type', $classes, 'uri');
         $query = <<<EOQ
-SELECT DISTINCT (ucase(str(substr(?label, 1, 1))) as ?l) $fcl WHERE {
-  ?c skos:prefLabel ?label .
-  ?c a ?type
-  FILTER(langMatches(lang(?label), '$lang'))
-  $values
+SELECT DISTINCT (ucase(str(substr(?label, 1, 1))) as ?l) WHERE {
+  $gcl {
+    ?c skos:prefLabel ?label .
+    ?c a ?type
+    FILTER(langMatches(lang(?label), '$lang'))
+    $values
+  }
 }
 EOQ;
         return $query;


### PR DESCRIPTION
It turns out that the existing SPARQL query to generate the letters of the alphabet for the alphabetical index is quite slow when using Fuseki TDB2. Switching to GRAPH instead of FROM makes it a lot faster.

See [this thread](https://lists.apache.org/thread.html/ree7a3136b972bacd4b89bb0ccd6cbf969516ab3313321880a3c3440b%40%3Cusers.jena.apache.org%3E) on the Jena users list for some more background.