### PR TITLE
fixes undefined offset by adding an isset test

### DIFF
--- a/controller/WebController.php
+++ b/controller/WebController.php
@@ -463,7 +463,7 @@ class WebController extends Controller
         if (!$allAtOnce) {
             $letters = $vocab->getAlphabet($contentLang);
             $letter = $request->getLetter();
-            if ($letter === '') {
+            if ($letter === '' && isset($letters[0])) {
                 $letter = $letters[0];
             }
             $searchResults = $vocab->searchConceptsAlphabetical($letter, $count, $offset, $contentLang);

--- a/model/sparql/GenericSparql.php
+++ b/model/sparql/GenericSparql.php
@@ -1327,6 +1327,9 @@ EOQ;
      * @param \EasyRdf\Resource|null $qualifier alphabetical list qualifier resource or null (default: null)
      */
     public function queryConceptsAlphabetical($letter, $lang, $limit = null, $offset = null, $classes = null, $showDeprecated = false, $qualifier = null) {
+        if ($letter === '') {
+            return array(); // special case: no letter given, return empty list
+        }
         $query = $this->generateAlphabeticalListQuery($letter, $lang, $limit, $offset, $classes, $showDeprecated, $qualifier);
         $results = $this->query($query);
         return $this->transformAlphabeticalListResults($results);

--- a/tests/GenericSparqlTest.php
+++ b/tests/GenericSparqlTest.php
@@ -133,6 +133,19 @@ class GenericSparqlTest extends PHPUnit\Framework\TestCase
    * @covers GenericSparql::formatLimitAndOffset
    * @covers GenericSparql::transformAlphabeticalListResults
    */
+  public function testQueryConceptsAlphabeticalEmpty() {
+    $actual = $this->sparql->queryConceptsAlphabetical('', 'en');
+    $expected = array();
+    $this->assertEquals($expected, $actual);
+  }
+
+  /**
+   * @covers GenericSparql::queryConceptsAlphabetical
+   * @covers GenericSparql::generateAlphabeticalListQuery
+   * @covers GenericSparql::formatFilterConditions
+   * @covers GenericSparql::formatLimitAndOffset
+   * @covers GenericSparql::transformAlphabeticalListResults
+   */
   public function testQueryConceptsAlphabeticalLimit() {
     $actual = $this->sparql->queryConceptsAlphabetical('b', 'en', 2);
     $expected = array (

--- a/tests/JenaTextSparqlTest.php
+++ b/tests/JenaTextSparqlTest.php
@@ -80,6 +80,15 @@ class JenaTextSparqlTest extends PHPUnit\Framework\TestCase
   /**
    * @covers JenaTextSparql::generateAlphabeticalListQuery
    */
+  public function testQueryConceptsAlphabeticalEmpty() {
+    $actual = $this->sparql->queryConceptsAlphabetical('', 'en');
+    $expected = array();
+    $this->assertEquals($expected, $actual);
+  }
+
+  /**
+   * @covers JenaTextSparql::generateAlphabeticalListQuery
+   */
   public function testQueryConceptsAlphabeticalLimitAndOffset() {
     $actual = $this->sparql->queryConceptsAlphabetical('b', 'en', 2, 1);
     $expected = array (


### PR DESCRIPTION
Whilst checking php error log for a Skosmos instance I noticed that the line 467 below https://github.com/NatLibFi/Skosmos/blob/254c2c66566527e873750fd36171086dc2d79417/controller/WebController.php#L443-L473 can cause `Undefined offset: 0` PHP Notice.

By following the code it calls  it seems like the `NULL` value is then passed here:
https://github.com/NatLibFi/Skosmos/blob/254c2c66566527e873750fd36171086dc2d79417/model/sparql/GenericSparql.php#L1187-L1216
where at line 1207 it is again (luckily) changed back to an empty string. This will, however, cause a filter clause that has a STRSTARTS() with an empty argument, which is unnecessary and will always evaluate to True.

Whilst this PR fixes the PHP notice, it won't change the behavior (i.e., the query as it is, now). I wonder if it would be more appropriate to, in this case, change the letter value to "\*", for which there is a special treatment (unlike for empty string). However, now that I look into that, it seems like the `STRSTARTS` part is unnecessary for the aforementioned "\*" value.

Additionally, I just noticed that this also affects the JenaTextSparql:
https://github.com/NatLibFi/Skosmos/blob/254c2c66566527e873750fd36171086dc2d79417/model/sparql/JenaTextSparql.php#L102-L171
Before merging it should be discussed whether something else should be done to both of these SPARQL parts, namely, if there should be a more special treatment for "*" and whether or not the letter value should be changed to that very same value.