### PR TITLE
fix php notice for defaultPropLabel when it is returned in different …

### DIFF
--- a/model/Concept.php
+++ b/model/Concept.php
@@ -530,13 +530,12 @@ class Concept extends VocabularyDataObject implements Modifiable
                 // note that this imply that the property has an rdf:type declared for the query to work
                 if(!$is_well_known && !$proplabel) {
                     $envLangLabels = $this->model->getDefaultSparql()->queryLabel($longUri, $this->getEnvLang());
-                    
-                    $defaultPropLabel = $this->model->getDefaultSparql()->queryLabel($longUri, '');
 
 					if($envLangLabels) {
 						$proplabel = $envLangLabels[$this->getEnvLang()];
                     } else {
-						if($defaultPropLabel) {
+                        $defaultPropLabel = $this->model->getDefaultSparql()->queryLabel($longUri, '');
+						if(isset($defaultPropLabel[''])) {
 							$proplabel = $defaultPropLabel[''];
 						}
 					}


### PR DESCRIPTION
…language than anticipated; references #813

This PR fixes previously unnoticed case of PHP Notice. It should be noted that the language selection of `defaultPropLabel` should be more language-aware. Also, there seems to be issues with tabs and spaces, here (not fixed in PR).