### PR TITLE
Issue1117 deduplicate autocomplete matches

### DIFF
--- a/model/Concept.php
+++ b/model/Concept.php
@@ -876,9 +876,10 @@ class Concept extends VocabularyDataObject implements Modifiable
 
     /**
      * Gets the values of skos:prefLabel and skos:altLabel in all other languages than in the current language.
+     * @param boolean $sortByLangToString Sort by (subset filtered) language name in UI language (default: true)
      * @return array Language-based multidimensional sorted array ([string][string][ConceptPropertyValueLiteral]) or empty array if no values
      */
-    public function getForeignLabels()
+    public function getForeignLabels($sortByLangToString=true)
     {
         $prefLabels = $this->getForeignLabelList('skos:prefLabel', 'prefLabel');
         $altLabels = $this->getForeignLabelList('skos:altLabel', 'altLabel');
@@ -895,7 +896,7 @@ class Concept extends VocabularyDataObject implements Modifiable
             {
                 $coll->sort($ret[$lang]['altLabel'], Collator::SORT_STRING);
             }
-            if ($lang !== '') {
+            if ($lang !== '' && $sortByLangToString) {
                 $ret[$this->langToString($lang)] = $ret[$lang];
                 unset($ret[$lang]);
             }

--- a/model/ConceptPropertyValue.php
+++ b/model/ConceptPropertyValue.php
@@ -46,6 +46,11 @@ class ConceptPropertyValue extends VocabularyDataObject
         return $this->getEnvLang();
     }
 
+    public function getContentLang()
+    {
+        return $this->clang;
+    }
+
     public function getLabel($lang = '', $fallbackToUri = 'uri')
     {
         if ($this->clang) {

--- a/view/search-result.twig
+++ b/view/search-result.twig
@@ -10,15 +10,15 @@
     <span class="prefLabel conceptlabel redirected-vocab-id" title="{{ concept.vocabTitle }}">{{ concept.shortName }}: </span>
     {% endif %}
     {% if concept.foundBy %} {# hit has been found through an alt/hidden/another language label #}
-      {% if concept.foundByType != 'lang' and concept.foundByType != 'hidden' %}<span class="versal replaced">{{ concept.foundBy }}{% if explicit_langcodes or request.queryparam('anylang') and concept.contentLang != '' %} ({{ concept.contentLang }}){% endif %}</span><span class="versal"> &rarr;&nbsp;</span>{% if concept.notation %}<span class="notation">{{ concept.notation }}</span>{% endif %}
-      <a class="prefLabel" href="{% if 'isothes:ConceptGroup' in concept.type %}{{ concept.uri | link_url(concept.vocab,request.lang,'page',concept.contentLang) }}{% else %}{{ concept.uri | link_url(concept.vocab,request.lang,'page',concept.contentLang) }}{% endif %}">{{ concept.label(request.contentLang) }}</a>{% if explicit_langcodes or request.queryparam('anylang') %}<span class="versal"> ({{ concept.label.lang }})</span>{% endif %}</span>
+      {% if concept.foundByType != 'lang' and concept.foundByType != 'hidden' %}<span class="versal replaced">{{ concept.foundBy }}{% if concept.contentLang and (explicit_langcodes or request.queryparam('anylang')) %} ({{ concept.contentLang }}){% endif %}</span><span class="versal"> &rarr;&nbsp;</span>{% if concept.notation %}<span class="notation">{{ concept.notation }}</span>{% endif %}
+      <a class="prefLabel" href="{% if 'isothes:ConceptGroup' in concept.type %}{{ concept.uri | link_url(concept.vocab,request.lang,'page',concept.contentLang) }}{% else %}{{ concept.uri | link_url(concept.vocab,request.lang,'page',concept.contentLang) }}{% endif %}">{{ concept.label(request.contentLang) }}</a>{% if concept.label.lang and (explicit_langcodes or request.queryparam('anylang')) %}<span class="versal"> ({{ concept.label.lang }})</span>{% endif %}</span>
  
       {% else %}{% if concept.notation %}<span class="notation">{{ concept.notation }}</span>{% endif %}
-      <a class="prefLabel" href="{% if "isothes:ConceptGroup" in concept.type %}{{ concept.uri | link_url(concept.vocab,request.lang,'page',concept.contentLang) }}{% else %}{{ concept.uri | link_url(concept.vocab,request.lang,'page',concept.contentLang) }}{% endif %}">{{ concept.label(request.contentLang) }}</a>{% if explicit_langcodes or request.queryparam('anylang') %}<span class="versal"> ({{ concept.contentLang }})</span>{% endif %}
+      <a class="prefLabel" href="{% if "isothes:ConceptGroup" in concept.type %}{{ concept.uri | link_url(concept.vocab,request.lang,'page',concept.contentLang) }}{% else %}{{ concept.uri | link_url(concept.vocab,request.lang,'page',concept.contentLang) }}{% endif %}">{{ concept.label(request.contentLang) }}</a>{% if concept.contentLang and (explicit_langcodes or request.queryparam('anylang')) %}<span class="versal"> ({{ concept.contentLang }})</span>{% endif %}
       {% endif %}
     {% else %}
     {% if concept.notation %}<span class="notation">{{ concept.notation }}</span>{% endif %}
-    <a class="prefLabel conceptlabel" href="{% if "isothes:ConceptGroup" in concept.type %}{{ concept.uri | link_url(concept.vocab, request.lang, 'page') }}{% elseif concept.exvocab is defined%}{{ concept.uri | link_url(concept.exvocab,concept.contentLang) }}{% else %}{{ concept.uri | link_url(concept.vocab,request.lang,'page',concept.contentLang) }}{% endif %}">{{ concept.label(request.contentLang) }}</a>{% if explicit_langcodes or request.queryparam('anylang') %}<span class="versal"> ({{ concept.contentLang }})</span>{% endif %}
+    <a class="prefLabel conceptlabel" href="{% if "isothes:ConceptGroup" in concept.type %}{{ concept.uri | link_url(concept.vocab, request.lang, 'page') }}{% elseif concept.exvocab is defined%}{{ concept.uri | link_url(concept.exvocab,concept.contentLang) }}{% else %}{{ concept.uri | link_url(concept.vocab,request.lang,'page',concept.contentLang) }}{% endif %}">{{ concept.label(request.contentLang) }}</a>{% if concept.contentLang and (explicit_langcodes or request.queryparam('anylang')) %}<span class="versal"> ({{ concept.contentLang }})</span>{% endif %}
     {% endif %}
   {% endspaceless %}
   {%- if concept.type == 'skosext:DeprecatedConcept' %}<span class="versal deprecated-alert">{% trans %}deprecated{% endtrans %}</span>{% endif -%}
@@ -36,7 +36,7 @@
           {% if propval.SubMembers %} {# if property is a group concept that has sub properties #}
             {% for sub_member in propval.SubMembers %}
               {% if previous != sub_member.label %}
-              <span class="versal value">{{ sub_member.label }}{% if sub_member.lang or explicit_langcodes %} ({{ sub_member.lang }}){% endif %}</span>{% if not outerLast %}<span class="versal">,</span>{% endif %}
+              <span class="versal value">{{ sub_member.label }}{% if sub_member.lang and (explicit_langcodes or request.queryparam('anylang') or sub_member.lang != request.contentLang) %} ({{ sub_member.lang }}){% endif %}</span>{% if not outerLast %}<span class="versal">,</span>{% endif %}
               {% endif %}
               {% set previous = sub_member.label %}
             {% endfor %}
@@ -49,11 +49,11 @@
                   {% else %}
                   <span class="versal value">{{ propval.label(request.contentLang) }}</span>
                   {% endif %}
-                  {% if propval.lang and (propval.lang != request.lang) or explicit_langcodes %}<span class="versal"> ({{ propval.lang }})</span>{% endif %}{% if not loop.last %}<span class="versal">,</span>{% endif %}
+                  {% if propval.lang and (explicit_langcodes or request.queryparam('anylang') or propval.label.lang != request.contentLang) %}<span class="versal"> ({{ propval.label.lang }})</span>{% endif %}{% if not loop.last %}<span class="versal">,</span>{% endif %}
                 {% endif %}
               {% endspaceless %}
               {% else %} {# Literals (no URI), eg. alternative labels as properties #}
-                 <span class="versal {% if propval.type == 'skos:altLabel' %}replaced {% endif %} value">{{ propval.label }}{% if not loop.last %},{% endif %}</span>
+                 <span class="versal {% if propval.type == 'skos:altLabel' %}replaced {% endif %} value">{{ propval.label }}{% if propval.lang and (explicit_langcodes or request.queryparam('anylang') or propval.lang != request.contentLang) %}<span class="versal"> ({{ propval.lang }}){% endif %}{% if not loop.last %},{% endif %}</span>
               {% endif %}
           {% endif %}
       {% endfor %}
@@ -83,7 +83,7 @@
           </span>
           <div class="property-values">
             {% for propval in property.values %} {# loop through ConceptMappingPropertyValue objects #}
-            {% if propval.exVocab %}<span class="redirected-vocab-id prefLabel">{{ propval.exVocab.shortName }}: </span>{% endif %}<span class="versal value">{{ propval.label(request.contentLang) }}</span>{% if propval.label(request.contentLang).lang != request.contentLang %}<span class="versal value"> ({{ propval.label(request.contentLang).lang }})</span>{% endif %}{% if loop.last == false %}<span class="versal">, </span>{% endif %}
+            {% if propval.exVocab %}{% set propvalLabel = propval.label(request.contentLang) %}<span class="redirected-vocab-id prefLabel">{{ propval.exVocab.shortName }}: </span>{% endif %}<span class="versal value">{{ propvalLabel }}</span>{% if propvalLabel.lang and (explicit_langcodes or request.queryparam('anylang') or propvalLabel.lang != request.contentLang) %}<span class="versal value"> ({{ propvalLabel.lang }})</span>{% endif %}{% if loop.last == false %}<span class="versal">, </span>{% endif %}
             {% endfor %}
           </div>
         </div>

--- a/view/search-result.twig
+++ b/view/search-result.twig
@@ -61,7 +61,7 @@
     </div>
     {% endif %}
   {% endfor %}
-  {% set foreignLabels = concept.foreignLabels %}
+  {% set foreignLabels = concept.foreignLabels(false) %}
   {% if foreignLabels %}
     <div class="property">
       <span class="property-click" title="{% trans "foreign prefLabel help" %}"><img class="property-hover" src="resource/pics/globe.gif"></span>


### PR DESCRIPTION
This is a draft PR that fixes #1117 and changes the way `in all languages` search works.

Noteworthy:
- Sorts deduplicated autocomplete matches. **NB: This may result in hiddenLabel matches showing prefLabels before/after the search string** as the prefLabel of hiddenLabel match may be any string. This used to be so that the hits are sorted by their **matching value**, i.e., by hiddenLabel match (which was not shown on UI in any way - leading to seemingly unordered list).
- (first commit) sorts the foreign labels in search results page by their language code. This is more easily understood by the user as there is no visual of the translated string. **Can be separated from the PR into its own.**
- **This will render somewhat useless the tricks used to obtain a list of unique concepts!** This will cause all hits in all languages to be shown - there is much room for query refactoring if this is accepted. See the lines around the code block below for more context. https://github.com/NatLibFi/Skosmos/blob/91aac3af5e58dd160b7b7c8685ce78ed9e37f94b/model/sparql/GenericSparql.php#L924-L932 
Further context to the above is shown below (notice the parameter change - now duplicated!) **TODO:** needs signature fix for the method if this PR is to be merged [or more intelligent logic to make these options to work simultaneously - maybe a new parameter?]): https://github.com/NatLibFi/Skosmos/blob/91aac3af5e58dd160b7b7c8685ce78ed9e37f94b/model/sparql/GenericSparql.php#L1046
- Adds language tag specifier for **all hits and to their all values (whether it be broader/alt/etc.)** in `in all languages` search! The default could be changed so that it does not show duplicate language code specifier if its the same as the language code of the hit (current behavior).

Tested with Generic search.