### PR TITLE
Disable Travis build job that uses Fuseki snapshot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,17 +32,9 @@ env:
     - CC_TEST_REPORTER_ID=fb98170a5c7ea9cc2bbab19ff26268335e6a11a4f8267ca935e5e8ff4624886c
   matrix:
     - FUSEKI_VERSION=3.14.0
-    - FUSEKI_VERSION=SNAPSHOT
 matrix:
   exclude:
-  - php: 7.1
-    env: FUSEKI_VERSION=SNAPSHOT
-  - php: 7.2
-    env: FUSEKI_VERSION=SNAPSHOT
-  - php: 7.4
-    env: FUSEKI_VERSION=SNAPSHOT
   allow_failures:
   - php: 7.4
-  - env: FUSEKI_VERSION=SNAPSHOT
 notifications:
     slack: kansalliskirjasto:9mOKu3Vws1CIddF5jqWgXbli


### PR DESCRIPTION
Recent Fuseki snapshots are 4.0.0-RELEASE. The Travis build jobs (e.g. [this one](https://travis-ci.com/github/NatLibFi/Skosmos/jobs/483699053)) fail in a nasty way, they get stuck until they time out after 2 hours.

The Java error looks like this, probably the Java environment in Travis is too old:

```
Error: A JNI error has occurred, please check your installation and try again

Exception in thread "main" java.lang.UnsupportedClassVersionError: org/apache/jena/fuseki/cmd/FusekiCmd has been compiled by a more recent version of the Java Runtime (class file version 55.0), this version of the Java Runtime only recognizes class file versions up to 52.0
	at java.lang.ClassLoader.defineClass1(Native Method)
	at java.lang.ClassLoader.defineClass(ClassLoader.java:763)
	at java.security.SecureClassLoader.defineClass(SecureClassLoader.java:142)
	at java.net.URLClassLoader.defineClass(URLClassLoader.java:467)
	at java.net.URLClassLoader.access$100(URLClassLoader.java:73)
	at java.net.URLClassLoader$1.run(URLClassLoader.java:368)
	at java.net.URLClassLoader$1.run(URLClassLoader.java:362)
	at java.security.AccessController.doPrivileged(Native Method)
	at java.net.URLClassLoader.findClass(URLClassLoader.java:361)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:335)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	at sun.launcher.LauncherHelper.checkAndLoadMain(LauncherHelper.java:495)
```

This is a quick PR fix to get the Travis builds running. I will open a separate issue about getting Fuseki snapshots working again under Travis.