### PR TITLE
Upgrade to PHPUnit 8; bump required PHP to 7.2+; try to fix Travis tests on PHP 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: required
 dist: trusty
 language: php
 php:
-  - 7.1
   - 7.2
   - 7.3
   - 7.4
@@ -35,6 +34,5 @@ env:
 matrix:
   exclude:
   allow_failures:
-  - php: 7.4
 notifications:
     slack: kansalliskirjasto:9mOKu3Vws1CIddF5jqWgXbli

--- a/composer.json
+++ b/composer.json
@@ -80,7 +80,7 @@
     "grimmlink/qtip2": "3.0.3"
   },
   "require-dev": {
-    "phpunit/phpunit": "7.2.0 - 7.5.20",
+    "phpunit/phpunit": "8.5.*",
     "umpirsky/twig-gettext-extractor": "1.3.*",
     "symfony/dom-crawler": "3.4.3",
     "mockery/mockery": "1.3.1"

--- a/model/DataObject.php
+++ b/model/DataObject.php
@@ -27,7 +27,7 @@ class DataObject
     public function __construct($model, $resource)
     {
         if (!($model instanceof Model) || !($resource instanceof EasyRdf\Resource)) {
-            throw new Exception('Invalid constructor parameter given to DataObject.');
+            throw new InvalidArgumentException('Invalid constructor parameter given to DataObject.');
         }
 
         $this->model = $model;

--- a/model/Model.php
+++ b/model/Model.php
@@ -417,7 +417,7 @@ class Model
                 return $voc;
             }
         }
-        throw new Exception("Vocabulary id '$vocid' not found in configuration.");
+        throw new ValueError("Vocabulary id '$vocid' not found in configuration.");
     }
 
     /**
@@ -444,7 +444,7 @@ class Model
         if (array_key_exists($key, $this->vocabsByGraph)) {
             return $this->vocabsByGraph[$key];
         } else {
-            throw new Exception("no vocabulary found for graph $graph and endpoint $endpoint");
+            throw new ValueError("no vocabulary found for graph $graph and endpoint $endpoint");
         }
 
     }

--- a/model/VocabularyCategory.php
+++ b/model/VocabularyCategory.php
@@ -8,7 +8,7 @@ class VocabularyCategory extends DataObject
     public function __construct($model, $resource)
     {
         if (!($model instanceof Model)) {
-            throw new Exception('Invalid constructor parameter given to DataObject.');
+            throw new InvalidArgumentException('Invalid constructor parameter given to DataObject.');
         }
 
         $this->model = $model;

--- a/model/sparql/GenericSparql.php
+++ b/model/sparql/GenericSparql.php
@@ -467,7 +467,11 @@ EOQ;
         $conceptArray = array();
         foreach ($uris as $index => $uri) {
             $conc = $result->resource($uri);
-            $vocab = (isset($vocabs) && sizeof($vocabs) == 1) ? $vocabs[0] : $vocabs[$index];
+            if (is_array($vocabs)) {
+                $vocab = (sizeof($vocabs) == 1) ? $vocabs[0] : $vocabs[$index];
+            } else {
+                $vocab = null;
+            }
             $conceptArray[] = new Concept($this->model, $vocab, $conc, $result, $clang);
         }
         return $conceptArray;

--- a/tests/ConceptMappingPropertyValueTest.php
+++ b/tests/ConceptMappingPropertyValueTest.php
@@ -7,7 +7,8 @@ class ConceptMappingPropertyValueTest extends PHPUnit\Framework\TestCase
   private $vocab;
   private $props;
 
-  protected function setUp() {
+  protected function setUp() : void
+  {
     putenv("LANGUAGE=en_GB.utf8");
     putenv("LC_ALL=en_GB.utf8");
     setlocale(LC_ALL, 'en_GB.utf8');

--- a/tests/ConceptPropertyTest.php
+++ b/tests/ConceptPropertyTest.php
@@ -4,7 +4,8 @@ class ConceptPropertyTest extends PHPUnit\Framework\TestCase
 {
   private $model;
 
-  protected function setUp() {
+  protected function setUp() : void
+  {
     putenv("LANGUAGE=en_GB.utf8");
     putenv("LC_ALL=en_GB.utf8");
     setlocale(LC_ALL, 'en_GB.utf8');

--- a/tests/ConceptPropertyValueLiteralTest.php
+++ b/tests/ConceptPropertyValueLiteralTest.php
@@ -6,7 +6,8 @@ class ConceptPropertyValueLiteralTest extends PHPUnit\Framework\TestCase
   private $concept;
   private $vocab;
 
-  protected function setUp() {
+  protected function setUp() : void
+  {
     putenv("LANGUAGE=en_GB.utf8");
     putenv("LC_ALL=en_GB.utf8");
     setlocale(LC_ALL, 'en_GB.utf8');

--- a/tests/ConceptPropertyValueLiteralTest.php
+++ b/tests/ConceptPropertyValueLiteralTest.php
@@ -48,14 +48,14 @@ class ConceptPropertyValueLiteralTest extends PHPUnit\Framework\TestCase
     $concepts = $vocab->getConceptInfo("http://www.skosmos.skos/date/d1", "en");
     $props = $concepts[0]->getProperties();
     $propvals = $props['http://www.skosmos.skos/date/ownDate']->getValues();
-    $this->assertContains('8/8/15', $propvals['8/8/15']->getLabel());
+    $this->assertStringContainsString('8/8/15', $propvals['8/8/15']->getLabel());
   }
 
   /**
    * @covers ConceptPropertyValueLiteral::getLabel
-   * @expectedException PHPUnit\Framework\Error\Warning
    */
   public function testGetLabelThatIsABrokenDate() {
+    $this->expectWarning();
     $vocab = $this->model->getVocabulary('dates');
     $concepts = $vocab->getConceptInfo("http://www.skosmos.skos/date/d2", "en");
     $props = $concepts[0]->getProperties();

--- a/tests/ConceptPropertyValueTest.php
+++ b/tests/ConceptPropertyValueTest.php
@@ -6,7 +6,8 @@ class ConceptPropertyValueTest extends PHPUnit\Framework\TestCase
   private $concept;
   private $vocab;
 
-  protected function setUp() {
+  protected function setUp() : void
+  {
     putenv("LANGUAGE=en_GB.utf8");
     putenv("LC_ALL=en_GB.utf8");
     setlocale(LC_ALL, 'en_GB.utf8');

--- a/tests/ConceptSearchParametersTest.php
+++ b/tests/ConceptSearchParametersTest.php
@@ -5,7 +5,8 @@ class ConceptSearchParametersTest extends PHPUnit\Framework\TestCase
     private $model;
     private $request;
 
-    protected function setUp() {
+    protected function setUp() : void
+    {
         putenv("LANGUAGE=en_GB.utf8");
         putenv("LC_ALL=en_GB.utf8");
         setlocale(LC_ALL, 'en_GB.utf8');
@@ -13,7 +14,8 @@ class ConceptSearchParametersTest extends PHPUnit\Framework\TestCase
         $this->model = new Model(new GlobalConfig('/../tests/testconfig.ttl'));
     }
 
-    protected function tearDown() {
+    protected function tearDown() : void
+    {
         $this->params = null;
     }
 

--- a/tests/ConceptTest.php
+++ b/tests/ConceptTest.php
@@ -284,7 +284,7 @@ class ConceptTest extends PHPUnit\Framework\TestCase
     $concepts = $vocab->getConceptInfo("http://www.skosmos.skos/test/ta123", "en");
     $concept = $concepts[0];
     $date = $concept->getDate();
-    $this->assertContains('10/1/14', $date);
+    $this->assertStringContainsString('10/1/14', $date);
   }
 
   /**
@@ -295,8 +295,8 @@ class ConceptTest extends PHPUnit\Framework\TestCase
     $concepts = $vocab->getConceptInfo("http://www.skosmos.skos/date/d1", "en");
     $concept = $concepts[0];
     $date = $concept->getDate();
-    $this->assertContains('1/3/00', $date);
-    $this->assertContains('6/6/12', $date);
+    $this->assertStringContainsString('1/3/00', $date);
+    $this->assertStringContainsString('6/6/12', $date);
   }
 
   /**
@@ -324,7 +324,7 @@ class ConceptTest extends PHPUnit\Framework\TestCase
     $concept = $concepts[0];
     # we use @ to suppress the exceptions in order to be able to check the result
     $date = @$concept->getDate();
-    $this->assertContains('1986-21-00', $date);
+    $this->assertStringContainsString('1986-21-00', $date);
   }
 
   /**
@@ -584,9 +584,9 @@ class ConceptTest extends PHPUnit\Framework\TestCase
 
     $concept->processExternalResource($res);
     $json =  $concept->dumpJsonLd();
-    $this->assertContains('HY', $json);
-    $this->assertContains('AK', $json);
-    $this->assertContains('OS', $json);
+    $this->assertStringContainsString('HY', $json);
+    $this->assertStringContainsString('AK', $json);
+    $this->assertStringContainsString('OS', $json);
     $contains_count = substr_count($json, "CONTAINS");
     $this->assertEquals($contains_count, 3);
   }

--- a/tests/ConceptTest.php
+++ b/tests/ConceptTest.php
@@ -10,7 +10,8 @@ class ConceptTest extends PHPUnit\Framework\TestCase
   private $cbdVocab;
   private $cbdGraph;
 
-  protected function setUp() {
+  protected function setUp() : void
+  {
     putenv("LANGUAGE=en_GB.utf8");
     putenv("LC_ALL=en_GB.utf8");
     setlocale(LC_ALL, 'en_GB.utf8');

--- a/tests/DataObjectTest.php
+++ b/tests/DataObjectTest.php
@@ -7,11 +7,11 @@ class DataObjectTest extends PHPUnit\Framework\TestCase
   /**
    * @covers DataObject::__construct
    * @uses DataObject
-   * @expectedException \Exception
-   * @expectedExceptionMessage Invalid constructor parameter given to DataObject.
    */
   public function testConstructorNoArguments()
   {
+    $this->expectException(InvalidArgumentException::class);
+    $this->expectExceptionMessage("Invalid constructor parameter given to DataObject");
     $obj = new DataObject(null, null);
     $this->assertNotNull($obj);
   }

--- a/tests/FeedbackTest.php
+++ b/tests/FeedbackTest.php
@@ -7,7 +7,8 @@ class FeedbackTest extends PHPUnit\Framework\TestCase
   private $model;
   private $request;
 
-  protected function setUp() {
+  protected function setUp() : void
+  {
     $config = new GlobalConfig('/../tests/testconfig-fordefaults.ttl');
     $this->model = new Model($config);
     $this->request = \Mockery::mock('Request', array($this->model))->makePartial();

--- a/tests/GenericSparqlTest.php
+++ b/tests/GenericSparqlTest.php
@@ -366,7 +366,7 @@ class GenericSparqlTest extends PHPUnit\Framework\TestCase
   public function testQueryConceptsAlphabeticalNumbers() {
     $actual = $this->sparql->queryConceptsAlphabetical('0-9', 'en');
     $this->assertEquals(1, sizeof($actual));
-    $this->assertContains("3D", $actual[0]['prefLabel']);
+    $this->assertStringContainsString("3D", $actual[0]['prefLabel']);
   }
 
   /**
@@ -732,7 +732,7 @@ class GenericSparqlTest extends PHPUnit\Framework\TestCase
     $actual = $this->sparql->queryConcepts(array($voc), null, null, $this->params);
     $this->assertEquals(3, sizeof($actual));
     foreach($actual as $match)
-      $this->assertContains('bass', $match['prefLabel'], '',true);
+      $this->assertStringContainsStringIgnoringCase('bass', $match['prefLabel']);
   }
 
   /**
@@ -751,7 +751,7 @@ class GenericSparqlTest extends PHPUnit\Framework\TestCase
     $actual = $this->sparql->queryConcepts(array($voc), null, null, $this->params);
     $this->assertEquals(3, sizeof($actual));
     foreach($actual as $match)
-      $this->assertContains('bass', $match['prefLabel'], '',true);
+      $this->assertStringContainsStringIgnoringCase('bass', $match['prefLabel']);
   }
 
   /**

--- a/tests/GenericSparqlTest.php
+++ b/tests/GenericSparqlTest.php
@@ -8,7 +8,8 @@ class GenericSparqlTest extends PHPUnit\Framework\TestCase
   private $vocab;
   private $params;
 
-  protected function setUp() {
+  protected function setUp() : void
+  {
     putenv("LANGUAGE=en_GB.utf8");
     putenv("LC_ALL=en_GB.utf8");
     setlocale(LC_ALL, 'en_GB.utf8');

--- a/tests/GlobalConfigTest.php
+++ b/tests/GlobalConfigTest.php
@@ -11,7 +11,7 @@ class GlobalConfigTest extends PHPUnit\Framework\TestCase
     /** @var GlobalConfig */
     private $configWithDefaults;
 
-    protected function setUp()
+    protected function setUp() : void
     {
         $this->config = new GlobalConfig('/../tests/testconfig.ttl');
         $this->assertNotNull($this->config->getCache());

--- a/tests/Http304Test.php
+++ b/tests/Http304Test.php
@@ -230,7 +230,7 @@ class Http304Test extends TestCase
         $this->assertEquals("", $content);
     }
 
-    public function tearDown()
+    public function tearDown() : void
     {
         parent::tearDown();
         \Mockery::close();

--- a/tests/JenaTextSparqlTest.php
+++ b/tests/JenaTextSparqlTest.php
@@ -271,7 +271,7 @@ class JenaTextSparqlTest extends PHPUnit\Framework\TestCase
   public function testQueryConceptsAlphabeticalNumbers() {
     $actual = $this->sparql->queryConceptsAlphabetical('0-9', 'en');
     $this->assertEquals(1, sizeof($actual));
-    $this->assertContains("3D", $actual[0]['prefLabel']);
+    $this->assertStringContainsString("3D", $actual[0]['prefLabel']);
   }
 
   /**
@@ -337,7 +337,7 @@ class JenaTextSparqlTest extends PHPUnit\Framework\TestCase
     $actual = $this->sparql->queryConcepts(array($voc), null, null, $this->params);
     $this->assertEquals(3, sizeof($actual));
     foreach($actual as $match)
-      $this->assertContains('bass', $match['prefLabel'], '',true);
+      $this->assertStringContainsStringIgnoringCase('bass', $match['prefLabel']);
   }
 
   /**

--- a/tests/JenaTextSparqlTest.php
+++ b/tests/JenaTextSparqlTest.php
@@ -8,7 +8,8 @@ class JenaTextSparqlTest extends PHPUnit\Framework\TestCase
   private $vocab;
   private $params;
 
-  protected function setUp() {
+  protected function setUp() : void
+  {
     putenv("LANGUAGE=en_GB.utf8");
     putenv("LC_ALL=en_GB.utf8");
     setlocale(LC_ALL, 'en_GB.utf8');

--- a/tests/JenaTextSparqlTest.php
+++ b/tests/JenaTextSparqlTest.php
@@ -183,7 +183,6 @@ class JenaTextSparqlTest extends PHPUnit\Framework\TestCase
   /**
    * @covers JenaTextSparql::queryConceptsAlphabetical
    * @covers JenaTextSparql::generateAlphabeticalListQuery
-   * @covers JenaTextSparql::transformAlphabeticalListResults
    */
   public function testQualifiedBroaderAlphabeticalList() {
     $voc = $this->model->getVocabulary('test-qualified-broader');

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -5,7 +5,8 @@ class ModelTest extends PHPUnit\Framework\TestCase
   private $params;
   private $model;
 
-  protected function setUp() {
+  protected function setUp() : void
+  {
     putenv("LANGUAGE=en_GB.utf8");
     putenv("LC_ALL=en_GB.utf8");
     setlocale(LC_ALL, 'en_GB.utf8');
@@ -15,7 +16,8 @@ class ModelTest extends PHPUnit\Framework\TestCase
     $this->params->method('getVocabs')->will($this->returnValue(array($this->model->getVocabulary('test'))));
   }
 
-  protected function tearDown() {
+  protected function tearDown() : void
+  {
     $this->params = null;
   }
 

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -76,10 +76,10 @@ class ModelTest extends PHPUnit\Framework\TestCase
 
   /**
    * @covers Model::getVocabulary
-   * @expectedException \Exception
-   * @expectedExceptionMessage Vocabulary id 'thisshouldnotbefound' not found in configuration
    */
   public function testGetVocabularyByFalseId() {
+    $this->expectException(ValueError::class);
+    $this->expectExceptionMessage("Vocabulary id 'thisshouldnotbefound' not found in configuration");
     $vocab = $this->model->getVocabulary('thisshouldnotbefound');
     $this->assertInstanceOf('Vocabulary', $vocab);
   }
@@ -94,10 +94,10 @@ class ModelTest extends PHPUnit\Framework\TestCase
 
   /**
    * @covers Model::getVocabularyByGraph
-   * @expectedException \Exception
-   * @expectedExceptionMessage no vocabulary found for graph http://no/address and endpoint http://localhost:13030/skosmos-test/sparql
    */
   public function testGetVocabularyByInvalidGraphUri() {
+    $this->expectException(ValueError::class);
+    $this->expectExceptionMessage("no vocabulary found for graph http://no/address and endpoint http://localhost:13030/skosmos-test/sparql");
     $vocab = $this->model->getVocabularyByGraph('http://no/address');
     $this->assertInstanceOf('Vocabulary', $vocab);
   }
@@ -312,7 +312,7 @@ class ModelTest extends PHPUnit\Framework\TestCase
 
   public function testGetRdfCustomPrefix() {
     $result = $this->model->getRDF('prefix', 'http://www.skosmos.skos/prefix/p1', 'text/turtle');
-    $this->assertContains("@prefix my: <http://example.com/myns#> .", $result);
+    $this->assertStringContainsString("@prefix my: <http://example.com/myns#> .", $result);
   }
 
   /**

--- a/tests/PluginRegisterTest.php
+++ b/tests/PluginRegisterTest.php
@@ -6,7 +6,8 @@ class PluginRegisterTest extends PHPUnit\Framework\TestCase
   private $concept;
   private $mockpr;
 
-  protected function setUp() {
+  protected function setUp() : void
+  {
     $this->mockpr = $this->getMockBuilder('PluginRegister')->setConstructorArgs(array(array('global-plugin')))->setMethods(array('getPlugins'))->getMock();
     $stubplugs = array ('test-plugin' => array ( 'js' => array ( 0 => 'first.js', 1 => 'second.min.js', ), 'css' => array ( 0 => 'stylesheet.css', ), 'templates' => array ( 0 => 'template.html', ), ), 'only-css' => array ( 'css' => array ( 0 => 'super.css')), 'global-plugin' => array('js' => array('everywhere.js')));
     $this->mockpr->method('getPlugins')->will($this->returnValue($stubplugs));

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -5,7 +5,8 @@ class RequestTest extends PHPUnit\Framework\TestCase
   private $model;
   private $request;
 
-  protected function setUp() {
+  protected function setUp() : void
+  {
     putenv("LANGUAGE=en_GB.utf8");
     putenv("LC_ALL=en_GB.utf8");
     setlocale(LC_ALL, 'en_GB.utf8');

--- a/tests/ResolverTest.php
+++ b/tests/ResolverTest.php
@@ -4,7 +4,8 @@ class ResolverTest extends PHPUnit\Framework\TestCase
 {
   private $resolver;
 
-  protected function setUp() {
+  protected function setUp() : void
+  {
     $model = new Model(new GlobalConfig('/../tests/testconfig.ttl'));
     $this->resolver = new Resolver($model);
   }

--- a/tests/RestControllerTest.php
+++ b/tests/RestControllerTest.php
@@ -15,7 +15,8 @@ class RestControllerTest extends \PHPUnit\Framework\TestCase
    * @var RestController
    */
   private $controller;
-  protected function setUp() {
+  protected function setUp() : void
+  {
     putenv("LANGUAGE=en_GB.utf8");
     putenv("LC_ALL=en_GB.utf8");
     setlocale(LC_ALL, 'en_GB.utf8');
@@ -28,7 +29,8 @@ class RestControllerTest extends \PHPUnit\Framework\TestCase
     $this->controller = new RestController($this->model);
   }
 
-  protected function tearDown() {
+  protected function tearDown() : void
+  {
     ob_clean();
   }
 

--- a/tests/VocabularyCategoryTest.php
+++ b/tests/VocabularyCategoryTest.php
@@ -5,7 +5,8 @@ class VocabularyCategoryTest extends PHPUnit\Framework\TestCase
   private $model;
   private $mockres;
 
-  protected function setUp() {
+  protected function setUp() : void
+  {
     putenv("LANGUAGE=en_GB.utf8");
     putenv("LC_ALL=en_GB.utf8");
     setlocale(LC_ALL, 'en_GB.utf8');

--- a/tests/VocabularyCategoryTest.php
+++ b/tests/VocabularyCategoryTest.php
@@ -17,10 +17,10 @@ class VocabularyCategoryTest extends PHPUnit\Framework\TestCase
 
   /**
    * @covers VocabularyCategory::__construct
-   * @expectedException Exception
-   * @expectedExceptionMessage Invalid constructor parameter given to DataObject.
    */
   public function testConstructorWithInvalidParameters() {
+    $this->expectException(InvalidArgumentException::class);
+    $this->expectExceptionMessage("Invalid constructor parameter given to DataObject");
     $vcat = new VocabularyCategory('invalid', 'invalid');
     $this->assertNotNull($vcat);
   }

--- a/tests/VocabularyConfigTest.php
+++ b/tests/VocabularyConfigTest.php
@@ -9,7 +9,8 @@ class VocabularyConfigTest extends PHPUnit\Framework\TestCase
    * @covers VocabularyConfig::getConfig
    * @throws Exception
    */
-  protected function setUp() {
+  protected function setUp() : void
+  {
     putenv("LANGUAGE=en_GB.utf8");
     putenv("LC_ALL=en_GB.utf8");
     setlocale(LC_ALL, 'en_GB.utf8');

--- a/tests/VocabularyConfigTest.php
+++ b/tests/VocabularyConfigTest.php
@@ -112,10 +112,11 @@ class VocabularyConfigTest extends PHPUnit\Framework\TestCase
 
   /**
    * @covers VocabularyConfig::getDefaultLanguage
-   * @expectedException PHPUnit\Framework\Error\Error
    */
   public function testGetDefaultLanguageWhenNotSet() {
     $vocab = $this->model->getVocabulary('testdiff');
+    $this->expectError();
+    $this->expectErrorMessage("Default language for vocabulary 'testdiff' unknown, choosing 'en'.");
     $lang = $vocab->getConfig()->getDefaultLanguage();
   }
 
@@ -171,10 +172,11 @@ class VocabularyConfigTest extends PHPUnit\Framework\TestCase
 
   /**
    * @covers VocabularyConfig::getDataURLs
-   * @expectedException PHPUnit\Framework\Error\Warning
    */
   public function testGetDataURLsNotGuessable() {
     $vocab = $this->model->getVocabulary('test');
+    $this->expectWarning();
+    $this->expectWarningMessage("Could not guess format for <http://skosmos.skos/dump/test/>.");
     $url = $vocab->getConfig()->getDataURLs();
   }
 
@@ -200,10 +202,11 @@ class VocabularyConfigTest extends PHPUnit\Framework\TestCase
 
   /**
    * @covers VocabularyConfig::getDataURLs
-   * @expectedException PHPUnit\Framework\Error\Warning
    */
   public function testGetDataURLsMarcNotDefined() {
     $vocab = $this->model->getVocabulary('marc-undefined');
+    $this->expectWarning();
+    $this->expectWarningMessage("Could not guess format for <http://skosmos.skos/dump/test/marc-undefined.mrcx>.");
     $url = $vocab->getConfig()->getDataURLs();
     $this->assertEquals(array(), $url);
   }
@@ -523,10 +526,11 @@ class VocabularyConfigTest extends PHPUnit\Framework\TestCase
 
   /**
    * @covers VocabularyConfig::getPropertyOrder
-   * @expectedException PHPUnit\Framework\Error\Error
    */
   public function testGetPropertyOrderUnknown() {
     $vocab = $this->model->getVocabulary('testUnknownPropertyOrder');
+    $this->expectWarning();
+    $this->expectWarningMessage("Property order for vocabulary 'testUnknownPropertyOrder' unknown, using default order");
     $params = $vocab->getConfig()->getPropertyOrder();
     $this->assertEquals(VocabularyConfig::DEFAULT_PROPERTY_ORDER, $params);
   }

--- a/tests/VocabularyTest.php
+++ b/tests/VocabularyTest.php
@@ -286,7 +286,7 @@ class VocabularyTest extends \PHPUnit\Framework\TestCase
    * @covers Vocabulary::searchConceptsAlphabetical
    * @covers JenaTextSparql::queryConceptsAlphabetical
    * @covers JenaTextSparql::generateAlphabeticalListQuery
-   * @covers JenaTextSparql::transformAlphabeticalListResults
+   * @covers GenericSparql::transformAlphabeticalListResults
    */
   public function testSearchConceptsAlphabeticalQualifiedNotation() {
     $vocab = $this->jenamodel->getVocabulary('test-qualified-notation');
@@ -329,7 +329,7 @@ class VocabularyTest extends \PHPUnit\Framework\TestCase
    * @covers Vocabulary::searchConceptsAlphabetical
    * @covers JenaTextSparql::queryConceptsAlphabetical
    * @covers JenaTextSparql::generateAlphabeticalListQuery
-   * @covers JenaTextSparql::transformAlphabeticalListResults
+   * @covers GenericSparql::transformAlphabeticalListResults
    */
   public function testSearchConceptsAlphabeticalQualifiedBroader() {
     $vocab = $this->jenamodel->getVocabulary('test-qualified-broader');

--- a/tests/VocabularyTest.php
+++ b/tests/VocabularyTest.php
@@ -7,7 +7,8 @@ class VocabularyTest extends \PHPUnit\Framework\TestCase
    */
   private $model;
 
-  protected function setUp() {
+  protected function setUp() : void
+  {
     putenv("LANGUAGE=en_GB.utf8");
     putenv("LC_ALL=en_GB.utf8");
     setlocale(LC_ALL, 'en_GB.utf8');

--- a/tests/WebControllerTest.php
+++ b/tests/WebControllerTest.php
@@ -7,7 +7,8 @@ class WebControllerTest extends TestCase
     private $webController;
     private $model;
 
-    protected function setUp() {
+    protected function setUp() : void
+    {
         $globalConfig = new GlobalConfig('/../tests/testconfig.ttl');
         $this->model = Mockery::mock(new Model($globalConfig));
         $this->webController = new WebController($this->model);


### PR DESCRIPTION
We have been using obsolete PHPUnit 7, which is not compatible with PHP 7.4 and is no longer supported.
This PR upgrades to PHPUnit 8, which is still supported (but only in Life Support mode).
It requires PHP 7.2, so this PR drops support for PHP 7.1 and attempts to get Travis CI tests working on PHP 7.4.

Some tests had to be modified (add void return types for setUp and tearDown methods) to keep PHPUnit 8 happy. There are warnings about deprecated PHPUnit features that should be addressed as well but they are not fatal (yet).

Fixes #920