### PR TITLE
Fix calculation of minimum time in feedback honeypot

### DIFF
--- a/controller/Honeypot.php
+++ b/controller/Honeypot.php
@@ -11,14 +11,14 @@ class Honeypot
     /**
      * Enable the Honeypot validation
      */
-    public function enable()
+    public function enable() : void
     {
         $this->disabled = false;
     }
     /**
      * Disable the Honeypot validation
      */
-    public function disable()
+    public function disable() : void
     {
         $this->disabled = true;
     }
@@ -28,7 +28,7 @@ class Honeypot
      * @param  string $honey_time
      * @return string
      */
-    public function generate($honey_name, $honey_time)
+    public function generate($honey_name, $honey_time) : string
     {
         // Encrypt the current time
         $honey_time_encrypted = $this->getEncryptedTime();
@@ -43,7 +43,7 @@ class Honeypot
     * @param  mixed $value
     * @return boolean
     */
-    public function validateHoneypot($value)
+    public function validateHoneypot($value) : bool
     {
         if ($this->disabled) {
             return true;
@@ -57,7 +57,7 @@ class Honeypot
      * @param  int $minDelta minimum time difference in seconds
      * @return boolean
      */
-    public function validateHoneytime($value, $minDelta)
+    public function validateHoneytime($value, $minDelta) : bool
     {
         if ($this->disabled) {
             return true;
@@ -72,7 +72,7 @@ class Honeypot
      * Get encrypted time
      * @return string
      */
-    public function getEncryptedTime()
+    public function getEncryptedTime() : string
     {
         return base64_encode(time());
     }
@@ -82,7 +82,7 @@ class Honeypot
      * @param  mixed $time
      * @return string|null
      */
-    public function decryptTime($time)
+    public function decryptTime($time) : int
     {
         try {
             return intval(base64_decode($time));

--- a/controller/Honeypot.php
+++ b/controller/Honeypot.php
@@ -80,9 +80,9 @@ class Honeypot
      * Decrypt the given time
      *
      * @param  mixed $time
-     * @return string|null
+     * @return int|null
      */
-    public function decryptTime($time) : int
+    public function decryptTime($time) : ?int
     {
         try {
             return intval(base64_decode($time));

--- a/controller/Honeypot.php
+++ b/controller/Honeypot.php
@@ -53,11 +53,11 @@ class Honeypot
     /**
      * Validate honey time was within the time limit
      *
-     * @param  mixed $value
-     * @param  array $parameters
+     * @param  string $value base64 encoded time value
+     * @param  int $minDelta minimum time difference in seconds
      * @return boolean
      */
-    public function validateHoneytime($value, $parameters)
+    public function validateHoneytime($value, $minDelta)
     {
         if ($this->disabled) {
             return true;
@@ -65,8 +65,8 @@ class Honeypot
 
         // Get the decrypted time
         $value = $this->decryptTime($value);
-        // The current time should be greater than the time the form was built + the speed option
-        return ( is_numeric($value) && time() > ($value + $parameters[0]) );
+        // The current time should be greater than the time the form was built + minimum
+        return ( is_numeric($value) && time() > ($value + $minDelta) );
     }
     /**
      * Get encrypted time
@@ -85,7 +85,7 @@ class Honeypot
     public function decryptTime($time)
     {
         try {
-            return base64_decode($time);
+            return intval(base64_decode($time));
         } catch (\Exception $exception) {
             return null;
         }

--- a/tests/FeedbackTest.php
+++ b/tests/FeedbackTest.php
@@ -21,6 +21,12 @@ class FeedbackTest extends PHPUnit\Framework\TestCase
    * @covers Honeypot::getEncryptedTime
    */
   public function testHoneypotFieldsGenerated() {
+    $this->controller
+        ->shouldReceive('sendFeedback')
+        ->withAnyArgs()
+        ->once()
+        ->andReturn(true);
+
     $initialTime = time();
     ob_start();
     $this->controller->invokeFeedbackForm($this->request);
@@ -68,7 +74,8 @@ class FeedbackTest extends PHPUnit\Framework\TestCase
     $this->request
         ->shouldReceive('getQueryParamPOST')
         ->with('user-captcha')
-        ->andReturn(base64_encode(time() - 5 * 60));
+        // 6 seconds ago is more than the default 5 seconds
+        ->andReturn(base64_encode(time() - 6));
     $this->controller
         ->shouldReceive('sendFeedback')
         ->withAnyArgs()
@@ -112,7 +119,7 @@ class FeedbackTest extends PHPUnit\Framework\TestCase
         ->shouldReceive('getQueryParamPOST')
         ->with('user-captcha')
         // 0 seconds ago is less than the default 5 seconds
-        ->andReturn(base64_encode(time() - 0 * 60));
+        ->andReturn(base64_encode(time() - 0));
     $this->controller
         ->shouldReceive('sendFeedback')
         ->withAnyArgs()
@@ -152,8 +159,8 @@ class FeedbackTest extends PHPUnit\Framework\TestCase
     $this->request
         ->shouldReceive('getQueryParamPOST')
         ->with('user-captcha')
-        // 0 seconds ago is less than the default 5 seconds
-        ->andReturn(base64_encode(time() - 0 * 60));
+        // 2 seconds ago is less than the default 5 seconds
+        ->andReturn(base64_encode(time() - 2));
     $this->controller
         ->shouldReceive('sendFeedback')
         ->withAnyArgs()
@@ -193,7 +200,7 @@ class FeedbackTest extends PHPUnit\Framework\TestCase
     $this->request
         ->shouldReceive('getQueryParamPOST')
         ->with('user-captcha')
-        ->andReturn(base64_encode(time() - 5 * 60));
+        ->andReturn(base64_encode(time() - 5));
     $this->controller
         ->shouldReceive('sendFeedback')
         ->withAnyArgs()


### PR DESCRIPTION
While trying to get the Skosmos tests working under PHP 7.4 (#1127), I got some PHP errors from the code related to the honeypot designed to deter spammers from using the feedback form (related: #875). Digging further, I noticed that the calculations used to determine the minimum time between loading the feedback page and submitting the form were not correct; unfortunately the unit tests designed to check them were also buggy, so this was not discovered earlier! Probably the timer in the honeypot has never worked properly.

Anyway, this PR fixes several interrelated problems with the honeypot timer:

1. The parameters of Honeypot::validateHoneytime are now better specified; in particular, instead of a vague `$parameters` (which was assigned to an integer, but used as `$parameters[0]` - leading to the PHP7.4 error) it takes an integer parameter `$minDelta`
2. The Honeypot::decryptTime method now returns an integer, not a string. This is probably not crucial as PHP is pretty relaxed about typing, but it felt like a good idea anyway since this is used as an integer value.
3. The test method FeedbackTest::testHoneypotFieldsGenerated now properly mocks the `sendFeedback` method of the controller; it should always have done this, but not doing so didn't cause problems since other bugs obscured it.
4. Several methods in FeedbackTest where time offsets are used have been corrected. Previously they multiplied values by 60 (converted seconds to minutes) for no reason. I avoided values that were just at the limit of the uiHoneypotTime value, so I used 2 seconds and 6 seconds instead of 0 seconds and 5 seconds, which are special cases and could easily lead to wrong conclusions (and in fact were).