### PR TITLE
Add a noscript tag to alert users when they have not enabled JS

### DIFF
--- a/view/light.twig
+++ b/view/light.twig
@@ -20,6 +20,9 @@
 <title>{{ ServiceName }}{% block title %}{% endblock %}</title>
 </head>
 <body{% if request.vocabid == '' and request.page != 'feedback' and request.page != 'about' %} class="frontpage-logo"{% else %} class="vocab-{{ request.vocabid }}"{% endif %}>
+  <noscript>
+    <strong>We're sorry but Skosmos doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>
+  </noscript>
   <a id="skiptocontent" href="{{ request.langurl }}#maincontent">{% trans "Skip to main" %}</a>
   {% if request.vocabid != '' or request.page == 'feedback' or request.page == 'about' %}<div class="topbar-white">{% endif %}
     <div class="topbar{% if request.vocabid != '' or request.vocabid == 'feedback' or request.vocabid == 'about' %} topbar-white{% else %} frontpage{% endif %}">

--- a/view/light.twig
+++ b/view/light.twig
@@ -21,7 +21,7 @@
 </head>
 <body{% if request.vocabid == '' and request.page != 'feedback' and request.page != 'about' %} class="frontpage-logo"{% else %} class="vocab-{{ request.vocabid }}"{% endif %}>
   <noscript>
-    <strong>We're sorry but Skosmos doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>
+    <strong>{% trans "We're sorry but Skosmos doesn't work properly without JavaScript enabled. Please enable it to continue." %}</strong>
   </noscript>
   <a id="skiptocontent" href="{{ request.langurl }}#maincontent">{% trans "Skip to main" %}</a>
   {% if request.vocabid != '' or request.page == 'feedback' or request.page == 'about' %}<div class="topbar-white">{% endif %}


### PR DESCRIPTION
While testing the #700 PR, I refreshed the page a few times thinking there was something wrong in my container. Then I realized NoScript had prevented the JS of running in the Skosmos application.

Without JavaScript it's not able to search or navigate the application, so I have added in this PR the exact same `noscript` that comes by default in Vue.js applications (I believe React's message/placement is very similar).

That's useful for users with extensions such as NoScript. I know a few other friends using it here in New Zealand (even my wife now), but I guess in Europe there might be some too that are concerned with cookies/privacy/etc. So maybe it's worth alerting them to enable for Skosmos?

Cheers
Bruno

![Screenshot from 2021-03-05 10-58-30](https://user-images.githubusercontent.com/304786/110036685-41f9dc80-7da2-11eb-87ad-c26f13446ff0.png)
