### PR TITLE
Automatically load rest of alphabetical index on vocabulary home page

### DIFF
--- a/resource/js/docready.js
+++ b/resource/js/docready.js
@@ -57,16 +57,14 @@ $(function() { // DOCUMENT READY
         });
         return removeThese.join(' ');
       });
-      if (settings.url.indexOf('index/') !== -1) {
-        $(".sidebar-grey").mCustomScrollbar({
-          alwaysShowScrollbar: 1,
-          scrollInertia: 0,
-          mouseWheel:{ preventDefault: true, scrollAmount: 105 },
-          snapAmount: 15,
-          snapOffset: 1,
-          callbacks: { alwaysTriggerOffsets: false, onTotalScroll: alphaWaypointCallback, onTotalScrollOffset: 300 }
-        });
-      }
+      $(".sidebar-grey-alpha").mCustomScrollbar({
+        alwaysShowScrollbar: 1,
+        scrollInertia: 0,
+        mouseWheel:{ preventDefault: true, scrollAmount: 105 },
+        snapAmount: 15,
+        snapOffset: 1,
+        callbacks: { alwaysTriggerOffsets: false, onTotalScroll: alphaWaypointCallback, onTotalScrollOffset: 300 }
+      });
     }
     // Sidenav actions only happen when doing other queries than the autocomplete.
     if (settings.url.indexOf('index') !== -1 || settings.url.indexOf('groups') !== -1) {


### PR DESCRIPTION
This PR fixes #1108: it wasn't possible to scroll down to see the full alphabetical index of the first letter (typically A) on the vocabulary front page. The normal mechanism that triggers an AJAX request when scrolling down to the bottom of the first 250 results wasn't triggered on the vocabulary home page; it only worked on the alphabetical index page.

As analyzed in [this comment](https://github.com/NatLibFi/Skosmos/issues/1108#issuecomment-770938478) the reason is that the callback for loading more lines isn't properly activated. The `if` check is too strict, it only works on the `index` page. I avoided the `if` check altogether and simply targeted the `sidebar-grey-alpha` CSS class, which is specific to the alphabetical index listings, instead of the more generic `sidebar-grey` class.