### PR TITLE
ignore phpunit cache file in git version control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ tests/jena-fuseki*
 .vagrant
 .project
 .DS_Store
+.phpunit.result.cache


### PR DESCRIPTION
follow-up fix to #1127 , suggested by @kouralex

It is [recommended](https://laravel-news.com/tips-to-speed-up-phpunit-tests) to ignore the cache file that PHPUnit generates and that helps it to remember which tests have failed in the previous run.