### PR TITLE
Add generator meta tag with Skosmos version

### DIFF
--- a/controller/WebController.php
+++ b/controller/WebController.php
@@ -305,12 +305,10 @@ class WebController extends Controller
         $template = $this->twig->loadTemplate('about.twig');
         $this->setLanguageProperties($request->getLang());
         $url = $request->getServerConstant('HTTP_HOST');
-        $version = $this->model->getVersion();
 
         echo $template->render(
             array(
                 'languages' => $this->languages,
-                'version' => $version,
                 'server_instance' => $url,
                 'request' => $request,
             ));

--- a/model/Model.php
+++ b/model/Model.php
@@ -74,7 +74,7 @@ class Model
      * it cannot be determined. The version information is based on Git tags.
      * @return string version
      */
-    public function getVersion()
+    public function getVersion() : string
     {
         $ver = null;
         if (file_exists('.git')) {

--- a/model/Model.php
+++ b/model/Model.php
@@ -78,7 +78,7 @@ class Model
     {
         $ver = null;
         if (file_exists('.git')) {
-            $ver = shell_exec('git describe --tags --always');
+            $ver = rtrim(shell_exec('git describe --tags --always'));
         }
 
         if ($ver === null) {

--- a/model/Request.php
+++ b/model/Request.php
@@ -266,4 +266,13 @@ class Request
         }
         return new PluginRegister($this->model->getConfig()->getGlobalPlugins());
     }
+
+    /**
+     * Return the version of this Skosmos installation, or "unknown" if
+     * it cannot be determined. The version information is based on Git tags.
+     * @return string version
+     */
+    public function getVersion() {
+        return $this->model->getVersion();
+    }
 }

--- a/model/Request.php
+++ b/model/Request.php
@@ -272,7 +272,8 @@ class Request
      * it cannot be determined. The version information is based on Git tags.
      * @return string version
      */
-    public function getVersion() {
+    public function getVersion() : string
+    {
         return $this->model->getVersion();
     }
 }

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -158,4 +158,11 @@ class RequestTest extends PHPUnit\Framework\TestCase
     $this->assertEquals('index', $this->request->getPage());
   }
 
+  /**
+   * @covers Request::getVersion
+   */
+  public function testGetVersion() {
+    $version = $this->request->getVersion();
+    $this->assertNotEmpty($version);
+  }
 }

--- a/view/about.twig
+++ b/view/about.twig
@@ -15,6 +15,7 @@
     <p>{% if ServiceName != 'SERVICE_NAME' %}{{ ServiceName }}{% else %}Skosmos{% endif %} {% trans "layout designed by Hahmo" %}</p>
   </div>
   <div class="version">
+    {% set version = request.version %}
     <p>{% trans %}Skosmos version {{ version }}{% endtrans %}</p>
   </div>
 </div>

--- a/view/meta.twig
+++ b/view/meta.twig
@@ -2,3 +2,4 @@
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="format-detection" content="telephone=no">
+<meta name="generator" content="Skosmos {{ request.version }}" />


### PR DESCRIPTION
Fixes #1116 

Adds this kind of meta tag, as requested by @nichtich:

    <meta name="generator" content="Skosmos v.2.9-93-g20d994b" />