### PR TITLE
Fix sorting of concepts in hierarchy that broke in PR 1133

### DIFF
--- a/resource/js/hierarchy.js
+++ b/resource/js/hierarchy.js
@@ -507,7 +507,7 @@ function getTreeConfiguration() {
         var aNode = this.get_node(a);
         var bNode = this.get_node(b);
 
-        // sort on notation if requested
+        // sort on notation if requested, and notations exist
         if (window.showNotation) {
             var aNotation = aNode.original.notation;
             var bNotation = bNode.original.notation;
@@ -524,15 +524,15 @@ function getTreeConfiguration() {
                 else return -1;
             }
             else if (bNotation) return 1;
-        } else {
-          // no sorting on notation requested
-          // make sure the tree nodes with class 'domain' are sorted before the others
-          // aDomain/bDomain will be "0" if a/b has a domain class, else "1"
-          var aDomain = (aNode.original.a_attr['class'] == 'domain') ? "0" : "1";
-          var bDomain = (bNode.original.a_attr['class'] == 'domain') ? "0" : "1";
-          return naturalCompare(aDomain + " " + aNode.text.toLowerCase(),
-                                bDomain + " " + bNode.text.toLowerCase());
-        }        
+            // NOTE: if no notations found, fall back on label comparison below
+        }
+        // no sorting on notation requested, or notations don't exist
+        // make sure the tree nodes with class 'domain' are sorted before the others
+        // aDomain/bDomain will be "0" if a/b has a domain class, else "1"
+        var aDomain = (aNode.original.a_attr['class'] == 'domain') ? "0" : "1";
+        var bDomain = (bNode.original.a_attr['class'] == 'domain') ? "0" : "1";
+        return naturalCompare(aDomain + " " + aNode.text.toLowerCase(),
+                              bDomain + " " + bNode.text.toLowerCase());
     }
   });
 }


### PR DESCRIPTION
In PR #1133, the sorting of concepts in the hierarchy view was modified to take into account the domain (if any) of concept schemes. However, as a side effect, it broke the sorting in a frequently occurring situation: when sortByNotation is enabled (which is the default) but no notation codes are actually defined in the vocabulary. This happens e.g. in YSO.

Original situation (good), concepts are alphabetically ordered:

![image](https://user-images.githubusercontent.com/1132830/111625359-6ec3e000-87f5-11eb-9e0f-1d9df010bfa3.png)

Situation after PR #1133 when sortByNotation is enabled (bad), not ordered:

![image](https://user-images.githubusercontent.com/1132830/111625450-89965480-87f5-11eb-99f0-85688511efb1.png)

The problem was that PR #1133 introduced an `if...else` structure but it didn't take into account the possibility of having sortByNotation enabled but not having any notations in the vocabulary data.

The solution is simply to remove the `else` block, so that the code that used to be in the `else` block is also executed if execution falls through the other `if` clauses. I've also added comments to highlight this somewhat unusual execution flow.

Thanks to @kouralex for originally reporting this!