### PR TITLE
Prepare code for jQuery 3.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
     } 
   },
   "require": {
-    "components/jquery": "2.2.*",
+    "components/jquery": "3.5.*",
     "components/jqueryui": "1.12.*",
     "components/handlebars.js": "v4.7.6",
     "davidstutz/bootstrap-multiselect": "v0.9.13",

--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
     } 
   },
   "require": {
-    "components/jquery": "3.5.*",
+    "components/jquery": "2.2.*",
     "components/jqueryui": "1.12.*",
     "components/handlebars.js": "v4.7.6",
     "davidstutz/bootstrap-multiselect": "v0.9.13",

--- a/resource/js/docready.js
+++ b/resource/js/docready.js
@@ -1,6 +1,6 @@
 $(function() { // DOCUMENT READY
 
-  var spinner = '<div class="loading-spinner"><span class="spinner-text">'+ loading_text + '</span><span class="spinner" /></div>';
+  var spinner = '<div class="loading-spinner"><span class="spinner-text">'+ loading_text + '</span><span class="spinner"></span></div>';
   var searchString = ''; // stores the search field's value before autocomplete selection changes it
   var selectedVocabs = [];
   var vocabId;
@@ -14,7 +14,7 @@ $(function() { // DOCUMENT READY
   shortenProperties();
 
   // kills the autocomplete after a form submit so we won't have to wait for the ajax to complete.
-  $('.navbar-form').submit(
+  $('.navbar-form').on('submit',
     function() {
       $('#search-field').typeahead('destroy');
       $.ajaxQ.abortAll();
@@ -198,8 +198,8 @@ $(function() { // DOCUMENT READY
   // ajaxing the concept count and the preflabel counts on the vocabulary front page
   if ($('#vocab-info').length && $('#statistics').length) {
     // adding the spinners
-    $('#counts tr:nth-of-type(1)').after('<tr><td><span class="spinner" /></td></td></tr>');
-    $('#statistics tr:nth-of-type(1)').after('<tr><td><span class="spinner" /></td></td></tr>');
+    $('#counts tr:nth-of-type(1)').after('<tr><td><span class="spinner"></span></td></td></tr>');
+    $('#statistics tr:nth-of-type(1)').after('<tr><td><span class="spinner"></span></td></td></tr>');
     $.ajax({
       url : rest_base_url + vocab + '/vocabularyStatistics',
       req_kind: $.ajaxQ.requestKind.GLOBAL,
@@ -501,7 +501,7 @@ $(function() { // DOCUMENT READY
 
   // Event handlers for the language selection links for setting the cookie
   $('#language a').each( function(index, el) {
-    $(el).click(function() {
+    $(el).on('click', function() {
       var langCode = el.id.substr(el.id.indexOf("-") + 1);
       setLangCookie(langCode);
     });
@@ -579,7 +579,7 @@ $(function() { // DOCUMENT READY
     createCookie('SKOSMOS_SEARCH_LANG', qlang, 365);
   }
 
-  $('.lang-button').click(function() {
+  $('.lang-button').on('click', function() {
     qlang = $(this)[0].attributes.hreflang ? $(this)[0].attributes.hreflang.value : 'anything';
     $('#lang-dropdown-toggle').html($(this).html() + ' <span class="caret"></span>');
     $('#lang-input').val(qlang);
@@ -587,7 +587,7 @@ $(function() { // DOCUMENT READY
     if (concepts) { concepts.clear(); }
   });
 
-  $('.lang-button, .lang-button-all').click(function() {
+  $('.lang-button, .lang-button-all').on('click', function() {
     $('#search-field').focus();
   });
 
@@ -597,7 +597,7 @@ $(function() { // DOCUMENT READY
   }
 
   // disables the button with an empty search form
-  $('#search-field').keyup(function() {
+  $('#search-field').on('keyup', function() {
     var empty = false;
     $('#search-field').each(function() {
       if ($(this).val().length === 0) { empty = true; }
@@ -779,7 +779,7 @@ $(function() { // DOCUMENT READY
         source: concepts.ttAdapter()
     }).on('typeahead:cursorchanged', function() {
       $('.tt-dropdown-menu').mCustomScrollbar("scrollTo", '.tt-cursor');
-    }).on('typeahead:selected', onSelection).bind('focus', function() {
+    }).on('typeahead:selected', onSelection).on('focus', function() {
       $('#search-field').typeahead('open');
     }).after(clearButton).on('keypress', function() {
       if ($typeahead.val().length > 0 && $(this).hasClass('clear-search-dark') === false) {
@@ -811,7 +811,8 @@ $(function() { // DOCUMENT READY
   });
 
   // Some form validation for the feedback form
-  $("#send-feedback").click(function() {
+  $('#send-feedback').on('click', function() {
+      $('#email').removeClass('missing-value');
       $('#message').removeClass('missing-value');
       $('#msgsubject').removeClass('missing-value');
       var emailMessageVal = $("#message").val();
@@ -829,7 +830,7 @@ $(function() { // DOCUMENT READY
   });
 
   // Initializes the waypoints plug-in used for the search listings.
-  var $loading = $("<p>" + loading_text + "&hellip;<span class='spinner'/></p>");
+  var $loading = $("<p>" + loading_text + "&hellip;<span class='spinner'></span></p>");
   var $trigger = $('.search-result:nth-last-of-type(6)');
   var options = { offset : '100%', continuous: false, triggerOnce: true };
   var alpha_complete = false;
@@ -1060,7 +1061,7 @@ $(function() { // DOCUMENT READY
   if ($('#alpha').hasClass('active') && $('#vocab-info').length === 1 && $('.alphabetical-search-results').length === 0) {
     // taking into account the possibility that the lang parameter has been changed by the WebController.
     var urlLangCorrected = vocab + '/' + lang + '/index?limit=250&offset=0&clang=' + clang;
-    $('.sidebar-grey').empty().append('<div class="loading-spinner"><span class="spinner-text">'+ loading_text + '</span><span class="spinner" /></div>');
+    $('.sidebar-grey').empty().append('<div class="loading-spinner"><span class="spinner-text">'+ loading_text + '</span><span class="spinner"></span></div>');
     $.ajax({
       url : urlLangCorrected,
       req_kind: $.ajaxQ.requestKind.SIDEBAR,
@@ -1114,7 +1115,7 @@ $(function() { // DOCUMENT READY
         source: concepts.ttAdapter()
     }).on('typeahead:cursorchanged', function() {
       $('.tt-dropdown-menu').mCustomScrollbar("scrollTo", '.tt-cursor');
-    }).on('typeahead:selected', onSelection).bind('focus', function() {
+    }).on('typeahead:selected', onSelection).on('focus', function() {
       $('#search-field').typeahead('open');
     });
   }

--- a/resource/js/docready.js
+++ b/resource/js/docready.js
@@ -812,7 +812,6 @@ $(function() { // DOCUMENT READY
 
   // Some form validation for the feedback form
   $('#send-feedback').on('click', function() {
-      $('#email').removeClass('missing-value');
       $('#message').removeClass('missing-value');
       $('#msgsubject').removeClass('missing-value');
       var emailMessageVal = $("#message").val();

--- a/resource/js/scripts.js
+++ b/resource/js/scripts.js
@@ -185,7 +185,7 @@ function setLangCookie(lang) {
 }
 
 function clearResultsAndAddSpinner() {
-  var $loading = $("<div class='search-result'><p>" + loading_text + "&hellip;<span class='spinner'/></p></div>"); 
+  var $loading = $("<div class='search-result'><p>" + loading_text + "&hellip;<span class='spinner'></span></p></div>");
   $('.search-result-listing').empty().append($loading);
 }
   

--- a/view/scripts.twig
+++ b/view/scripts.twig
@@ -1,4 +1,4 @@
-<script type="text/javascript">
+<script>
 <!-- translations needed in javascript -->
 var noResultsTranslation = "{% trans %}No results{% endtrans %}";
 var loading_text = "{% trans %}Loading more items{% endtrans %}";
@@ -45,24 +45,24 @@ var pluginParameters = {{ plugin_params|raw }};
 {{ search_results|first.dumpJsonLd|raw }}
 </script>
 {% endif %}
-<script type="text/javascript" src="vendor/components/jquery/jquery.min.js"></script>
-<script type="text/javascript" src="vendor/components/jqueryui/jquery-ui.min.js"></script>
-<script type="text/javascript" src="vendor/components/handlebars.js/handlebars.min.js"></script>
-<script type="text/javascript" src="vendor/vakata/jstree/dist/jstree.min.js"></script>
-<script type="text/javascript" src="vendor/twitter/typeahead.js/dist/typeahead.bundle.min.js"></script>
-<script type="text/javascript" src="vendor/medialize/uri.js/src/URI.min.js"></script>
-<script type="text/javascript" src="vendor/davidstutz/bootstrap-multiselect/dist/js/bootstrap-multiselect.js"></script>
-<script type="text/javascript" src="vendor/twitter/bootstrap/dist/js/bootstrap.js"></script>
-<script type="text/javascript" src="vendor/grimmlink/qtip2/dist/jquery.qtip.min.js"></script>
-<script type="text/javascript" src="vendor/etdsolutions/waypoints/jquery.waypoints.min.js"></script>
-<script type="text/javascript" src="vendor/newerton/jquery-mousewheel/jquery.mousewheel.min.js"></script>
-<script type="text/javascript" src="vendor/pamelafox/lscache/lscache.min.js"></script>
-<script type="text/javascript" src="vendor/malihu/malihu-custom-scrollbar-plugin/jquery.mCustomScrollbar.concat.min.js"></script>
-<script type="text/javascript" src="resource/js/config.js"></script>
-<script type="text/javascript" src="resource/js/hierarchy.js"></script>
-<script type="text/javascript" src="resource/js/groups.js"></script>
-<script type="text/javascript" src="resource/js/scripts.js"></script>
-{% for files in request.plugins.pluginsJS %}{% for file in files %}<script type="text/javascript" src="{{ file }}"></script>{% endfor %}{% endfor %}
-{% if request.plugins.callbacks %}<script type="text/javascript">var pluginCallbacks = [{% for function in request.plugins.callbacks %}{% if not loop.first %}, {% endif %}"{{ function }}"{% endfor %}];</script>{% endif %}
-<script type="text/javascript" src="resource/js/docready.js"></script>
+<script src="vendor/components/jquery/jquery.min.js"></script>
+<script src="vendor/components/jqueryui/jquery-ui.min.js"></script>
+<script src="vendor/components/handlebars.js/handlebars.min.js"></script>
+<script src="vendor/vakata/jstree/dist/jstree.min.js"></script>
+<script src="vendor/twitter/typeahead.js/dist/typeahead.bundle.min.js"></script>
+<script src="vendor/medialize/uri.js/src/URI.min.js"></script>
+<script src="vendor/davidstutz/bootstrap-multiselect/dist/js/bootstrap-multiselect.js"></script>
+<script src="vendor/twitter/bootstrap/dist/js/bootstrap.js"></script>
+<script src="vendor/grimmlink/qtip2/dist/jquery.qtip.min.js"></script>
+<script src="vendor/etdsolutions/waypoints/jquery.waypoints.min.js"></script>
+<script src="vendor/newerton/jquery-mousewheel/jquery.mousewheel.min.js"></script>
+<script src="vendor/pamelafox/lscache/lscache.min.js"></script>
+<script src="vendor/malihu/malihu-custom-scrollbar-plugin/jquery.mCustomScrollbar.concat.min.js"></script>
+<script src="resource/js/config.js"></script>
+<script src="resource/js/hierarchy.js"></script>
+<script src="resource/js/groups.js"></script>
+<script src="resource/js/scripts.js"></script>
+{% for files in request.plugins.pluginsJS %}{% for file in files %}<script src="{{ file }}"></script>{% endfor %}{% endfor %}
+{% if request.plugins.callbacks %}<script>var pluginCallbacks = [{% for function in request.plugins.callbacks %}{% if not loop.first %}, {% endif %}"{{ function }}"{% endfor %}];</script>{% endif %}
+<script src="resource/js/docready.js"></script>
 


### PR DESCRIPTION
This PR mitigates warnings related to jQuery 3.x upgrade that were encountered whilst testing the product with jQuery 3.6.0 and jQuery Migrate 3.3.2 plugin. Additionally, fixes some validator.w3.org warnings.

Next step: replace/upgrade libraries that depend on jQuery 2.x or cause hassle, list includes (but is not necessarily limited to):
* malihu/malihu-custom-scrollbar-plugin (visible difference between jQuery 2.x and 3.x)
* grimmlink/qtip2 (jQuery migration plugin warnings)
* twitter/typeahead.js (jQuery migration plugin warnings)
* twitter/bootstrap (jQuery migration plugin warnings)
* etdsolutions/waypoints (jQuery migration plugin warnings)
* vakata/jstree (jQuery migration plugin warnings)

Some of these "only" use deprecated features that are not per se dangerous and jQuery Migrate plugin (which restores old API) can be used in production for a while. See https://github.com/jquery/jquery-migrate/blob/main/warnings.md for more information.

Additional info: https://jquery.com/upgrade-guide/3.0/ and https://jquery.com/upgrade-guide/3.5/