### PR TITLE
Avoid sending empty email when invoking the feedback form. 

### DIFF
--- a/controller/WebController.php
+++ b/controller/WebController.php
@@ -206,22 +206,21 @@ class WebController extends Controller
         $vocab = $request->getVocab();
 
         $feedbackSent = false;
-        $feedbackMsg = null;
         if ($request->getQueryParamPOST('message')) {
             $feedbackSent = true;
             $feedbackMsg = $request->getQueryParamPOST('message');
-        }
-        $feedbackName = $request->getQueryParamPOST('name');
-        $feedbackEmail = $request->getQueryParamPOST('email');
-        $msgSubject = $request->getQueryParamPOST('msgsubject');
-        $feedbackVocab = $request->getQueryParamPOST('vocab');
-        $feedbackVocabEmail = ($feedbackVocab !== null && $feedbackVocab !== '') ?
-            $this->model->getVocabulary($feedbackVocab)->getConfig()->getFeedbackRecipient() : null;
-        // if the hidden field has been set a value we have found a spam bot
-        // and we do not actually send the message.
-        if ($this->honeypot->validateHoneypot($request->getQueryParamPOST('item-description')) &&
-            $this->honeypot->validateHoneytime($request->getQueryParamPOST('user-captcha'), $this->model->getConfig()->getHoneypotTime())) {
-            $this->sendFeedback($request, $feedbackMsg, $msgSubject, $feedbackName, $feedbackEmail, $feedbackVocab, $feedbackVocabEmail);
+            $feedbackName = $request->getQueryParamPOST('name');
+            $feedbackEmail = $request->getQueryParamPOST('email');
+            $msgSubject = $request->getQueryParamPOST('msgsubject');
+            $feedbackVocab = $request->getQueryParamPOST('vocab');
+            $feedbackVocabEmail = ($feedbackVocab !== null && $feedbackVocab !== '') ?
+                $this->model->getVocabulary($feedbackVocab)->getConfig()->getFeedbackRecipient() : null;
+            // if the hidden field has been set a value we have found a spam bot
+            // and we do not actually send the message.
+            if ($this->honeypot->validateHoneypot($request->getQueryParamPOST('item-description')) &&
+                $this->honeypot->validateHoneytime($request->getQueryParamPOST('user-captcha'), $this->model->getConfig()->getHoneypotTime())) {
+                $this->sendFeedback($request, $feedbackMsg, $msgSubject, $feedbackName, $feedbackEmail, $feedbackVocab, $feedbackVocabEmail);
+            }
         }
         echo $template->render(
             array(


### PR DESCRIPTION
There was a logic error in WebController. The feedback message is always sent even when just displaying the feedback form. This was previously hidden by the honeypot check, but the bug surfaced after the changes to honeypot code in PR #1131.

Fixes #1139