### PR TITLE
Add topbar-container css hook

### DIFF
--- a/view/light.twig
+++ b/view/light.twig
@@ -24,11 +24,11 @@
     <strong>{% trans "We're sorry but Skosmos doesn't work properly without JavaScript enabled. Please enable it to continue." %}</strong>
   </noscript>
   <a id="skiptocontent" href="{{ request.langurl }}#maincontent">{% trans "Skip to main" %}</a>
-  {% if request.vocabid != '' or request.page == 'feedback' or request.page == 'about' %}<div class="topbar-white">{% endif %}
+  <div class="topbar-container {% if request.vocabid != '' or request.page == 'feedback' or request.page == 'about' %}topbar-white{% else %}topbar-frontpage{% endif %}">
     <div class="topbar{% if request.vocabid != '' or request.vocabid == 'feedback' or request.vocabid == 'about' %} topbar-white{% else %} frontpage{% endif %}">
       {% include 'topbar.twig' %}
     </div>
-  {% if request.vocabid != '' or request.page == 'feedback' or request.page == 'about' %}</div>{% endif %}
+  </div>
   {% block headernav %}
   <div class="headerbar{% if request.vocabid == '' or global_search %} frontpage-spacing{% endif %}">
     {% include 'headerbar.twig' %}


### PR DESCRIPTION
At the moment I'm not sure if it's possible to make the frontpage topbar look the same as the topbar on other pages with just CSS, since the outer div is missing on the frontpage.

This PR adds an outer div to the frontpage topbar, which makes it easier to style the frontpage topbar as you like. I've added a class name "topbar-container", but otherwise kept the old class names, so I wouldn't expect this change to break anyone's CSS.

## Frontpage

```diff
+ <div class="topbar-container topbar-frontpage">
    <div class="topbar frontpage">
```

## Non-frontpage

```diff
- <div class="topbar-white">
+ <div class="topbar-container topbar-white">
    <div class="topbar topbar-white">
```
