### PR TITLE
Install Composer dependencies for Docker + add .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,3 +11,4 @@ tests/jena-fuseki*
 .project
 .DS_Store
 .phpunit.result.cache
+.git

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+config.ttl
+build
+vendor
+report
+components
+plugins/*
+composer.phar
+composer.lock
+tests/jena-fuseki*
+.vagrant
+.project
+.DS_Store
+.phpunit.result.cache

--- a/dockerfiles/Dockerfile.ubuntu
+++ b/dockerfiles/Dockerfile.ubuntu
@@ -68,6 +68,9 @@ WORKDIR /var/www/html
 RUN rm index.html
 
 COPY . /var/www/html
+RUN curl -sS https://getcomposer.org/installer | php
+RUN php composer.phar install --no-dev
+
 
 # Configure Skosmos
 COPY dockerfiles/config/config-docker.ttl /var/www/html/config.ttl


### PR DESCRIPTION
This PR contains the changes from @jrvosse's PR #1157, i.e. Composer dependencies are now installed within the Docker container.

I'm still a bit nervous about the interaction between changes done on source tree and the Docker image. I thought it would be better to have a cleaner separation between them - for example, whatever is (or isn't) done with Composer on the original source tree shouldn't affect how Composer packages are installed within the container.

So in an additional commit, I created a simple `.dockerfile` (based on `.gitignore`) that omits the following files and directories when copying files inside the Docker container:

```
config.ttl
build
vendor
report
components
plugins/*
composer.phar
composer.lock
tests/jena-fuseki*
.vagrant
.project
.DS_Store
.phpunit.result.cache
```

Not sure if this is the exact set we want but I think this is a good starting point, and it seems to work. These are files and directories that are not under version control anyway, and with Composer running inside the container, building a Docker image from a fresh git clone-d source tree already works (I just tested it), so I don't think there should be any danger in excluding these files. As a bonus, potentially large files such as Fuseki installations used by the test suite are excluded from the Docker image as well.

Comments @jrvosse @kinow ?