### PR TITLE
Specify SPARQL endpoint URL via environment variable

### DIFF
--- a/model/GlobalConfig.php
+++ b/model/GlobalConfig.php
@@ -189,6 +189,8 @@ class GlobalConfig extends BaseConfig {
         $endpoint = $this->resource->get('skosmos:sparqlEndpoint');
         if ($endpoint) {
             return $endpoint->getUri();
+        } elseif (getenv('SKOSMOS_SPARQL_ENDPOINT')) {
+            return getenv('SKOSMOS_SPARQL_ENDPOINT');
         } else {
             return 'http://localhost:3030/ds/sparql';
         }

--- a/model/Vocabulary.php
+++ b/model/Vocabulary.php
@@ -31,14 +31,7 @@ class Vocabulary extends DataObject implements Modifiable
      */
     public function getEndpoint()
     {
-        $endpoint = $this->resource->get('void:sparqlEndpoint');
-        if ($endpoint) {
-            return $endpoint->getUri();
-        } elseif (getenv('SKOSMOS_SPARQL_ENDPOINT')) {
-            return getenv('SKOSMOS_SPARQL_ENDPOINT');
-        } else {
-            return 'http://localhost:3030/ds/sparql';
-        }
+        return $this->config->getSparqlEndpoint();
     }
 
     /**
@@ -48,12 +41,7 @@ class Vocabulary extends DataObject implements Modifiable
      */
     public function getGraph()
     {
-        $graph = $this->resource->get('skosmos:sparqlGraph');
-        if ($graph) {
-            $graph = $graph->getUri();
-        }
-
-        return $graph;
+        return $this->config->getSparqlGraph();
     }
 
     /**
@@ -63,10 +51,10 @@ class Vocabulary extends DataObject implements Modifiable
      */
     public function getSparql()
     {
-        $endpoint = $this->getEndpoint();
-        $graph = $this->getGraph();
-        $dialect = $this->resource->get('skosmos:sparqlDialect');
-        $dialect = $dialect ? $dialect->getValue() : $this->model->getConfig()->getDefaultSparqlDialect();
+        $endpoint = $this->config->getSparqlEndpoint();
+        $graph = $this->config->getSparqlGraph();
+        $dialect = $this->config->getSparqlDialect();
+        $dialect = $dialect ? $dialect : $this->model->getConfig()->getDefaultSparqlDialect();
 
         return $this->model->getSparqlImplementation($dialect, $endpoint, $graph);
     }

--- a/model/Vocabulary.php
+++ b/model/Vocabulary.php
@@ -32,7 +32,7 @@ class Vocabulary extends DataObject implements Modifiable
     public function getEndpoint()
     {
         $endpoint = $this->config->getSparqlEndpoint();
-        if (!$endpoint) {
+        if ($endpoint === null) {
             $endpoint = $this->model->getConfig()->getDefaultEndpoint();
         }
         return $endpoint;

--- a/model/Vocabulary.php
+++ b/model/Vocabulary.php
@@ -57,8 +57,7 @@ class Vocabulary extends DataObject implements Modifiable
     {
         $endpoint = $this->getEndpoint();
         $graph = $this->getGraph();
-        $dialect = $this->config->getSparqlDialect();
-        $dialect = $dialect ? $dialect : $this->model->getConfig()->getDefaultSparqlDialect();
+        $dialect = $this->config->getSparqlDialect() ?? $this->model->getConfig()->getDefaultSparqlDialect();
 
         return $this->model->getSparqlImplementation($dialect, $endpoint, $graph);
     }

--- a/model/Vocabulary.php
+++ b/model/Vocabulary.php
@@ -31,7 +31,14 @@ class Vocabulary extends DataObject implements Modifiable
      */
     public function getEndpoint()
     {
-        return $this->resource->get('void:sparqlEndpoint')->getUri();
+        $endpoint = $this->resource->get('void:sparqlEndpoint');
+        if ($endpoint) {
+            return $endpoint->getUri();
+        } elseif (getenv('SKOSMOS_SPARQL_ENDPOINT')) {
+            return getenv('SKOSMOS_SPARQL_ENDPOINT');
+        } else {
+            return 'http://localhost:3030/ds/sparql';
+        }
     }
 
     /**

--- a/model/Vocabulary.php
+++ b/model/Vocabulary.php
@@ -31,7 +31,11 @@ class Vocabulary extends DataObject implements Modifiable
      */
     public function getEndpoint()
     {
-        return $this->config->getSparqlEndpoint();
+        $endpoint = $this->config->getSparqlEndpoint();
+        if (!$endpoint) {
+            $endpoint = $this->model->getConfig()->getDefaultEndpoint();
+        }
+        return $endpoint;
     }
 
     /**
@@ -51,8 +55,8 @@ class Vocabulary extends DataObject implements Modifiable
      */
     public function getSparql()
     {
-        $endpoint = $this->config->getSparqlEndpoint();
-        $graph = $this->config->getSparqlGraph();
+        $endpoint = $this->getEndpoint();
+        $graph = $this->getGraph();
         $dialect = $this->config->getSparqlDialect();
         $dialect = $dialect ? $dialect : $this->model->getConfig()->getDefaultSparqlDialect();
 

--- a/model/VocabularyConfig.php
+++ b/model/VocabularyConfig.php
@@ -71,24 +71,21 @@ class VocabularyConfig extends BaseConfig
     /**
      * Get the SPARQL endpoint URL for this vocabulary
      *
-     * @return string endpoint URL
+     * @return string|null endpoint URL, or null if not set
      */
     public function getSparqlEndpoint()
     {
         $endpoint = $this->resource->get('void:sparqlEndpoint');
         if ($endpoint) {
             return $endpoint->getUri();
-        } elseif (getenv('SKOSMOS_SPARQL_ENDPOINT')) {
-            return getenv('SKOSMOS_SPARQL_ENDPOINT');
-        } else {
-            return 'http://localhost:3030/ds/sparql';
         }
+        return null;
     }
 
     /**
      * Get the SPARQL graph URI for this vocabulary
      *
-     * @return string|null graph URI
+     * @return string|null graph URI, or null if not set
      */
     public function getSparqlGraph()
     {

--- a/model/VocabularyConfig.php
+++ b/model/VocabularyConfig.php
@@ -69,6 +69,53 @@ class VocabularyConfig extends BaseConfig
     }
 
     /**
+     * Get the SPARQL endpoint URL for this vocabulary
+     *
+     * @return string endpoint URL
+     */
+    public function getSparqlEndpoint()
+    {
+        $endpoint = $this->resource->get('void:sparqlEndpoint');
+        if ($endpoint) {
+            return $endpoint->getUri();
+        } elseif (getenv('SKOSMOS_SPARQL_ENDPOINT')) {
+            return getenv('SKOSMOS_SPARQL_ENDPOINT');
+        } else {
+            return 'http://localhost:3030/ds/sparql';
+        }
+    }
+
+    /**
+     * Get the SPARQL graph URI for this vocabulary
+     *
+     * @return string|null graph URI
+     */
+    public function getSparqlGraph()
+    {
+        $graph = $this->resource->get('skosmos:sparqlGraph');
+        if ($graph) {
+            $graph = $graph->getUri();
+        }
+
+        return $graph;
+    }
+
+    /**
+     * Get the SPARQL dialect for this vocabulary
+     *
+     * @return string|null dialect name
+     */
+    public function getSparqlDialect()
+    {
+        $dialect = $this->resource->get('skosmos:sparqlDialect');
+        if ($dialect) {
+            $dialect = $dialect->getValue();
+        }
+
+        return $dialect;
+    }
+
+    /**
      * Get the default language of this vocabulary
      * @return string default language, e.g. 'en'
      */

--- a/tests/GlobalConfigTest.php
+++ b/tests/GlobalConfigTest.php
@@ -23,7 +23,7 @@ class GlobalConfigTest extends PHPUnit\Framework\TestCase
 
     public function testGetDefaultEndpoint()
     {
-        $this->assertEquals("http://localhost:13030/skosmos-test/sparql", $this->config->getDefaultEndpoint());
+        $this->assertEquals(getenv('SKOSMOS_SPARQL_ENDPOINT'), $this->config->getDefaultEndpoint());
     }
 
     public function testGetDefaultSparqlDialect()

--- a/tests/JenaTextSparqlTest.php
+++ b/tests/JenaTextSparqlTest.php
@@ -17,14 +17,15 @@ class JenaTextSparqlTest extends PHPUnit\Framework\TestCase
     $this->vocab = $this->model->getVocabulary('test');
     $this->graph = $this->vocab->getGraph();
     $this->params = $this->getMockBuilder('ConceptSearchParameters')->disableOriginalConstructor()->getMock();
-    $this->sparql = new JenaTextSparql('http://localhost:13030/skosmos-test/sparql', $this->graph, $this->model);
+    $this->endpoint = getenv('SKOSMOS_SPARQL_ENDPOINT');
+    $this->sparql = new JenaTextSparql($this->endpoint, $this->graph, $this->model);
   }
 
   /**
    * @covers JenaTextSparql::__construct
    */
   public function testConstructor() {
-    $gs = new JenaTextSparql('http://localhost:13030/skosmos-test/sparql', $this->graph, $this->model);
+    $gs = new JenaTextSparql($this->endpoint, $this->graph, $this->model);
     $this->assertInstanceOf('JenaTextSparql', $gs);
   }
 
@@ -117,7 +118,7 @@ class JenaTextSparqlTest extends PHPUnit\Framework\TestCase
   public function testQualifiedNotationAlphabeticalList() {
     $voc = $this->model->getVocabulary('test-qualified-notation');
     $res = new EasyRdf\Resource("http://www.w3.org/2004/02/skos/core#notation");
-    $sparql = new GenericSparql('http://localhost:13030/skosmos-test/sparql', $voc->getGraph(), $this->model);
+    $sparql = new GenericSparql($this->endpoint, $voc->getGraph(), $this->model);
 
     $actual = $sparql->queryConceptsAlphabetical("a", "en", null, null, null, false, $res);
 
@@ -187,7 +188,7 @@ class JenaTextSparqlTest extends PHPUnit\Framework\TestCase
   public function testQualifiedBroaderAlphabeticalList() {
     $voc = $this->model->getVocabulary('test-qualified-broader');
     $res = new EasyRdf\Resource("http://www.w3.org/2004/02/skos/core#broader");
-    $sparql = new JenaTextSparql('http://localhost:13030/skosmos-test/sparql', $voc->getGraph(), $this->model);
+    $sparql = new JenaTextSparql($this->endpoint, $voc->getGraph(), $this->model);
 
     $actual = $sparql->queryConceptsAlphabetical("a", "en", null, null, null, false, $res);
 
@@ -358,7 +359,7 @@ class JenaTextSparqlTest extends PHPUnit\Framework\TestCase
   public function testQueryConceptsAlphabeticalOrderBy() {
     $vocab = $this->model->getVocabulary('collation');
     $graph = $vocab->getGraph();
-    $sparql = new JenaTextSparql('http://localhost:13030/skosmos-test/sparql', $graph, $this->model);
+    $sparql = new JenaTextSparql($this->endpoint, $graph, $this->model);
     $actual = $sparql->queryConceptsAlphabetical('t', 'fi');
     $expected = array (
       0 => array (

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,3 +1,11 @@
 <?php
+
+// make sure that a SPARQL endpoint is set by an environment variable
+$endpoint = getenv('SKOSMOS_SPARQL_ENDPOINT');
+if (!$endpoint) {
+    // default to Fuseki running on localhost:13030 as provided by init_fuseki.sh
+    putenv('SKOSMOS_SPARQL_ENDPOINT=http://localhost:13030/skosmos-test/sparql');
+}
+
 require_once(__DIR__ . '/../vendor/autoload.php');
 require_once(__DIR__ . '/../model/Model.php');

--- a/tests/jenatestconfig.ttl
+++ b/tests/jenatestconfig.ttl
@@ -19,9 +19,8 @@
 # Skosmos main configuration
 
 :config a skosmos:Configuration ;
-    # SPARQL endpoint
-    # a local Fuseki server is usually on localhost:3030
-    skosmos:sparqlEndpoint "http://localhost:13030/skosmos-test/sparql" ;
+    # SPARQL endpoint defaults to $SKOSMOS_SPARQL_ENDPOINT environment var
+    # skosmos:sparqlEndpoint <http://localhost:13030/skosmos-test/sparql> ;
     # sparql-query extension, or "Generic" for plain SPARQL 1.1
     # set to "JenaText" instead if you use Fuseki with jena-text index
     skosmos:sparqlDialect "JenaText" ;
@@ -70,7 +69,6 @@
 	dc:subject :cat_science ;
     dc:type mdrtype:ONTOLOGY ;
 	void:dataDump <http://skosmos.skos/dump/test/> ;
-	void:sparqlEndpoint <http://localhost:13030/skosmos-test/sparql> ;
 	void:uriSpace "http://www.skosmos.skos/test/";
     skos:prefLabel "Test ontology"@en ;
 	skosmos:arrayClass isothes:ThesaurusArray ;
@@ -88,7 +86,6 @@
     dc:title "Test qualified alphabetical listing queries (skos:broader)"@en ;
     dc:subject :cat_science ;
     dc:type mdrtype:ONTOLOGY ;
-    void:sparqlEndpoint <http://localhost:13030/skosmos-test/sparql> ;
     void:uriSpace "http://www.skosmos.skos/test-qualified-broader/" ;
     skosmos:defaultLanguage "en" ;
     skosmos:groupClass skos:Collection ;
@@ -100,7 +97,6 @@
     dc:title "Test qualified alphabetical listing queries (skos:notation)"@en ;
     dc:subject :cat_science ;
     dc:type mdrtype:ONTOLOGY ;
-    void:sparqlEndpoint <http://localhost:13030/skosmos-test/sparql> ;
     void:uriSpace "http://www.skosmos.skos/test-qualified-notation/" ;
     skosmos:defaultLanguage "en" ;
     skosmos:groupClass skos:Collection ;
@@ -112,7 +108,6 @@
 	skos:prefLabel "Mutiple Schemes vocabulary"@en ;
 	dc:title "Mutiple Schemes vocabulary"@en ;
     dc:type mdrtype:ONTOLOGY ;
-	void:sparqlEndpoint <http://localhost:13030/skosmos-test/sparql> ;
 	void:uriSpace "http://www.skosmos.skos/multiple-schemes/";
 	skosmos:defaultLanguage "en";
 	skosmos:language "en";
@@ -123,7 +118,6 @@
 	dc11:title "Test ontology 2"@en ;
 	dc:subject :cat_general ;
 	void:uriSpace "http://www.skosmos.skos/onto/testdiff#";
-	void:sparqlEndpoint <http://localhost:13030/skosmos-test/sparql> ;
 	skosmos:language "fi", "en";
 	skosmos:sparqlDialect "JenaText";
 	skosmos:fullAlphabeticalIndex "true";
@@ -142,7 +136,6 @@
 	void:uriSpace "http://www.skosmos.skos/onto/groups/";
 	skosmos:arrayClass isothes:ThesaurusArray ;
     skosmos:groupClass skos:Collection ;
-	void:sparqlEndpoint <http://localhost:13030/skosmos-test/sparql> ;
 	skosmos:language "fi", "en";
 	skosmos:defaultLanguage "fi";
 	skosmos:indexShowClass meta:TestClass, meta:TestClass2;
@@ -157,7 +150,6 @@
 	void:uriSpace "http://www.exemple.fr/";
 	skosmos:arrayClass isothes:ThesaurusArray ;
  	skosmos:groupClass skos:Collection ;
-	void:sparqlEndpoint <http://localhost:13030/skosmos-test/sparql> ;
 	skosmos:language "en";
 	skosmos:defaultLanguage "en";
 	skosmos:sparqlGraph <http://www.skosmos.skos/test-concept-schemes/> .
@@ -170,7 +162,6 @@
 	void:uriSpace "http://www.skosmos.skos/onto/groups/";
 	skosmos:arrayClass isothes:ThesaurusArray ;
   	skosmos:groupClass skos:Collection ;
-	void:sparqlEndpoint <http://localhost:13030/skosmos-test/sparql> ;
 	skosmos:language "fi", "en";
 	skosmos:defaultLanguage "fi";
 	skosmos:showDeprecated "true";
@@ -180,7 +171,6 @@
 	dc11:title "Cycle test vocabulary"@en ;
 	dc:subject :cat_general ;
 	void:uriSpace "http://www.skosmos.skos/onto/cycle/";
-	void:sparqlEndpoint <http://localhost:13030/skosmos-test/sparql> ;
 	skosmos:language "en";
 	skosmos:sparqlGraph <http://www.skosmos.skos/cycle/> .
 
@@ -188,7 +178,6 @@
 	dc11:title "Duplicate labels test vocabulary"@en ;
 	dc:subject :cat_general ;
 	void:uriSpace "http://www.skosmos.skos/onto/dup/";
-	void:sparqlEndpoint <http://localhost:13030/skosmos-test/sparql> ;
 	skosmos:language "en";
 	skosmos:sparqlGraph <http://www.skosmos.skos/dup/> .
 
@@ -199,7 +188,6 @@
 	rdfs:label "Date information vocabulary"@en ;
 	dc:subject :cat_general ;
 	void:uriSpace "http://www.skosmos.skos/onto/date/";
-	void:sparqlEndpoint <http://localhost:13030/skosmos-test/sparql> ;
 	skosmos:language "en";
 	skosmos:showPropertyInSearch skos:exactMatch;
     skosmos:hasMultiLingualProperty skos:altLabel ;
@@ -210,7 +198,6 @@
 	dc11:title "Vocabulary with mappings"@en ;
 	dc:subject :cat_general ;
 	void:uriSpace "http://www.skosmos.skos/onto/mapping/";
-	void:sparqlEndpoint <http://localhost:13030/skosmos-test/sparql> ;
 	skosmos:language "en";
 	skosmos:sparqlGraph <http://www.skosmos.skos/mapping/> .
 
@@ -218,7 +205,6 @@
 	dc11:title "A vocabulary for testing the change list creation"@en ;
 	dc:subject :cat_general ;
 	void:uriSpace "http://www.skosmos.skos/changes/";
-	void:sparqlEndpoint <http://localhost:13030/skosmos-test/sparql> ;
 	skosmos:language "en";
 	skosmos:sparqlGraph <http://www.skosmos.skos/changes/> .
 
@@ -226,7 +212,6 @@
 	dc11:title "A vocabulary for testing custom prefixes"@en ;
 	dc:subject :cat_general ;
 	void:uriSpace "http://www.skosmos.skos/prefix/";
-	void:sparqlEndpoint <http://localhost:13030/skosmos-test/sparql> ;
 	skosmos:language "en";
 	skosmos:sparqlGraph <http://www.skosmos.skos/prefix/> .
 
@@ -234,7 +219,6 @@
 	dc11:title "Subproperties of hiddenLabel"@en ;
 	dc:subject :cat_general ;
 	void:uriSpace "http://www.skosmos.skos/sub/";
-	void:sparqlEndpoint <http://localhost:13030/skosmos-test/sparql> ;
 	skosmos:language "en";
 	skosmos:sparqlGraph <http://www.skosmos.skos/sub/> .
 
@@ -242,7 +226,6 @@
 	dc11:title "SuperGroup and member relationship double trouble"@en ;
 	dc:subject :cat_general ;
 	void:uriSpace "http://www.skosmos.skos/onto/dupgroup/";
-	void:sparqlEndpoint <http://localhost:13030/skosmos-test/sparql> ;
 	skosmos:language "en";
 	skosmos:sparqlGraph <http://www.skosmos.skos/dupgroup/> .
 
@@ -250,7 +233,6 @@
 	dc11:title "A vocabulary for testing language subtags"@en ;
 	dc:subject :cat_general ;
 	void:uriSpace "http://www.skosmos.skos/subtag/";
-	void:sparqlEndpoint <http://localhost:13030/skosmos-test/sparql> ;
 	skosmos:language "en";
     skosmos:fallbackLanguages ( "fr" "de" "sv" ) ;
 	skosmos:sparqlGraph <http://www.skosmos.skos/subtag/> ;
@@ -260,7 +242,6 @@
     dc11:title "A vocabulary for test SPARQL with collation"@en ;
     dc:subject :cat_general ;
     void:uriSpace "http://www.skosmos.skos/collation/";
-    void:sparqlEndpoint <http://localhost:13030/skosmos-test/sparql> ;
     skosmos:language "fi";
     skosmos:sparqlGraph <http://www.skosmos.skos/collation/> .
 
@@ -272,7 +253,6 @@
     skosmos:externalProperty dc11:creator ;
     skosmos:externalProperty dc11:relation ;
     skosmos:externalProperty rdfs:comment ;
-    void:sparqlEndpoint <http://localhost:13030/skosmos-test/sparql> ;
     skosmos:language "en";
     skosmos:sparqlGraph <http://www.skosmos.skos/cbd/> .
 
@@ -280,7 +260,6 @@
     dc11:title "A vocabulary for testing SKOS XL"@en ;
     dc:subject :cat_general ;
     void:uriSpace "http://www.skosmos.skos/xl/";
-    void:sparqlEndpoint <http://localhost:13030/skosmos-test/sparql> ;
     skosmos:language "en";
     skosmos:sparqlGraph <http://www.skosmos.skos/xl/> .
 

--- a/tests/testconfig.ttl
+++ b/tests/testconfig.ttl
@@ -21,9 +21,8 @@
 # Skosmos main configuration
 
 :config a skosmos:Configuration ;
-    # SPARQL endpoint
-    # a local Fuseki server is usually on localhost:3030
-    skosmos:sparqlEndpoint <http://localhost:13030/skosmos-test/sparql> ;
+    # SPARQL endpoint defaults to $SKOSMOS_SPARQL_ENDPOINT environment var
+    # skosmos:sparqlEndpoint <http://localhost:13030/skosmos-test/sparql> ;
     # sparql-query extension, or "Generic" for plain SPARQL 1.1
     # set to "JenaText" instead if you use Fuseki with jena-text index
     # skosmos:sparqlDialect "JenaText" ;
@@ -74,7 +73,6 @@
 	dc:subject :cat_science ;
     dc:type mdrtype:ONTOLOGY ;
 	void:dataDump <http://skosmos.skos/dump/test/> ;
-	void:sparqlEndpoint <http://localhost:13030/skosmos-test/sparql> ;
 	void:uriSpace "http://www.skosmos.skos/test/";
     skos:prefLabel "Test ontology"@en ;
 	skosmos:arrayClass isothes:ThesaurusArray ;
@@ -93,7 +91,6 @@
 	dc:title "Test notation sort ontology"@en ;
 	dc:subject :cat_science ;
     dc:type mdrtype:ONTOLOGY ;
-	void:sparqlEndpoint <http://localhost:13030/skosmos-test/sparql> ;
 	void:uriSpace "http://www.skosmos.skos/test-notation-sort/";
     skos:prefLabel "Test notation sort ontology"@en ;
 	skosmos:defaultLanguage "en";
@@ -106,7 +103,6 @@
     dc:title "Test qualified alphabetical listing queries (skos:broader)"@en ;
     dc:subject :cat_science ;
     dc:type mdrtype:ONTOLOGY ;
-    void:sparqlEndpoint <http://localhost:13030/skosmos-test/sparql> ;
     void:uriSpace "http://www.skosmos.skos/test-qualified-broader/" ;
     skosmos:defaultLanguage "en" ;
     skosmos:groupClass skos:Collection ;
@@ -118,7 +114,6 @@
     dc:title "Test qualified alphabetical listing queries (skos:notation)"@en ;
     dc:subject :cat_science ;
     dc:type mdrtype:ONTOLOGY ;
-    void:sparqlEndpoint <http://localhost:13030/skosmos-test/sparql> ;
     void:uriSpace "http://www.skosmos.skos/test-qualified-notation/" ;
     skosmos:defaultLanguage "en" ;
     skosmos:groupClass skos:Collection ;
@@ -132,7 +127,6 @@
     dc:type mdrtype:ONTOLOGY ;
     void:dataDump <http://skosmos.skos/dump/test/marc-fi.mrcx> ;
     void:dataDump <http://skosmos.skos/dump/test/marc-sv.mrcx> ;
-    void:sparqlEndpoint <http://localhost:13030/skosmos-test/sparql> ;
     void:uriSpace "http://www.skosmos.skos/test-marc/";
     skosmos:defaultLanguage "fi" ;
     skosmos:marcSourceCode "test/fin"@fi, "test/swe"@sv ;
@@ -145,7 +139,6 @@
     dc:title "Test undefined marc source"@en ;
     dc:type mdrtype:ONTOLOGY ;
     void:dataDump <http://skosmos.skos/dump/test/marc-undefined.mrcx> ;
-    void:sparqlEndpoint <http://localhost:13030/skosmos-test/sparql> ;
     void:uriSpace "http://www.skosmos.skos/test-marc/" ;
     skosmos:defaultLanguage "fi" ;
     skosmos:marcSourceCode "test/fin"@fi, "test/swe"@sv ;
@@ -165,7 +158,6 @@
 	skos:prefLabel "Mutiple Schemes vocabulary"@en ;
 	dc:title "Mutiple Schemes vocabulary"@en ;
     dc:type mdrtype:ONTOLOGY ;
-	void:sparqlEndpoint <http://localhost:13030/skosmos-test/sparql> ;
 	void:uriSpace "http://www.skosmos.skos/multiple-schemes/";
 	skosmos:defaultLanguage "en";
 	skosmos:marcSourceCode "ysa/gen";
@@ -177,7 +169,6 @@
 	dc11:title "Test ontology 2"@en ;
 	dc:subject :cat_general ;
 	void:uriSpace "http://www.skosmos.skos/onto/testdiff#";
-	void:sparqlEndpoint <http://localhost:13030/skosmos-test/sparql> ;
 	skosmos:language "fi", "en";
 	skosmos:sparqlDialect "JenaText";
 	skosmos:fullAlphabeticalIndex "true";
@@ -196,7 +187,6 @@
 	void:uriSpace "http://www.skosmos.skos/onto/groups/";
 	skosmos:arrayClass isothes:ThesaurusArray ;
     skosmos:groupClass skos:Collection ;
-	void:sparqlEndpoint <http://localhost:13030/skosmos-test/sparql> ;
 	skosmos:language "fi", "en";
 	skosmos:defaultLanguage "fi";
 	skosmos:indexShowClass meta:TestClass, meta:TestClass2;
@@ -211,7 +201,6 @@
 	void:uriSpace "http://www.exemple.fr/";
 	skosmos:arrayClass isothes:ThesaurusArray ;
  	skosmos:groupClass skos:Collection ;
-	void:sparqlEndpoint <http://localhost:13030/skosmos-test/sparql> ;
 	skosmos:language "en";
 	skosmos:defaultLanguage "en";
 	skosmos:sparqlGraph <http://www.skosmos.skos/test-concept-schemes/> .
@@ -224,7 +213,6 @@
 	void:uriSpace "http://www.skosmos.skos/onto/groups/";
 	skosmos:arrayClass isothes:ThesaurusArray ;
   	skosmos:groupClass skos:Collection ;
-	void:sparqlEndpoint <http://localhost:13030/skosmos-test/sparql> ;
 	skosmos:language "fi", "en";
 	skosmos:defaultLanguage "fi";
 	skosmos:showDeprecated "true";
@@ -234,7 +222,6 @@
 	dc11:title "Cycle test vocabulary"@en ;
 	dc:subject :cat_general ;
 	void:uriSpace "http://www.skosmos.skos/onto/cycle/";
-	void:sparqlEndpoint <http://localhost:13030/skosmos-test/sparql> ;
 	skosmos:language "en";
 	skosmos:sparqlGraph <http://www.skosmos.skos/cycle/> .
 
@@ -242,7 +229,6 @@
 	dc11:title "Duplicate labels test vocabulary"@en ;
 	dc:subject :cat_general ;
 	void:uriSpace "http://www.skosmos.skos/onto/dup/";
-	void:sparqlEndpoint <http://localhost:13030/skosmos-test/sparql> ;
 	skosmos:language "en";
 	skosmos:sparqlGraph <http://www.skosmos.skos/dup/> .
 
@@ -253,7 +239,6 @@
 	rdfs:label "Date information vocabulary"@en ;
 	dc:subject :cat_general ;
 	void:uriSpace "http://www.skosmos.skos/onto/date/";
-	void:sparqlEndpoint <http://localhost:13030/skosmos-test/sparql> ;
 	skosmos:language "en";
 	skosmos:showPropertyInSearch skos:exactMatch;
     skosmos:hasMultiLingualProperty skos:altLabel ;
@@ -264,7 +249,6 @@
 	dc11:title "Vocabulary with mappings"@en ;
 	dc:subject :cat_general ;
 	void:uriSpace "http://www.skosmos.skos/onto/mapping/";
-	void:sparqlEndpoint <http://localhost:13030/skosmos-test/sparql> ;
 	skosmos:language "en";
 	skosmos:sparqlGraph <http://www.skosmos.skos/mapping/> .
 
@@ -272,7 +256,6 @@
 	dc11:title "A vocabulary for testing the change list creation"@en ;
 	dc:subject :cat_general ;
 	void:uriSpace "http://www.skosmos.skos/changes/";
-	void:sparqlEndpoint <http://localhost:13030/skosmos-test/sparql> ;
 	skosmos:language "en";
 	skosmos:sparqlGraph <http://www.skosmos.skos/changes/> .
 
@@ -280,7 +263,6 @@
 	dc11:title "A vocabulary for testing custom prefixes"@en ;
 	dc:subject :cat_general ;
 	void:uriSpace "http://www.skosmos.skos/prefix/";
-	void:sparqlEndpoint <http://localhost:13030/skosmos-test/sparql> ;
 	skosmos:language "en";
 	skosmos:sparqlGraph <http://www.skosmos.skos/prefix/> .
 
@@ -288,7 +270,6 @@
 	dc11:title "Subproperties of hiddenLabel"@en ;
 	dc:subject :cat_general ;
 	void:uriSpace "http://www.skosmos.skos/sub/";
-	void:sparqlEndpoint <http://localhost:13030/skosmos-test/sparql> ;
 	skosmos:language "en";
 	skosmos:sparqlGraph <http://www.skosmos.skos/sub/> .
 
@@ -296,7 +277,6 @@
 	dc11:title "SuperGroup and member relationship double trouble"@en ;
 	dc:subject :cat_general ;
 	void:uriSpace "http://www.skosmos.skos/onto/dupgroup/";
-	void:sparqlEndpoint <http://localhost:13030/skosmos-test/sparql> ;
 	skosmos:language "en";
 	skosmos:sparqlGraph <http://www.skosmos.skos/dupgroup/> .
 
@@ -304,7 +284,6 @@
 	dc11:title "A vocabulary for testing language subtags"@en ;
 	dc:subject :cat_general ;
 	void:uriSpace "http://www.skosmos.skos/subtag/";
-	void:sparqlEndpoint <http://localhost:13030/skosmos-test/sparql> ;
 	skosmos:language "en";
     skosmos:fallbackLanguages ( "fr" "de" "sv" ) ;
 	skosmos:sparqlGraph <http://www.skosmos.skos/subtag/> ;
@@ -314,7 +293,6 @@
     dc11:title "A vocabulary for test SPARQL with collation"@en ;
     dc:subject :cat_general ;
     void:uriSpace "http://www.skosmos.skos/collation/";
-    void:sparqlEndpoint <http://localhost:13030/skosmos-test/sparql> ;
     skosmos:language "fi";
     skosmos:sparqlGraph <http://www.skosmos.skos/collation/> .
 
@@ -326,7 +304,6 @@
     skosmos:externalProperty dc11:creator ;
     skosmos:externalProperty dc11:relation ;
     skosmos:externalProperty rdfs:comment ;
-    void:sparqlEndpoint <http://localhost:13030/skosmos-test/sparql> ;
     skosmos:language "en";
     skosmos:sparqlGraph <http://www.skosmos.skos/cbd/> .
 
@@ -334,7 +311,6 @@
     dc11:title "A vocabulary for testing SKOS XL"@en ;
     dc:subject :cat_general ;
     void:uriSpace "http://www.skosmos.skos/xl/";
-    void:sparqlEndpoint <http://localhost:13030/skosmos-test/sparql> ;
     skosmos:language "en";
     skosmos:sparqlGraph <http://www.skosmos.skos/xl/> .
 
@@ -342,7 +318,6 @@
     dc11:title "A vocabulary for testing HTTP 304 new settings"@en ;
     dc:subject :cat_general ;
     void:uriSpace "http://www.skosmos.skos/http304disabled/";
-    void:sparqlEndpoint <http://localhost:13030/skosmos-test/sparql> ;
     skosmos:language "fi";
     skosmos:useModifiedDate "false";
     skosmos:sparqlGraph <http://www.skosmos.skos/http304/>;
@@ -352,7 +327,6 @@
     dc11:title "A vocabulary for testing HTTP 304 new settings"@en ;
     dc:subject :cat_general ;
     void:uriSpace "http://www.skosmos.skos/http304enabled/";
-    void:sparqlEndpoint <http://localhost:13030/skosmos-test/sparql> ;
     skosmos:language "fi";
     skosmos:useModifiedDate "true";
     skosmos:sparqlGraph <http://www.skosmos.skos/http304/>;
@@ -362,7 +336,6 @@
     dc11:title "A vocabulary for testing vocabularies with notation features"@en ;
     dc:subject :cat_general ;
     void:uriSpace "http://www.skosmos.skos/notationFeatures/";
-    void:sparqlEndpoint <http://localhost:13030/skosmos-test/sparql> ;
     skosmos:language "fi";
     skosmos:sortByNotation true ;
     skosmos:searchByNotation true ;
@@ -376,7 +349,6 @@
 	dc:subject :cat_science ;
     dc:type mdrtype:ONTOLOGY ;
 	void:dataDump <http://skosmos.skos/dump/test/> ;
-	void:sparqlEndpoint <http://localhost:13030/skosmos-test/sparql> ;
 	void:uriSpace "http://www.skosmos.skos/test/";
     skos:prefLabel "Test plugin parameters"@en ;
 	skosmos:arrayClass isothes:ThesaurusArray ;
@@ -408,7 +380,6 @@
 	dc:subject :cat_science ;
 	skosmos:propertyOrder skosmos:iso25964PropertyOrder ;
 	void:dataDump <http://skosmos.skos/dump/test/> ;
-	void:sparqlEndpoint <http://localhost:13030/skosmos-test/sparql> ;
 	void:uriSpace "http://www.skosmos.skos/testOrder/";
 	skosmos:language "en";
 	skosmos:sparqlGraph <http://www.skosmos.skos/testOrder/> .
@@ -418,7 +389,6 @@
 	dc:subject :cat_science ;
 	skosmos:propertyOrder skosmos:defaultPropertyOrder ;
 	void:dataDump <http://skosmos.skos/dump/test/> ;
-	void:sparqlEndpoint <http://localhost:13030/skosmos-test/sparql> ;
 	void:uriSpace "http://www.skosmos.skos/testOrder/";
 	skosmos:language "en";
 	skosmos:sparqlGraph <http://www.skosmos.skos/testOrder/> .
@@ -432,7 +402,6 @@
 		skos:historyNote skos:prefLabel
 	) ] ;
 	void:dataDump <http://skosmos.skos/dump/test/> ;
-	void:sparqlEndpoint <http://localhost:13030/skosmos-test/sparql> ;
 	void:uriSpace "http://www.skosmos.skos/testOrder/";
 	skosmos:language "en";
 	skosmos:sparqlGraph <http://www.skosmos.skos/testOrder/> .
@@ -442,7 +411,6 @@
 	dc:subject :cat_science ;
 	skosmos:propertyOrder skosmos:unknown ;
 	void:dataDump <http://skosmos.skos/dump/test/> ;
-	void:sparqlEndpoint <http://localhost:13030/skosmos-test/sparql> ;
 	void:uriSpace "http://www.skosmos.skos/testOrder/";
 	skosmos:language "en";
 	skosmos:sparqlGraph <http://www.skosmos.skos/testOrder/> .


### PR DESCRIPTION
I was trying to set up GitHub Actions CI (#1163, #1147) for running the tests but hit problems caused by hardcoded SPARQL endpoint URLs in the test suite (PHPUnit classes & Skosmos configuration files). Under GitHub Actions it would be easier to use a Fuseki running in a Docker container.

This PR makes the global `skosmos:sparqlEndpoint` and vocabulary-specific `void:sparqlEndpoint` settings default to the value of the `SKOSMOS_SPARQL_ENDPOINT` environment variable when no value is set in `config.ttl`.

The test suite makes use of this by relying on the environment variable instead of hardcoding the endpoint URL. The default (set in `tests/bootstrap.php`) is still to use Fuseki running on localhost:13030 if the environment variable hasn't been set, so the existing way of running unit tests on a developer machine (start Fuseki using init_fuseki.sh and leave it running in the background, then run vendor/bin/phpunit) should still work.