### PR TITLE
add support for showDeprecated parameter in hierarchy queries; touche…

### DIFF
--- a/model/Vocabulary.php
+++ b/model/Vocabulary.php
@@ -334,7 +334,7 @@ class Vocabulary extends DataObject implements Modifiable
         $lang = $lang ? $lang : $this->getEnvLang();
         $fallback = count($this->config->getLanguageOrder($lang)) > 1 ? $this->config->getLanguageOrder($lang)[1] : $this->config->getDefaultLanguage();
         $props = $this->config->getHierarchyProperty();
-        return $this->getSparql()->queryParentList($uri, $lang, $fallback, $props);
+        return $this->getSparql()->queryParentList($uri, $lang, $fallback, $props, $this->config->getShowDeprecated());
     }
 
     /**
@@ -346,7 +346,7 @@ class Vocabulary extends DataObject implements Modifiable
         $lang = $lang ? $lang : $this->getEnvLang();
         $fallback = count($this->config->getLanguageOrder($lang)) > 1 ? $this->config->getLanguageOrder($lang)[1] : $this->config->getDefaultLanguage();
         $props = $this->config->getHierarchyProperty();
-        return $this->getSparql()->queryChildren($uri, $lang, $fallback, $props);
+        return $this->getSparql()->queryChildren($uri, $lang, $fallback, $props, $this->config->getShowDeprecated());
     }
 
     /**
@@ -369,7 +369,7 @@ class Vocabulary extends DataObject implements Modifiable
     public function getConceptTransitiveNarrowers($uri, $limit, $lang)
     {
         $lang = $lang ? $lang : $this->getEnvLang();
-        return $this->getSparql()->queryTransitiveProperty($uri, array('skos:narrower'), $lang, $limit);
+        return $this->getSparql()->queryTransitiveProperty($uri, array('skos:narrower'), $lang, $limit, $this->config->getShowDeprecated());
     }
 
     /**
@@ -394,7 +394,7 @@ class Vocabulary extends DataObject implements Modifiable
     {
         $lang = $lang ? $lang : $this->getEnvLang();
         $fallback = $this->config->getDefaultLanguage();
-        return $this->getSparql()->queryTransitiveProperty($uri, array('skos:broader'), $lang, $limit, $any, $fallback);
+        return $this->getSparql()->queryTransitiveProperty($uri, array('skos:broader'), $lang, $limit, $any, $fallback, $this->config->getShowDeprecated());
     }
 
     /**


### PR DESCRIPTION
…s #1143

This draft PR brings support for `showDeprecated` parameter in multiple hierarchy-related queries. However, implementing this has proven to be a bit difficult and this PR is not yet ready. There seems to be quite a bit of different cases involved and,, thus, open, questions, e.g., 

- Deprecated concept (attached to hierarchy) is opened, what to do with hierarchy? E.g., https://finto.fi/juho/fi/page/p4304
-- Show it normally
-- Show the hierarchy 'till the opened deprecated concept (this is what this draft PR is doing)
-- Only show the deprecated concept (and maybe it's non-deprecated children?)
-- Previous one combined with "base" hierarchy
-- Something else, what?

- If a concept lies below a deprecated one, what to do with hierarchy? E.g., https://finto.fi/juho/fi/page/p5875
-- Show the whole tree without deprecated ones ("jumping" over deprecated ones)
-- Only show the hierarchy 'till there is non-deprecated concepts (current implementation, additionally, breadcrumbs halt at the very same non-deprecated concept)
-- Somethings else, what?

- Deprecated sub-tree
-- Show that part, if one of those is chosen?

Requires tests for each of the ones above, both live and PHPUnit. One must pay attention that changing some functions here may affect the input of other queries, too (e.g., `queryTransitiveProperty`).

Other questions:
- Configurable via REST?
- Utilization of dct:isReplacedBy - direct replacement?

Additional note: after playing a bit back and forth, it seems like it could be possible to just return the states of concepts (whether a concept is deprecated or not) and from there, adjust the hierarchy in either JavaScript or in the `transform*` function. This would simplify the required code quite a bit compared to what it would have to be - e.g., the `deprecatedClauses` in files changed may not be complete in many cases. E.g., skipping deprecated broader concepts in hierarchy in cases of non-deprecated subconcepts is not a very easy feat to do directly in SPARQL.
