### PR TITLE
Define order for more vocabulary home page properties

### DIFF
--- a/model/Vocabulary.php
+++ b/model/Vocabulary.php
@@ -162,7 +162,17 @@ class Vocabulary extends DataObject implements Modifiable
         $sparql = $this->getSparql();
         $result = $sparql->queryConceptScheme($defaultcs);
         $conceptscheme = $result->resource($defaultcs);
-        $this->order = array("dc:title", "dc11:title", "skos:prefLabel", "rdfs:label", "dc:subject", "dc11:subject", "dc:description", "dc11:description", "dc:publisher", "dc11:publisher", "dc:creator", "dc11:creator", "dc:contributor", "dc:language", "dc11:language", "owl:versionInfo", "dc:source", "dc11:source");
+        $this->order = array(
+            "dc:title", "dc11:title", "skos:prefLabel", "rdfs:label",
+            "dc:subject", "dc11:subject",
+            "dc:description", "dc11:description",
+            "dc:publisher", "dc11:publisher",
+            "dc:creator", "dc11:creator",
+            "dc:contributor",
+            "dc:language", "dc11:language",
+            "owl:versionInfo",
+            "dc:source", "dc11:source"
+        );
 
         foreach ($conceptscheme->properties() as $prop) {
             foreach ($conceptscheme->allLiterals($prop, $lang) as $val) {

--- a/model/Vocabulary.php
+++ b/model/Vocabulary.php
@@ -166,12 +166,19 @@ class Vocabulary extends DataObject implements Modifiable
             "dc:title", "dc11:title", "skos:prefLabel", "rdfs:label",
             "dc:subject", "dc11:subject",
             "dc:description", "dc11:description",
+            "foaf:homepage",
             "dc:publisher", "dc11:publisher",
             "dc:creator", "dc11:creator",
             "dc:contributor",
+            "dc:license",
+            "dc:rights", "dc11:rights",
             "dc:language", "dc11:language",
             "owl:versionInfo",
-            "dc:source", "dc11:source"
+            "dc:source", "dc11:source",
+            "dc:relation", "dc11:relation",
+            "dc:created",
+            "dc:modified",
+            "dc:date", "dc11:date"
         );
 
         foreach ($conceptscheme->properties() as $prop) {


### PR DESCRIPTION
Fixes #1100 

This PR defines the order of some properties commonly used for concept scheme metadata:

- foaf:homepage
- dc:license
- dc:rights
- dc11:rights
- dc:relation
- dc11:relation
- dc:created
- dc:modified
- dc:date
- dc11:date

Thanks to @MikkoAleksanteri for helping to define the order.

Here's a crude screenshot (stitched from two parts...) of the HERO front page after the change:

![image](https://user-images.githubusercontent.com/1132830/120445659-81c86400-c391-11eb-8aa8-e17bcd2d5cd1.png)
