### PR TITLE
Switch to upstream php-actions/phpunit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
         php_extensions: gettext intl xsl pcov
 
     - name: Run PHPUnit tests
-      uses: osma/phpunit@v2-network-host-debug
+      uses: php-actions/phpunit@91ff02a58932e63741157ea8c04e7e7077233537
       env:
         LANGUAGE: fr
       with:


### PR DESCRIPTION
Related to #1147

Now that my [host networking PR](https://github.com/php-actions/phpunit/pull/29) for php-actions/phpunit is merged, we can switch to the upstream version instead of my fork that was used in PR #1168 . There is no tagged version with the fix yet, so the `uses` declaration is pinned to the specific commit instead.