### PR TITLE
Modify code to always have an ld json element, may be empty

### DIFF
--- a/view/scripts.twig
+++ b/view/scripts.twig
@@ -41,11 +41,13 @@ var pluginParameters = {{ plugin_params|raw }};
 {% endif %}
 </script>
 
-{% if request.page == 'page' and search_results and search_results|length == 1 %}
 <script type="application/ld+json">
+{% if search_results and search_results|length == 1 %}
 {{ search_results|first.dumpJsonLd|raw }}
-</script>
+{% else %}
+{}
 {% endif %}
+</script>
 <script src="vendor/components/jquery/jquery.min.js"></script>
 <script src="vendor/components/jqueryui/jquery-ui.min.js"></script>
 <script src="vendor/components/handlebars.js/handlebars.min.js"></script>


### PR DESCRIPTION
I think this issue happens due to a mix of Twig and JS code. When you visit a vocabulary, the value of `request.page == 'page'` is false, since `request.page` has the value "vocab".

But if you click on a concept, it will trigger the code to load concept mappings without changing the value of `request.page`. That code won't find the JSON-LD script element, and result in a JS error. If you reload the page, now the `request.page` will be `page` and now the concept mappings will be displayed correctly.

This pull request simply modifies the template to always have a JSON-LD script element, that may be empty (`{}`). This way the code should work no matter what page is trying to load concept mappings. Tested locally with YSO vocabulary.

Closes #1016  