### PR TITLE
Add dependency on symfony/polyfill-php80 to define ValueError

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,6 +60,7 @@
     "davidstutz/bootstrap-multiselect": "v0.9.13",
     "easyrdf/easyrdf": "1.1.*",
     "etdsolutions/waypoints": "4.0.0",
+    "symfony/polyfill-php80": "1.*",
     "twig/twig": "2.13.*",
     "twig/extensions": "1.5.*",
     "twitter/bootstrap": "3.3.*",


### PR DESCRIPTION
Related to #1170 and especially [this comment](https://github.com/NatLibFi/Skosmos/issues/1170#issuecomment-887594417) by @hekl

Skosmos started throwing ValueError exceptions in some situations since PR #1127. However, ValueError was only added in PHP 8, and we are still (mostly) using PHP 7. ValueError still usually worked, because [symfony/polyfill-php80](https://github.com/symfony/polyfill-php80) declared it, but it was only available when developmend dependencies were installed.

This PR adds an explicit dependency on symfony/polyfill-php80 also for non-development installs, ensuring that ValueError is always available.