### PR TITLE
Add "lexical" and "natural" sort strategies for notation codes

### DIFF
--- a/model/Concept.php
+++ b/model/Concept.php
@@ -558,7 +558,7 @@ class Concept extends VocabularyDataObject implements Modifiable
                 if ($superprop) {
                     $superprop = EasyRdf\RdfNamespace::shorten($superprop) ? EasyRdf\RdfNamespace::shorten($superprop) : $superprop;
                 }
-                $sort_by_notation = $this->vocab->getConfig()->sortByNotation();
+                $sort_by_notation = $this->vocab->getConfig()->getSortByNotation();
                 $propobj = new ConceptProperty($prop, $proplabel, $prophelp, $superprop, $sort_by_notation);
 
                 if ($propobj->getLabel() !== null) {

--- a/model/ConceptProperty.php
+++ b/model/ConceptProperty.php
@@ -130,8 +130,12 @@ class ConceptProperty
                         return -1;
                     }
                     else {
-                        // assume that notations are unique
-                        return strnatcasecmp($anot, $bnot);
+                        // assume that notations are unique, choose strategy
+                        if ($this->sort_by_notation == "decimal") {
+                            return strcoll($anot, $bnot);
+                        } else { // natural
+                            return strnatcasecmp($anot, $bnot);
+                        }
                     }
                 });
             }

--- a/model/ConceptProperty.php
+++ b/model/ConceptProperty.php
@@ -131,7 +131,7 @@ class ConceptProperty
                     }
                     else {
                         // assume that notations are unique, choose strategy
-                        if ($this->sort_by_notation == "decimal") {
+                        if ($this->sort_by_notation == "lexical") {
                             return strcoll($anot, $bnot);
                         } else { // natural
                             return strnatcasecmp($anot, $bnot);

--- a/model/ConceptPropertyValue.php
+++ b/model/ConceptPropertyValue.php
@@ -33,12 +33,7 @@ class ConceptPropertyValue extends VocabularyDataObject
 
     public function __toString()
     {
-        $label = is_string($this->getLabel()) ? $this->getLabel() : $this->getLabel()->getValue();
-        if ($this->vocab->getConfig()->sortByNotation()) {
-            $label = ltrim($this->getNotation() . ' ') . $label;
-        }
-
-        return $label;
+        return is_string($this->getLabel()) ? $this->getLabel() : $this->getLabel()->getValue();
     }
 
     public function getLang()

--- a/model/VocabularyConfig.php
+++ b/model/VocabularyConfig.php
@@ -179,20 +179,20 @@ class VocabularyConfig extends BaseConfig
 
     /**
      * Returns the sorting strategy for notation codes set in the config.ttl
-     * config: either "decimal" (default), "natural", or null if
+     * config: either "lexical" (default), "natural", or null if
      * sorting by notations is disabled.
      * @return string|bool
      */
     public function getSortByNotation(): ?string
     {
         $value = $this->getLiteral('skosmos:sortByNotation');
-        if ($value == "decimal" || $value == "natural") {
+        if ($value == "lexical" || $value == "natural") {
             return $value;
         }
         // not a special value - interpret as boolean instead
         $bvalue = $this->getBoolean('skosmos:sortByNotation');
-        // default sorting strategy is "decimal"
-        return $bvalue ? "decimal" : null;
+        // default sorting strategy is "lexical"
+        return $bvalue ? "lexical" : null;
     }
 
     /**

--- a/model/VocabularyConfig.php
+++ b/model/VocabularyConfig.php
@@ -179,8 +179,9 @@ class VocabularyConfig extends BaseConfig
 
     /**
      * Returns the sorting strategy for notation codes set in the config.ttl
-     * config: either "lexical" (default), "natural", or null if
-     * sorting by notations is disabled.
+     * config: either "lexical", "natural", or null if sorting by notations is 
+     * disabled. A "true" value in the configuration file is interpreted as
+     * "lexical".
      * @return string|bool
      */
     public function getSortByNotation(): ?string
@@ -191,7 +192,7 @@ class VocabularyConfig extends BaseConfig
         }
         // not a special value - interpret as boolean instead
         $bvalue = $this->getBoolean('skosmos:sortByNotation');
-        // default sorting strategy is "lexical"
+        // "true" is interpreted as "lexical"
         return $bvalue ? "lexical" : null;
     }
 

--- a/model/VocabularyConfig.php
+++ b/model/VocabularyConfig.php
@@ -178,12 +178,21 @@ class VocabularyConfig extends BaseConfig
     }
 
     /**
-     * Returns a boolean value set in the config.ttl config.
-     * @return boolean
+     * Returns the sorting strategy for notation codes set in the config.ttl
+     * config: either "decimal" (default), "natural", or null if
+     * sorting by notations is disabled.
+     * @return string|bool
      */
-    public function sortByNotation()
+    public function getSortByNotation(): ?string
     {
-        return $this->getBoolean('skosmos:sortByNotation');
+        $value = $this->getLiteral('skosmos:sortByNotation');
+        if ($value == "decimal" || $value == "natural") {
+            return $value;
+        }
+        // not a special value - interpret as boolean instead
+        $bvalue = $this->getBoolean('skosmos:sortByNotation');
+        // default sorting strategy is "decimal"
+        return $bvalue ? "decimal" : null;
     }
 
     /**

--- a/resource/js/hierarchy.js
+++ b/resource/js/hierarchy.js
@@ -514,7 +514,7 @@ function getTreeConfiguration() {
 
             if (aNotation) {
                 if (bNotation) {
-                    if (window.sortByNotation == "decimal") {
+                    if (window.sortByNotation == "lexical") {
                         if (aNotation < bNotation) {
                             return -1;
                         }

--- a/resource/js/hierarchy.js
+++ b/resource/js/hierarchy.js
@@ -508,17 +508,21 @@ function getTreeConfiguration() {
         var bNode = this.get_node(b);
 
         // sort on notation if requested, and notations exist
-        if (window.showNotation) {
+        if (window.sortByNotation) {
             var aNotation = aNode.original.notation;
             var bNotation = bNode.original.notation;
 
             if (aNotation) {
                 if (bNotation) {
-                    if (aNotation < bNotation) {
-                        return -1;
-                    }
-                    else if (aNotation > bNotation) {
-                        return 1;
+                    if (window.sortByNotation == "decimal") {
+                        if (aNotation < bNotation) {
+                            return -1;
+                        }
+                        else if (aNotation > bNotation) {
+                            return 1;
+                        }
+                    } else { // natural
+                        return naturalCompare(aNotation, bNotation);
                     }
                 }
                 else return -1;

--- a/resource/js/hierarchy.js
+++ b/resource/js/hierarchy.js
@@ -434,7 +434,7 @@ function nodeLabelSortKey(node) {
 
   // parse the HTML code in node.text and return just the label as a lower case value for sorting
   // should look like '<span class="tree-notation">12.3</span> <span class="tree-label">Hello</span>'
-  label = $(node.text.toLowerCase()).filter('.tree-label').text();
+  var label = $(node.text.toLowerCase()).filter('.tree-label').text();
 
   return domain + " " + label;
 }

--- a/resource/js/hierarchy.js
+++ b/resource/js/hierarchy.js
@@ -73,9 +73,9 @@ function getLabel(object) {
     labelProp = 'label';
   }
   if (window.showNotation && object.notation) {
-    return '<span class="tree-notation">' + object.notation + '</span> ' + object[labelProp];
+    return '<span class="tree-notation">' + object.notation + '</span> <span class="tree-label">' + escapeHtml(object[labelProp]) + '</span>';
   }
-  return escapeHtml(object[labelProp]);
+  return '<span class="tree-label">' + escapeHtml(object[labelProp]) + '</span>';
 }
 
 function createObjectsFromChildren(conceptData, conceptUri) {
@@ -423,6 +423,22 @@ function topConceptsToSchemes(topConcepts, schemes) {
   return childArray;
 }
 
+/*
+ * Return a sort key suitable for sorting hierarchy nodes mainly by label.
+ * Nodes with domain class will be sorted first, followed by non-domain nodes.
+ */
+function nodeLabelSortKey(node) {
+  // make sure the tree nodes with class 'domain' are sorted before the others
+  // domain will be "0" if the node has a domain class, else "1"
+  var domain = (node.original.a_attr['class'] == 'domain') ? "0" : "1";
+
+  // parse the HTML code in node.text and return just the label as a lower case value for sorting
+  // should look like '<span class="tree-notation">12.3</span> <span class="tree-label">Hello</span>'
+  label = $(node.text.toLowerCase()).filter('.tree-label').text();
+
+  return domain + " " + label;
+}
+
 /* 
  * Gives you the Skosmos default jsTree configuration.
  */
@@ -531,12 +547,7 @@ function getTreeConfiguration() {
             // NOTE: if no notations found, fall back on label comparison below
         }
         // no sorting on notation requested, or notations don't exist
-        // make sure the tree nodes with class 'domain' are sorted before the others
-        // aDomain/bDomain will be "0" if a/b has a domain class, else "1"
-        var aDomain = (aNode.original.a_attr['class'] == 'domain') ? "0" : "1";
-        var bDomain = (bNode.original.a_attr['class'] == 'domain') ? "0" : "1";
-        return naturalCompare(aDomain + " " + aNode.text.toLowerCase(),
-                              bDomain + " " + bNode.text.toLowerCase());
+        return naturalCompare(nodeLabelSortKey(aNode), nodeLabelSortKey(bNode));
     }
   });
 }

--- a/resource/js/scripts.js
+++ b/resource/js/scripts.js
@@ -326,7 +326,14 @@ function countAndSetOffset() {
   }
 }
 
+// return -1 if the value is negative, 1 otherwise
+// used to coerce sort values so they are compatible with the jsTree sort plugin
+function negVsPos(val) {
+  return (val < 0) ? -1 : 1;
+}
+
 // Natural sort from: http://stackoverflow.com/a/15479354/3894569
+// adapted to return only -1 or 1 using negVsPos function above
 function naturalCompare(a, b) {
   var ax = [], bx = [];
 
@@ -337,10 +344,10 @@ function naturalCompare(a, b) {
     var an = ax.shift();
     var bn = bx.shift();
     var nn = (an[0] - bn[0]) || an[1].localeCompare(bn[1], lang);
-    if(nn) return nn;
+    if(nn) return negVsPos(nn);
   }
 
-  return ax.length - bx.length;
+  return negVsPos(ax.length - bx.length);
 }
 
 function makeCallbacks(data, pageType) {

--- a/tests/ConceptPropertyTest.php
+++ b/tests/ConceptPropertyTest.php
@@ -123,8 +123,8 @@ class ConceptPropertyTest extends PHPUnit\Framework\TestCase
    * @covers ConceptProperty::addValue
    * @covers ConceptProperty::sortValues
    */
-  public function testSortNotatedValuesDecimal() {
-    # the vocabulary is configured to use decimal sorting
+  public function testSortNotatedValuesLexical() {
+    # the vocabulary is configured to use lexical sorting
     $vocab = $this->model->getVocabulary('test-notation-sort');
     $concepts = $vocab->getConceptInfo('http://www.skosmos.skos/test/ta01', 'en');
     $concept = $concepts[0];

--- a/tests/ConceptPropertyTest.php
+++ b/tests/ConceptPropertyTest.php
@@ -123,12 +123,52 @@ class ConceptPropertyTest extends PHPUnit\Framework\TestCase
    * @covers ConceptProperty::addValue
    * @covers ConceptProperty::sortValues
    */
-  public function testSortNotatedValues() {
+  public function testSortNotatedValuesDecimal() {
+    # the vocabulary is configured to use decimal sorting
     $vocab = $this->model->getVocabulary('test-notation-sort');
     $concepts = $vocab->getConceptInfo('http://www.skosmos.skos/test/ta01', 'en');
     $concept = $concepts[0];
     $props = $concept->getProperties();
-    $expected = array("test:ta0112", "test:ta0119", "test:ta0117", "test:ta0116", "test:ta0114","test:ta0115","test:ta0113", "test:ta0120", "test:ta0111", );
+    $expected = array(
+      "test:ta0111", # 33.01
+      "test:ta0116", # 33.02
+      "test:ta0112", # 33.1
+      "test:ta0114", # 33.10
+      "test:ta0115", # 33.2
+      "test:ta0117", # 33.9
+      "test:ta0119", # 33.90
+      "test:ta0120", # K2
+      "test:ta0113"  # concept not defined, no notation code
+    );
+    $ret = array();
+
+    foreach($props['skos:narrower']->getValues() as $val) {
+        $ret[] = EasyRdf\RdfNamespace::shorten($val->getUri());
+    }
+    $this->assertEquals($expected, $ret);
+  }
+
+  /**
+   * @covers ConceptProperty::addValue
+   * @covers ConceptProperty::sortValues
+   */
+  public function testSortNotatedValuesNatural() {
+    # the vocabulary is configured to use natural sorting
+    $vocab = $this->model->getVocabulary('testNotation');
+    $concepts = $vocab->getConceptInfo('http://www.skosmos.skos/test/ta01', 'en');
+    $concept = $concepts[0];
+    $props = $concept->getProperties();
+    $expected = array(
+      "test:ta0111", # 33.01
+      "test:ta0116", # 33.02
+      "test:ta0112", # 33.1
+      "test:ta0115", # 33.2
+      "test:ta0117", # 33.9
+      "test:ta0114", # 33.10
+      "test:ta0119", # 33.90
+      "test:ta0120", # K2
+      "test:ta0113"  # concept not defined, no notation code
+    );
     $ret = array();
 
     foreach($props['skos:narrower']->getValues() as $val) {

--- a/tests/ConceptPropertyValueTest.php
+++ b/tests/ConceptPropertyValueTest.php
@@ -131,44 +131,6 @@ class ConceptPropertyValueTest extends PHPUnit\Framework\TestCase
   }
 
   /**
-   * @covers ConceptPropertyValue::__toString
-   */
-  public function testToStringWithNotation() {
-    $mockres = $this->getMockBuilder('EasyRdf\\Resource')->disableOriginalConstructor()->getMock();
-    $mockvoc = $this->getMockBuilder('Vocabulary')->disableOriginalConstructor()->getMock();
-    $mockconf = $this->getMockBuilder('VocabularyConfig')->disableOriginalConstructor()->getMock();
-    $mocklit = $this->getMockBuilder('EasyRdf\\Literal')->disableOriginalConstructor()->getMock();
-    $mocklit->method('getValue')->will($this->returnValue('T3ST'));
-    $mockconf->method('sortByNotation')->will($this->returnValue(true));
-    $mockconf->method('showNotation')->will($this->returnValue(true));
-    $mockvoc->method('getConfig')->will($this->returnValue($mockconf));
-    $mockres->method('label')->will($this->returnValue('Term label'));
-    $mockres->method('get')->will($this->returnValue($mocklit));
-    $mockres->method('getUri')->will($this->returnValue('http://thisdoesntexistatalland.sefsf/2j2h4/'));
-    $propval = new ConceptPropertyValue($this->model, $mockvoc, $mockres, null);
-    $this->assertEquals('T3ST Term label', (string)$propval);
-  }
-
-  /**
-   * @covers ConceptPropertyValue::__toString
-   */
-  public function testToStringWhenNotationExistsButIsConfiguredOff() {
-    $mockres = $this->getMockBuilder('EasyRdf\\Resource')->disableOriginalConstructor()->getMock();
-    $mockvoc = $this->getMockBuilder('Vocabulary')->disableOriginalConstructor()->getMock();
-    $mockconf = $this->getMockBuilder('VocabularyConfig')->disableOriginalConstructor()->getMock();
-    $mocklit = $this->getMockBuilder('EasyRdf\\Literal')->disableOriginalConstructor()->getMock();
-    $mocklit->method('getValue')->will($this->returnValue('T3ST'));
-    $mockconf->method('sortByNotation')->will($this->returnValue(true));
-    $mockconf->method('showNotation')->will($this->returnValue(false));
-    $mockvoc->method('getConfig')->will($this->returnValue($mockconf));
-    $mockres->method('label')->will($this->returnValue('Term label'));
-    $mockres->method('get')->will($this->returnValue($mocklit));
-    $mockres->method('getUri')->will($this->returnValue('http://thisdoesntexistatalland.sefsf/2j2h4/'));
-    $propval = new ConceptPropertyValue($this->model, $mockvoc, $mockres, null);
-    $this->assertEquals('Term label', (string)$propval);
-  }
-
-  /**
    * @covers ConceptPropertyValue::addSubMember
    * @covers ConceptPropertyValue::sortSubMembers
    * @covers ConceptPropertyValue::getSubMembers

--- a/tests/VocabularyConfigTest.php
+++ b/tests/VocabularyConfigTest.php
@@ -318,12 +318,43 @@ class VocabularyConfigTest extends PHPUnit\Framework\TestCase
   }
 
   /**
-   * @covers VocabularyConfig::sortByNotation
+   * @covers VocabularyConfig::getSortByNotation
+   * @covers VocabularyConfig::getLiteral
    * @covers VocabularyConfig::getBoolean
    */
   public function testShowSortByNotationDefaultValue() {
     $vocab = $this->model->getVocabulary('test');
-    $this->assertEquals(false, $vocab->getConfig()->sortByNotation());
+    $this->assertNull($vocab->getConfig()->getSortByNotation());
+  }
+
+  /**
+   * @covers VocabularyConfig::getSortByNotation
+   * @covers VocabularyConfig::getLiteral
+   * @covers VocabularyConfig::getBoolean
+   */
+  public function testShowSortByNotationTrueIsDecimal() {
+    $vocab = $this->model->getVocabulary('test-notation-sort');
+    $this->assertEquals("decimal", $vocab->getConfig()->getSortByNotation());
+  }
+
+  /**
+   * @covers VocabularyConfig::getSortByNotation
+   * @covers VocabularyConfig::getLiteral
+   * @covers VocabularyConfig::getBoolean
+   */
+  public function testShowSortByNotationDecimal() {
+    $vocab = $this->model->getVocabulary('test-qualified-notation');
+    $this->assertEquals("decimal", $vocab->getConfig()->getSortByNotation());
+  }
+
+  /**
+   * @covers VocabularyConfig::getSortByNotation
+   * @covers VocabularyConfig::getLiteral
+   * @covers VocabularyConfig::getBoolean
+   */
+  public function testShowSortByNotationNatural() {
+    $vocab = $this->model->getVocabulary('testNotation');
+    $this->assertEquals("natural", $vocab->getConfig()->getSortByNotation());
   }
 
   /**

--- a/tests/VocabularyConfigTest.php
+++ b/tests/VocabularyConfigTest.php
@@ -332,9 +332,9 @@ class VocabularyConfigTest extends PHPUnit\Framework\TestCase
    * @covers VocabularyConfig::getLiteral
    * @covers VocabularyConfig::getBoolean
    */
-  public function testShowSortByNotationTrueIsDecimal() {
+  public function testShowSortByNotationTrueIsLexical() {
     $vocab = $this->model->getVocabulary('test-notation-sort');
-    $this->assertEquals("decimal", $vocab->getConfig()->getSortByNotation());
+    $this->assertEquals("lexical", $vocab->getConfig()->getSortByNotation());
   }
 
   /**
@@ -342,9 +342,9 @@ class VocabularyConfigTest extends PHPUnit\Framework\TestCase
    * @covers VocabularyConfig::getLiteral
    * @covers VocabularyConfig::getBoolean
    */
-  public function testShowSortByNotationDecimal() {
+  public function testShowSortByNotationLexical() {
     $vocab = $this->model->getVocabulary('test-qualified-notation');
-    $this->assertEquals("decimal", $vocab->getConfig()->getSortByNotation());
+    $this->assertEquals("lexical", $vocab->getConfig()->getSortByNotation());
   }
 
   /**

--- a/tests/test-vocab-data/test-notation-sort.ttl
+++ b/tests/test-vocab-data/test-notation-sort.ttl
@@ -38,11 +38,12 @@ test:ta0111 a skos:Concept, meta:TestClass ;
     skos:broader test:ta01 ;
     skos:inScheme test:conceptscheme ;
     owl:deprecated true ;
+    skos:notation "33.01" ;
     skos:prefLabel "Tuna"@en .
 
 test:ta0112 a skos:Concept, meta:TestClass ;
     skosmos:testprop "Test property value" ;
-    skos:notation "665" ;
+    skos:notation "33.1" ;
     skos:broader test:ta01 ;
     skos:narrower test:ta0121 ;
     skos:exactMatch test:ta0118 ;
@@ -56,6 +57,7 @@ test:ta0112 a skos:Concept, meta:TestClass ;
 test:ta0114 a skos:Concept, meta:TestClass ;
     skos:broader test:ta01 ;
     dct:modified "1986-21-00"^^xsd:date ; # date invalid on purpose
+    skos:notation "33.10" ;
     skos:inScheme test:conceptscheme ;
     skos:prefLabel "Buri"@en .
 
@@ -64,16 +66,19 @@ test:ta0115 a skos:Concept, meta:TestClass ;
     skos:inScheme test:conceptscheme ;
     skos:definition "any fish belonging to the order Anguilliformes"@en, 
       "Iljettävä limanuljaska"@fi ;
+    skos:notation "33.2" ;
     skos:prefLabel "Eel"@en .
 
 test:ta0116 a skos:Concept, meta:TestClass ;
     skos:broader test:ta01 ;
     skos:inScheme test:conceptscheme ;
+    skos:notation "33.02" ;
     skos:prefLabel "Barracuda"@en .
 
 test:ta0117 a skos:Concept, meta:TestClass ;
     skos:broader test:ta01 ;
     skos:inScheme test:conceptscheme ;
+    skos:notation "33.9" ;
     skos:relatedMatch test:ta0115 ;
     skos:prefLabel "3D Barracuda"@en .
 
@@ -85,11 +90,12 @@ test:ta0118 a skos:Concept, meta:TestClass ;
 test:ta0119 a skos:Concept, meta:TestClass ;
     skos:broader test:ta01 ;
     skos:inScheme test:conceptscheme ;
-    skos:notation "690" ;
+    skos:notation "33.90" ;
     skos:prefLabel "Hauki"@fi .
 
 test:ta0120 a skos:Concept, meta:TestClass ;
     skos:broader test:ta01 ;
+    skos:notation "K2" ;
     skos:inScheme test:conceptscheme .
 
 test:ta0121 a skos:Concept, meta:TestClass ;

--- a/tests/testconfig.ttl
+++ b/tests/testconfig.ttl
@@ -117,6 +117,7 @@
     void:uriSpace "http://www.skosmos.skos/test-qualified-notation/" ;
     skosmos:defaultLanguage "en" ;
     skosmos:groupClass skos:Collection ;
+    skosmos:sortByNotation "decimal" ;
     skosmos:language "en" ;
     skosmos:alphabeticalListQualifier skos:notation ;
     skosmos:sparqlGraph <http://www.skosmos.skos/test-qualified-notation/> .
@@ -337,7 +338,7 @@
     dc:subject :cat_general ;
     void:uriSpace "http://www.skosmos.skos/notationFeatures/";
     skosmos:language "fi";
-    skosmos:sortByNotation true ;
+    skosmos:sortByNotation "natural" ;
     skosmos:searchByNotation true ;
     skosmos:showNotation true ;
     skosmos:useModifiedDate "true";

--- a/tests/testconfig.ttl
+++ b/tests/testconfig.ttl
@@ -117,7 +117,7 @@
     void:uriSpace "http://www.skosmos.skos/test-qualified-notation/" ;
     skosmos:defaultLanguage "en" ;
     skosmos:groupClass skos:Collection ;
-    skosmos:sortByNotation "decimal" ;
+    skosmos:sortByNotation "lexical" ;
     skosmos:language "en" ;
     skosmos:alphabeticalListQualifier skos:notation ;
     skosmos:sparqlGraph <http://www.skosmos.skos/test-qualified-notation/> .

--- a/tests/testconfig.ttl
+++ b/tests/testconfig.ttl
@@ -336,13 +336,13 @@
 :testNotation a skosmos:Vocabulary, void:Dataset ;
     dc11:title "A vocabulary for testing vocabularies with notation features"@en ;
     dc:subject :cat_general ;
-    void:uriSpace "http://www.skosmos.skos/notationFeatures/";
+    void:uriSpace "http://www.skosmos.skos/test-notation-sort/";
     skosmos:language "fi";
     skosmos:sortByNotation "natural" ;
     skosmos:searchByNotation true ;
     skosmos:showNotation true ;
     skosmos:useModifiedDate "true";
-    skosmos:sparqlGraph <http://www.skosmos.skos/notation/>;
+    skosmos:sparqlGraph <http://www.skosmos.skos/test-notation-sort/>;
     skosmos:mainConceptScheme test:notationMainConceptScheme .
 
 :paramPluginTest a skosmos:Vocabulary, void:Dataset ;

--- a/view/scripts.twig
+++ b/view/scripts.twig
@@ -32,8 +32,8 @@ var prefLabels = [{"lang": "{{ search_results|first.label.lang }}","label": "{{ 
 {% if request.vocab and request.vocab.uriSpace %}
 var uriSpace = "{{ request.vocab.uriSpace }}";
 {% endif %}
+var showNotation = {% if request.vocab and not request.vocab.config.showNotation %}false{% else %}true{% endif %};
 {% if request.vocab  %}
-var showNotation = {% if request.vocab.config.showNotation %}true{% else %}false{% endif %};
 var sortByNotation = {% if request.vocab.config.sortByNotation %}"{{ request.vocab.config.sortByNotation }}"{% else %}null{% endif %};
 var languageOrder = [{% for lang in request.vocab.config.languageOrder(request.contentLang) %}"{{ lang }}"{% if not loop.last %},{% endif %}{% endfor %}];
 var vocShortName = "{{ request.vocab.config.shortname }}";

--- a/view/scripts.twig
+++ b/view/scripts.twig
@@ -32,8 +32,9 @@ var prefLabels = [{"lang": "{{ search_results|first.label.lang }}","label": "{{ 
 {% if request.vocab and request.vocab.uriSpace %}
 var uriSpace = "{{ request.vocab.uriSpace }}";
 {% endif %}
-var showNotation = {% if request.vocab and request.vocab.config.showNotation == false %}false{% else %}true{% endif %};
 {% if request.vocab  %}
+var showNotation = {% if request.vocab.config.showNotation %}true{% else %}false{% endif %};
+var sortByNotation = {% if request.vocab.config.sortByNotation %}"{{ request.vocab.config.sortByNotation }}"{% else %}null{% endif %};
 var languageOrder = [{% for lang in request.vocab.config.languageOrder(request.contentLang) %}"{{ lang }}"{% if not loop.last %},{% endif %}{% endfor %}];
 var vocShortName = "{{ request.vocab.config.shortname }}";
 {% endif %}


### PR DESCRIPTION
This PR makes it possible to select either "lexical" or "natural" sort strategy for sorting notation codes (see #937 for more background). The sorting is implemented both on the PHP and JS sides. The `skosmos:sortByNotation` configuration setting, which previously was just a boolean value, can now given a literal value to select the appropriate sort strategy:

    skosmos:sortByNotation "false";    # disabled, i.e. sort by labels, not notations
    skosmos:sortByNotation "lexical";  # lexical sorting
    skosmos:sortByNotation "natural";  # natural sorting
    skosmos:sortByNotation "true";     # default sorting i.e. decimal, as it's the most common

TODO:

- [x] more testing - ~~it seems that sorting by notation is not always working on the JS side because notations are missing for the jsTree concept objects~~ (fixed, the problem was in Finto layout footer.inc)
- [x] more unit tests to check that the sort order is as expected
- [ ] update wiki documentation (Configuration)

Fixes #937 
