### PR TITLE
Replace NBSP by spaces

### DIFF
--- a/model/DataObject.php
+++ b/model/DataObject.php
@@ -50,7 +50,7 @@ class DataObject
                 $exsparql = $exvoc->getSparql();
                 $results = $exsparql->queryLabel($exuri, $lang);
                 return isset($results[$lang]) ? $results[$lang] : null;
-            } catch (EasyRdf\Http\Exception | EasyRdf\Exception | Throwable $e) {
+            } catch (EasyRdf\Http\Exception | EasyRdf\Exception | Throwable $e) {
                 if ($this->model->getConfig()->getLogCaughtExceptions()) {
                     error_log('Caught exception: ' . $e->getMessage());
                 }
@@ -72,7 +72,7 @@ class DataObject
                 $exsparql = $exvoc->getSparql();
                 $results = $exsparql->queryNotation($exuri);
                 return isset($results) ? $results : null;
-            } catch (EasyRdf\Http\Exception | EasyRdf\Exception | Throwable $e) {
+            } catch (EasyRdf\Http\Exception | EasyRdf\Exception | Throwable $e) {
                 if ($this->model->getConfig()->getLogCaughtExceptions()) {
                     error_log('Caught exception: ' . $e->getMessage());
                 }

--- a/model/Model.php
+++ b/model/Model.php
@@ -478,7 +478,7 @@ class Model
                             // not found in preferred vocabulary, fall back to next method
                             break;
                         }
-                    } catch (EasyRdf\Http\Exception | EasyRdf\Exception | Throwable $e) {
+                    } catch (EasyRdf\Http\Exception | EasyRdf\Exception | Throwable $e) {
                         if ($this->getConfig()->getLogCaughtExceptions()) {
                             error_log('Caught exception: ' . $e->getMessage());
                         }
@@ -494,7 +494,7 @@ class Model
                 if ($vocab->getConceptLabel($uri, null) !== null) {
                     return $vocab;
                 }
-            } catch (EasyRdf\Http\Exception | EasyRdf\Exception | Throwable $e) {
+            } catch (EasyRdf\Http\Exception | EasyRdf\Exception | Throwable $e) {
                 if ($this->getConfig()->getLogCaughtExceptions()) {
                     error_log('Caught exception: ' . $e->getMessage());
                 }

--- a/model/Vocabulary.php
+++ b/model/Vocabulary.php
@@ -162,7 +162,7 @@ class Vocabulary extends DataObject implements Modifiable
             // query everything the endpoint knows about the ConceptScheme
             $sparql = $this->getSparql();
             $result = $sparql->queryConceptScheme($defaultcs);
-        } catch (EasyRdf\Http\Exception | EasyRdf\Exception | Throwable $e) {
+        } catch (EasyRdf\Http\Exception | EasyRdf\Exception | Throwable $e) {
              if ($this->model->getConfig()->getLogCaughtExceptions()) {
                  error_log('Caught exception: ' . $e->getMessage());
              }
@@ -252,7 +252,7 @@ class Vocabulary extends DataObject implements Modifiable
         $conceptSchemes = null;
         try {
             $conceptSchemes = $this->getSparql()->queryConceptSchemes($lang);
-        } catch (EasyRdf\Http\Exception | EasyRdf\Exception | Throwable $e) {
+        } catch (EasyRdf\Http\Exception | EasyRdf\Exception | Throwable $e) {
              if ($this->model->getConfig()->getLogCaughtExceptions()) {
                  error_log('Caught exception: ' . $e->getMessage());
              }
@@ -452,7 +452,7 @@ class Vocabulary extends DataObject implements Modifiable
         $conceptInfo = null;
         try {
             $conceptInfo = $sparql->queryConceptInfo($uri, $this->config->getArrayClassURI(), array($this), $clang);
-        } catch (EasyRdf\Http\Exception | EasyRdf\Exception | Throwable $e) {
+        } catch (EasyRdf\Http\Exception | EasyRdf\Exception | Throwable $e) {
              if ($this->model->getConfig()->getLogCaughtExceptions()) {
                  error_log('Caught exception: ' . $e->getMessage());
              }

--- a/resource/js/scripts.js
+++ b/resource/js/scripts.js
@@ -114,7 +114,7 @@ $.ajaxQ = (function(){
       var r = [];
       $.each(Q, function(i, jqXHR){
         r.push(jqXHR._id);
-        if (jqXHR.req_kind == $.ajaxQ.requestKind.CONTENT || jqXHR.req_kind == $.ajaxQ.requestKind.PLUGIN) {
+        if (jqXHR.req_kind == $.ajaxQ.requestKind.CONTENT || jqXHR.req_kind == $.ajaxQ.requestKind.PLUGIN) {
           jqXHR.abort();
         }
       });
@@ -124,7 +124,7 @@ $.ajaxQ = (function(){
       var r = [];
       $.each(Q, function(i, jqXHR){
         r.push(jqXHR._id);
-        if (jqXHR.req_kind == $.ajaxQ.requestKind.SIDEBAR || all && jqXHR.req_kind == $.ajaxQ.requestKind.SIDEBAR_PRIVILEGED) {
+        if (jqXHR.req_kind == $.ajaxQ.requestKind.SIDEBAR || all && jqXHR.req_kind == $.ajaxQ.requestKind.SIDEBAR_PRIVILEGED) {
           jqXHR.abort();
         }
       });


### PR DESCRIPTION
Was reading the code, searching for language label/value, and noticed the `NBSP` character. It's not really a space char, although most browsers/IDE's support it, it can still cause issues when refactoring with a regex like `\s` for instance.

The GitHub UI will show like a space. But if you open on PhpStorm, or `vim` (click `G` followed by `A` to show the current char code in the status bar of `vim`) you should be able to see the char.