### PR TITLE
Allow clicking on either label or notation in hierarchy

### DIFF
--- a/resource/js/docready.js
+++ b/resource/js/docready.js
@@ -280,7 +280,7 @@ $(function() { // DOCUMENT READY
   $(document).on('click', '.concept-hierarchy a',
       function(event) {
         $.ajaxQ.abortContentQueries();
-        var targetUrl = event.target.href;
+        var targetUrl = event.target.href || event.target.parentElement.href;
         $('#hier-trigger').attr('href', targetUrl);
         var $content = $('.content').empty().append($delayedSpinner.hide());
         var loading = delaySpinner();


### PR DESCRIPTION
Fixes #1210

Clicking on notation codes in the hierarchy didn't work in the previous release, and in current master even clicking on labels is broken. This PR fixes both issues. The problem was that when clickin on a `<span>` element, the URL for the target concept/page wasn't extracted properly.