### PR TITLE
Fix notation data type tests

### DIFF
--- a/model/ConceptPropertyValueLiteral.php
+++ b/model/ConceptPropertyValueLiteral.php
@@ -48,7 +48,7 @@ class ConceptPropertyValueLiteral extends VocabularyDataObject
             $dtLabel = $graph->resource($datatype)->label($this->clang);
             return $dtLabel->getValue();
         }
-        return "";
+        return null;
     }
 
     public function getType()

--- a/tests/ConceptPropertyValueLiteralTest.php
+++ b/tests/ConceptPropertyValueLiteralTest.php
@@ -63,7 +63,7 @@ class ConceptPropertyValueLiteralTest extends PHPUnit\Framework\TestCase
   }
 
   /**
-  * @covers ConceptPropertyValueLiteral::getLabel
+  * @covers ConceptPropertyValueLiteral::getDatatype
   */
   public function testGetLabelForDatatype() {
     $vocab = $this->model->getVocabulary('test');
@@ -74,7 +74,7 @@ class ConceptPropertyValueLiteralTest extends PHPUnit\Framework\TestCase
   }
 
   /**
-  * @covers ConceptPropertyValueLiteral::getLabel
+  * @covers ConceptPropertyValueLiteral::getDatatype
   */
   public function testGetNotationDatatypeWithoutLabel() {
     $vocab = $this->model->getVocabulary('test');
@@ -85,7 +85,7 @@ class ConceptPropertyValueLiteralTest extends PHPUnit\Framework\TestCase
   }
 
 /**
- * @covers ConceptPropertyValueLiteral::getLabel
+ * @covers ConceptPropertyValueLiteral::getDatatype
  */
 public function testGetLabelForDatatypeIfNull() {
     $vocab = $this->model->getVocabulary('test');

--- a/tests/ConceptPropertyValueLiteralTest.php
+++ b/tests/ConceptPropertyValueLiteralTest.php
@@ -81,7 +81,7 @@ class ConceptPropertyValueLiteralTest extends PHPUnit\Framework\TestCase
     $concepts = $vocab->getConceptInfo('http://www.skosmos.skos/test/ta128', 'en');
     $props = $concepts[0]->getProperties();
     $propvals = $props['skos:notation']->getValues();
-    $this->assertEquals('', $propvals['testnotation']->getDatatype());
+    $this->assertNull($propvals['testnotation']->getDatatype());
   }
 
 /**


### PR DESCRIPTION
A couple of minor fixes after merging PR #1198:

- fix the coverage annotations (so that the test coverage is properly assessed for the getDatatype method)
- change getDatatype to return `null` if a datatype exists without a label (and modify corresponding test)

ping @miguelahonen 