### PR TITLE
Gracefully produce 404 error page for URLs with unknown vocabulary ID

### DIFF
--- a/index.php
+++ b/index.php
@@ -49,7 +49,7 @@ if (sizeof($parts) <= 2) {
         $vocab = $parts[1];
         try {
             $request->setVocab($parts[1]);
-        } catch (Exception $e) {
+        } catch (Exception | ValueError $e) {
             $request->setLang($controller->guessLanguage());
             $controller->invokeGenericErrorPage($request);
             return;


### PR DESCRIPTION
This PR fixes a problem with URLs containing vocabulary IDs that are known to Skosmos.

Example: https://finto.fi/notfound/ -> produces a blank page and a message in the server error log:

```
[Wed Oct 06 10:15:19.928508 2021] [php7:error] [pid 16194] [client 127.0.0.1:58340] PHP Fatal error:  Uncaught ValueError: Vocabulary id 'notfound' not found in configuration. in /var/www/finto.fi/model/Model.php:420\nStack trace:\n#0 /var/www/finto.fi/model/Request.php(246): Model->getVocabulary('notfound')\n#1 /var/www/finto.fi/index.php(51): Request->setVocab('notfound')\n#2 {main}\n  thrown in /var/www/finto.fi/model/Model.php on line 420
```

The reason is that the code in index.php attempts catch Exception, but nowadays (since PR #1127) ValueError is produced instead and it is a subclass of Error, not Exception. 

This one-line fix changes the catch block to also include ValueError. The end result is that a 404 page is produced instead of a blank page, and nothing gets written into the error log.

(credit to @kouralex for pointing this out)