### PR TITLE
Fix performance problems in query for notation label

### DIFF
--- a/model/sparql/GenericSparql.php
+++ b/model/sparql/GenericSparql.php
@@ -431,9 +431,9 @@ CONSTRUCT {
   {
    ?uri ?p ?o .
    OPTIONAL {
-     FILTER(?p = skos:notation)
-     FILTER(isLiteral(?o))
-     BIND(datatype(?o) AS ?dt)
+     ?uri skos:notation ?nVal .
+     FILTER(isLiteral(?nVal))
+     BIND(datatype(?nVal) AS ?dt)
      ?dt rdfs:label ?dtlabel
    }
    OPTIONAL {


### PR DESCRIPTION
The sparql query in #1198 did not perform well with Lexvo and gave too many results. This PR changes the query to have results faster and without unnecessary data.