### PR TITLE
Move allcaps in property-labels (and vocabulary-category) from twig  to css

### DIFF
--- a/resource/css/styles.css
+++ b/resource/css/styles.css
@@ -751,6 +751,10 @@ span.xl-pref-label > img {
   padding: 15px 0 15px 10px;
 }
 
+.property-label, .vocab-category > h3 {
+  text-transform: uppercase;
+}
+
 .vocab-category {
   display: inline-block;
   width: 100%;

--- a/view/concept-shared.twig
+++ b/view/concept-shared.twig
@@ -42,7 +42,7 @@
       {% spaceless %}
       <div class="row{% if concept.type == 'skosext:DeprecatedConcept' %} deprecated{% endif %} property prop-preflabel">
         <div class="property-label property-label-pref">
-          <h3 class="versal">{% set subPrefLabelTranslation = concept.preferredSubpropertyLabelTranslation(request.lang) %}{% if subPrefLabelTranslation %}{{ subPrefLabelTranslation|upper }}{% else %}{{ 'skos:prefLabel'|trans|upper }}{% endif %}</h3>
+          <h3 class="versal">{% set subPrefLabelTranslation = concept.preferredSubpropertyLabelTranslation(request.lang) %}{% if subPrefLabelTranslation %}{{ subPrefLabelTranslation }}{% else %}{{ 'skos:prefLabel'|trans }}{% endif %}</h3>
         </div>
         {% if concept.foundBy %} {# hit has been found through an alternative label #}
         <span class="versal">{{ concept.foundBy }} ></span>
@@ -90,7 +90,7 @@
         {% if property.getSubPropertyOf != 'skos:hiddenLabel' %}
         <div class="row{% if property.type == 'dc:isReplacedBy' %} replaced-by{% endif%} property prop-{{property.ID}}">
           <div class="property-label">
-            <h3 class="versal{% if property.type == 'rdf:type' %}-bold{% endif %}{% if property.description %} property-click" title="{{ property.description }}{% endif %}">{{ property.label|upper }}</h3>
+            <h3 class="versal{% if property.type == 'rdf:type' %}-bold{% endif %}{% if property.description %} property-click" title="{{ property.description }}{% endif %}">{{ property.label }}</h3>
           </div>
           <div class="property-value-column"><div class="property-value-wrapper">
         {% if request.vocab.config.hasMultiLingualProperty(property.type) %}
@@ -141,7 +141,7 @@
       {% set foreignLabels = concept.foreignLabels %}
       {% if foreignLabels %}
       <div class="row property prop-other-languages">
-        <div class="property-label"><h3 class="versal property-click" title="{% trans "foreign prefLabel help" %}" >{{ 'foreign prefLabels'|trans|upper }}</h3></div>
+        <div class="property-label"><h3 class="versal property-click" title="{% trans "foreign prefLabel help" %}" >{{ 'foreign prefLabels'|trans }}</h3></div>
         <div class="property-value-column">
           <div class="property-value-wrapper">
             <ul>
@@ -207,7 +207,7 @@
 <template id="property-mappings-template">
     {{#each properties}}
     <div class="row{{#ifDeprecated concept.type 'skosext:DeprecatedConcept'}} deprecated{{/ifDeprecated}} property prop-{{ id }}">
-        <div class="property-label"><h3 class="versal{{#ifNotInDescription type description}} property-click" title="{{ description }}{{/ifNotInDescription}}">{{toUpperCase label}}</h3></div>
+        <div class="property-label"><h3 class="versal{{#ifNotInDescription type description}} property-click" title="{{ description }}{{/ifNotInDescription}}">{{label}}</h3></div>
         <div class="property-value-column">
             {{#each values }} {{! loop through ConceptPropertyValue objects }}
             {{#if prefLabel }}

--- a/view/vocab-shared.twig
+++ b/view/vocab-shared.twig
@@ -15,7 +15,7 @@
         {% for key, values in vocabInfo %}
         {% set keytrans = key %}
         <div class="row">
-          <div class="property-label versal"><h3>{{ keytrans|trans|upper }}</h3><div class="property-divider"></div></div>
+          <div class="property-label versal"><h3>{{ keytrans|trans }}</h3><div class="property-divider"></div></div>
           <div class="property-value-column versal">
             {% for val in values %}
             <div class="property-value-wrapper">

--- a/view/vocabularylist.twig
+++ b/view/vocabularylist.twig
@@ -12,7 +12,7 @@
   <div class="vocabularies">
     {% for vocabClassName,vocabArray in request.vocabList %}
     <div class="vocab-category">
-      <h3>{{ vocabClassName|upper }}</h3>
+      <h3>{{ vocabClassName }}</h3>
       <ul>
       {% for vocab in vocabArray %}
         <li><a class="navigation-font" href="{{ vocab.id }}/{{ request.lang }}/{% if request.contentLang != request.lang and request.contentLang != '' and request.contentLang in vocab.config.languages %}?clang={{ request.contentLang }}{% endif %}">{{ vocab.title }}</a></li>


### PR DESCRIPTION
Making the changes discussed in issue #1222: removing `|upper` and `toUpperCase` from twig files to make these labels regular case again, then adding the relevant classes to styles.css and using `text-transform: uppercase`on them.