### PR TITLE
Fix hierarchy js error for special characters in prefLabels

### DIFF
--- a/resource/js/hierarchy.js
+++ b/resource/js/hierarchy.js
@@ -210,7 +210,7 @@ function vocabRoot(topConcepts) {
   for (var i = 0; i < topConcepts.length; i++) {
     var conceptData = topConcepts[i];
     var childObject = {
-      text: conceptData.label, 
+      text: getLabel(conceptData), 
       a_attr : getHrefForUri(conceptData.uri),
       uri: conceptData.uri,
       notation: conceptData.notation,
@@ -218,8 +218,6 @@ function vocabRoot(topConcepts) {
     };
     if (conceptData.hasChildren)
       childObject.children = true;
-    if (window.showNotation && conceptData.notation)
-      childObject.text = '<span class="tree-notation">' + conceptData.notation + '</span> ' + childObject.text;
     setNode(childObject);
     topArray.push(childObject);
   }


### PR DESCRIPTION
related to #1221.

The trouble was that in one place when building the tree, the getLabel function wasn't used to create the html for notation and preflabel. The getLabel function unescapes special characters in labels and also adds a .tree-label class to the label span, which is later filtered for when sorting the tree in naturalCompare - if it doesn't exist, the variable it depends on isn't filled and the whole thing breaks down.

Lines 221 and 222 are removed because a) the same thing is done in getLabel, and 2) because it didn't escape special chars and doesn't add the .tree-label class that getLabel does.