### PR TITLE
Avoid uncaught fatal errors in REST API if vocabulary ID not found

### DIFF
--- a/rest.php
+++ b/rest.php
@@ -44,7 +44,7 @@ try {
         $vocab = $parts[1];
         try {
             $request->setVocab($parts[1]);
-        } catch (Exception $e) {
+        } catch (Exception | ValueError $e) {
             header("HTTP/1.0 404 Not Found");
             header("Content-type: text/plain; charset=utf-8");
             echo ("404 Not Found : Vocabulary id '$parts[1]' not found.");


### PR DESCRIPTION
Fixes #1170

This is a similar fix as #1215, but for the REST API. 

For an URL like this: http://localhost/Skosmos/rest/v1/koko2/data?format=text/turtle

(note that there is no vocabulary with the id `koko2` defined in config.ttl)

it prevents uncaught fatal errors like this:

```
[Tue Nov 02 09:49:37.020140 2021] [php7:error] [pid 175327] [client 127.0.0.1:53116] PHP Fatal error:  Uncaught ValueError: Vocabulary id 'koko2' not found in configuration. in /var/www/html/Skosmos/model/Model.php:420\nStack trace:\n#0 /var/www/html/Skosmos/model/Request.php(246): Model->getVocabulary()\n#1 /var/www/html/Skosmos/rest.php(46): Request->setVocab()\n#2 {main}\n  thrown in /var/www/html/Skosmos/model/Model.php on line 420
```

Instead a 404 error is produced, like this:

    404 Not Found : Vocabulary id 'koko2' not found.