### PR TITLE
Fix language switcher "eating" part of vocids that end in a langcode (e.g. "interessen" and "en")

### DIFF
--- a/view/topbar.twig
+++ b/view/topbar.twig
@@ -25,7 +25,7 @@
   <ul class="dropdown-menu dropdown-menu-right">
   {% for langcode, langdata in languages %}
   {% if request.lang != langcode %}
-  <li><a id="language-{{ langcode }}" class="versal" href="{{ request.langurl|replace({("#{request.lang}/"): "#{langcode}/"}) }}"> {{langdata.lemma}}</a></li>
+  <li><a id="language-{{ langcode }}" class="versal" href="{{ request.langurl|replace({("/#{request.lang}/"): "/#{langcode}/"}) }}"> {{langdata.lemma}}</a></li>
   {% endif %}
   {% endfor %}
   </ul>
@@ -34,7 +34,7 @@
 <div id="language"><span class="navigation-font">|</span>
   {% for langcode, langdata in languages %}
   {% if request.lang != langcode %}
-  <a id="language-{{ langcode}}" class="navigation-font" href="{{ request.langurl|replace({("#{request.lang}/"): "#{langcode}/"}) }}"> {{langdata.name}}</a>
+  <a id="language-{{ langcode}}" class="navigation-font" href="{{ request.langurl|replace({("/#{request.lang}/"): "/#{langcode}/"}) }}"> {{langdata.name}}</a>
   {% endif %}
   {% endfor %}
 </div>


### PR DESCRIPTION
I happend to have a vocabulary named (vocid) "interessen", which ends in "en", one of the available ui languages. 
When switching the UI to German, the "en" ending in the url (**/interessen/en/**) was replaced with the "de" code, as well as appending another /de. So en was (re)placed twice, leading to broken urls such as /interess**de**/de/.

I fixed this for now by making the "| replace" filter that rewrites the url not as greedy: instead of any langcode-looking text, it now looks for a slash preceding it (/en instead of just en). This will probably not fix instances where a vocid is exactly the same as one of the langcodes (vocabularies named "en", "de", "fr" etc.) but is good enough for me at the moment.