### PR TITLE
Custom labels and tooltips for properties in concept view

### DIFF
--- a/controller/WebController.php
+++ b/controller/WebController.php
@@ -178,6 +178,11 @@ class WebController extends Controller
         if ($this->notModified($results[0])) {
             return;
         }
+        $customLabels = $vocab->getConfig()->getPropertyLabelOverrides();
+
+        $logger = $this->model->getLogger();
+        $logger->info("Custom Labels\n" . print_r($customLabels, TRUE));
+
         $pluginParameters = json_encode($vocab->getConfig()->getPluginParameters());
         $template = (in_array('skos:Concept', $results[0]->getType()) || in_array('skos:ConceptScheme', $results[0]->getType())) ? $this->twig->loadTemplate('concept-info.twig') : $this->twig->loadTemplate('group-contents.twig');
 
@@ -191,7 +196,8 @@ class WebController extends Controller
             'bread_crumbs' => $crumbs['breadcrumbs'],
             'combined' => $crumbs['combined'],
             'request' => $request,
-            'plugin_params' => $pluginParameters)
+            'plugin_params' => $pluginParameters,
+            'custom_labels' => $customLabels)
         );
     }
 

--- a/controller/WebController.php
+++ b/controller/WebController.php
@@ -180,9 +180,6 @@ class WebController extends Controller
         }
         $customLabels = $vocab->getConfig()->getPropertyLabelOverrides();
 
-        $logger = $this->model->getLogger();
-        $logger->info("Custom Labels\n" . print_r($customLabels, TRUE));
-
         $pluginParameters = json_encode($vocab->getConfig()->getPluginParameters());
         $template = (in_array('skos:Concept', $results[0]->getType()) || in_array('skos:ConceptScheme', $results[0]->getType())) ? $this->twig->loadTemplate('concept-info.twig') : $this->twig->loadTemplate('group-contents.twig');
 

--- a/model/VocabularyConfig.php
+++ b/model/VocabularyConfig.php
@@ -157,7 +157,7 @@ class VocabularyConfig extends BaseConfig
         foreach ($labels as $label) {
             $newOverrides['label'][$label->getLang()] = $label->getValue();
         }
-        $descriptions = $override->allLiterals('schema:description'); //optionally override property label tooltips
+        $descriptions = $override->allLiterals('rdfs:comment'); //optionally override property label tooltips
         foreach ($descriptions as $description) {
              $newOverrides['description'][$description->getLang()] = $description->getValue();
         }

--- a/model/VocabularyConfig.php
+++ b/model/VocabularyConfig.php
@@ -8,6 +8,7 @@ class VocabularyConfig extends BaseConfig
     private $pluginRegister;
     private $pluginParameters = array();
     private $languageOrderCache = array();
+    private $labelOverrides = array();
 
     const DEFAULT_PROPERTY_ORDER = array("rdf:type", "dc:isReplacedBy",
     "skos:definition", "skos:broader", "isothes:broaderGeneric",
@@ -33,6 +34,7 @@ class VocabularyConfig extends BaseConfig
         $this->resource = $resource;
         $this->globalPlugins = $globalPlugins;
         $this->setParameterizedPlugins();
+        $this->setPropertyLabelOverrides();
         $pluginArray = $this->getPluginArray();
         $this->pluginRegister = new PluginRegister($pluginArray);
     }
@@ -121,6 +123,46 @@ class VocabularyConfig extends BaseConfig
                 $this->pluginParameters[$pluginName][$paramName] = $paramValue;
             }
         }
+    }
+
+    /**
+     * Sets array of configured property label overrides
+     *  @return void
+     */
+    private function setPropertyLabelOverrides() : void
+    {
+        $this->labelOverrides = array();
+        $overrides = $this->resource->allResources('skosmos:propertyLabelOverride');
+        if ($overrides) {
+            foreach ($overrides as $override) {
+                $this->setLabelOverride($override);
+            }
+        }
+    }
+
+    /**
+     * Updates array of label overrides by adding a new override from the configuration file
+     * @param Easyrdf\Resource $labelOverride
+     * @return void
+     */
+    private function setLabelOverride(Easyrdf\Resource $override) : void
+    {
+        $labelProperty = $override->getResource('skosmos:property');
+        $labelPropUri = $labelProperty->shorten();
+        if (empty($this->labelOverrides[$labelPropUri])) {
+            $this->labelOverrides[$labelPropUri]  = array();
+        }
+        $newOverrides = array();
+
+        $labels = $override->allLiterals('rdfs:label'); //property label overrides
+        foreach ($labels as $label) {
+            $newOverrides['label'][$label->getLang()] = $label->getValue();
+        }
+        $descriptions = $override->allLiterals('schema:description'); //optionally override property label tooltips
+        foreach ($descriptions as $description) {
+             $newOverrides['description'][$description->getLang()] = $description->getValue();
+        }
+        $this->labelOverrides[$labelPropUri] = array_merge($newOverrides, $this->labelOverrides[$labelPropUri]);
     }
 
     /**
@@ -503,6 +545,14 @@ class VocabularyConfig extends BaseConfig
      */
     public function getPluginParameters() {
         return $this->pluginParameters;
+    }
+
+    /**
+     * Get the list of property label overrides
+     * @return array of custom property labels
+     */
+    public function getPropertyLabelOverrides() {
+        return $this->labelOverrides;
     }
 
     /**

--- a/model/VocabularyConfig.php
+++ b/model/VocabularyConfig.php
@@ -73,7 +73,6 @@ class VocabularyConfig extends BaseConfig
 
     /**
      * Sets array of parameterized plugins
-     * @param Easyrdf\Resource $pluginResource
      * @return void
      */
     private function setParameterizedPlugins() : void
@@ -133,7 +132,7 @@ class VocabularyConfig extends BaseConfig
     {
         $this->labelOverrides = array();
         $overrides = $this->resource->allResources('skosmos:propertyLabelOverride');
-        if ($overrides) {
+        if (!empty($overrides)) {
             foreach ($overrides as $override) {
                 $this->setLabelOverride($override);
             }

--- a/tests/VocabularyConfigTest.php
+++ b/tests/VocabularyConfigTest.php
@@ -618,4 +618,22 @@ class VocabularyConfigTest extends PHPUnit\Framework\TestCase
     $this->assertEquals($order, $params);
   }
 
+  /**
+   * @covers VocabularyConfig::getPropertyLabelOverrides
+   * @covers VocabularyConfig::setPropertyLabelOverrides
+   * @covers VocabularyConfig::setLabelOverride
+   */
+  public function testGetPropertyLabelOverrides() {
+    $vocab = $this->model->getVocabulary('conceptPropertyLabels');
+
+    $overrides = $vocab->getConfig()->getPropertyLabelOverrides();
+
+    $expected = array(
+      'skos:prefLabel' => array( 'label' => array ( 'en' => 'Caption', 'fi' => 'Luokka' ) ),
+      'skos:notation' => array( 'label' => array ( 'en' => 'UDC number', 'fi' => 'UDC-numero', 'sv' => 'UDC-nummer' ),
+                                'description' => array( 'en' => 'Class Number') ),
+    );
+    $this->assertEquals($expected, $overrides);
+  }
+
 }

--- a/tests/testconfig.ttl
+++ b/tests/testconfig.ttl
@@ -298,6 +298,22 @@
     skosmos:language "fi";
     skosmos:sparqlGraph <http://www.skosmos.skos/collation/> .
 
+:conceptPropertyLabels  a skosmos:Vocabulary, void:Dataset ;
+	dc:title "Test custom property labels"@en ;
+	dc:subject :cat_science ;
+    dc:type mdrtype:ONTOLOGY ;
+	void:dataDump <http://skosmos.skos/dump/test/> ;
+	void:uriSpace "http://www.skosmos.skos/test/";
+	skosmos:defaultLanguage "en";
+	skosmos:language "en";
+    skosmos:propertyLabelOverride
+        [ skosmos:property skos:prefLabel ;
+          rdfs:label "Caption"@en, "Luokka"@fi ],
+        [ skosmos:property skos:notation ;
+          rdfs:label "UDC number"@en, "UDC-numero"@fi, "UDC-nummer"@sv ;
+          schema:description "Class Number"@en ] ;
+	skosmos:sparqlGraph <http://www.skosmos.skos/conceptPropertyLabels/> .
+
 :cbd a skosmos:Vocabulary, void:Dataset ;
     dc11:title "A vocabulary for testing blank node processing and reification"@en ;
     dc:subject :cat_general ;

--- a/tests/testconfig.ttl
+++ b/tests/testconfig.ttl
@@ -311,7 +311,7 @@
           rdfs:label "Caption"@en, "Luokka"@fi ],
         [ skosmos:property skos:notation ;
           rdfs:label "UDC number"@en, "UDC-numero"@fi, "UDC-nummer"@sv ;
-          schema:description "Class Number"@en ] ;
+          rdfs:comment "Class Number"@en ] ;
 	skosmos:sparqlGraph <http://www.skosmos.skos/conceptPropertyLabels/> .
 
 :cbd a skosmos:Vocabulary, void:Dataset ;

--- a/view/concept-shared.twig
+++ b/view/concept-shared.twig
@@ -99,15 +99,16 @@
         {% if property.getSubPropertyOf != 'skos:hiddenLabel' %}
         <div class="row{% if property.type == 'dc:isReplacedBy' %} replaced-by{% endif%} property prop-{{property.ID}}">
           <div class="property-label">
-            {% if custom_labels[property.type]['label'][request.lang] %}
-              <h3 class="versal{% if property.type == 'rdf:type' %}-bold{% endif %}
-                {% if custom_labels[property.type]['description'][request.lang] %}property-click" title="{{ custom_labels[property.type]['description'][request.lang] }}
-                {% elseif property.description %} property-click" title="{{ property.description }}
-                {% endif %}
-                ">{{ custom_labels[property.type]['label'][request.lang] }}</h3>
-            {% else %}
-              <h3 class="versal{% if property.type == 'rdf:type' %}-bold{% endif %}{% if property.description %} property-click" title="{{ property.description }}{% endif %}">{{ property.label }}</h3>
-            {% endif %}
+            <h3 class="versal{% if property.type == 'rdf:type' %}-bold{% endif %}
+              {% if custom_labels[property.type]['description'][request.lang] %}property-click" title="{{ custom_labels[property.type]['description'][request.lang] }}
+              {% elseif property.description %} property-click" title="{{ property.description }}
+              {% endif %}">
+              {% if custom_labels[property.type]['label'][request.lang] %}
+                {{ custom_labels[property.type]['label'][request.lang] }}
+              {% else %}
+                {{ property.label }}
+              {% endif %}
+            </h3>
           </div>
           <div class="property-value-column"><div class="property-value-wrapper">
         {% if request.vocab.config.hasMultiLingualProperty(property.type) %}

--- a/view/concept-shared.twig
+++ b/view/concept-shared.twig
@@ -47,7 +47,7 @@
             {% if subPrefLabelTranslation %}
               {{ subPrefLabelTranslation }}
             {% elseif custom_labels['skos:prefLabel'] %}
-              {{ custom_labels['skos:prefLabel']['label'][request.contentLang] }}
+              {{ custom_labels['skos:prefLabel']['label'][request.lang] }}
             {% else %}
               {{ 'skos:prefLabel'|trans }}
             {% endif %}
@@ -101,10 +101,10 @@
           <div class="property-label">
             {% if custom_labels[property.type] %}
               <h3 class="versal{% if property.type == 'rdf:type' %}-bold{% endif %}
-                {% if custom_labels[property.type] and custom_labels[property.type]['description'] and custom_labels[property.type]['description'][request.contentLang] %}property-click" title="{{ custom_labels[property.type]['description'][request.contentLang] }}
+                {% if custom_labels[property.type] and custom_labels[property.type]['description'] and custom_labels[property.type]['description'][request.lang] %}property-click" title="{{ custom_labels[property.type]['description'][request.lang] }}
                 {% elseif property.description %} property-click" title="{{ property.description }}
                 {% endif %}
-                ">{{ custom_labels[property.type]['label'][request.contentLang] }}</h3>
+                ">{{ custom_labels[property.type]['label'][request.lang] }}</h3>
             {% else %}
               <h3 class="versal{% if property.type == 'rdf:type' %}-bold{% endif %}{% if property.description %} property-click" title="{{ property.description }}{% endif %}">{{ property.label }}</h3>
             {% endif %}

--- a/view/concept-shared.twig
+++ b/view/concept-shared.twig
@@ -46,7 +46,7 @@
             {% set subPrefLabelTranslation = concept.preferredSubpropertyLabelTranslation(request.lang) %}
             {% if subPrefLabelTranslation %}
               {{ subPrefLabelTranslation }}
-            {% elseif custom_labels['skos:prefLabel'] %}
+            {% elseif custom_labels['skos:prefLabel']['label'][request.lang] %}
               {{ custom_labels['skos:prefLabel']['label'][request.lang] }}
             {% else %}
               {{ 'skos:prefLabel'|trans }}
@@ -99,9 +99,9 @@
         {% if property.getSubPropertyOf != 'skos:hiddenLabel' %}
         <div class="row{% if property.type == 'dc:isReplacedBy' %} replaced-by{% endif%} property prop-{{property.ID}}">
           <div class="property-label">
-            {% if custom_labels[property.type] %}
+            {% if custom_labels[property.type]['label'][request.lang] %}
               <h3 class="versal{% if property.type == 'rdf:type' %}-bold{% endif %}
-                {% if custom_labels[property.type] and custom_labels[property.type]['description'] and custom_labels[property.type]['description'][request.lang] %}property-click" title="{{ custom_labels[property.type]['description'][request.lang] }}
+                {% if custom_labels[property.type]['description'][request.lang] %}property-click" title="{{ custom_labels[property.type]['description'][request.lang] }}
                 {% elseif property.description %} property-click" title="{{ property.description }}
                 {% endif %}
                 ">{{ custom_labels[property.type]['label'][request.lang] }}</h3>

--- a/view/concept-shared.twig
+++ b/view/concept-shared.twig
@@ -42,7 +42,16 @@
       {% spaceless %}
       <div class="row{% if concept.type == 'skosext:DeprecatedConcept' %} deprecated{% endif %} property prop-preflabel">
         <div class="property-label property-label-pref">
-          <h3 class="versal">{% set subPrefLabelTranslation = concept.preferredSubpropertyLabelTranslation(request.lang) %}{% if subPrefLabelTranslation %}{{ subPrefLabelTranslation }}{% else %}{{ 'skos:prefLabel'|trans }}{% endif %}</h3>
+          <h3 class="versal">
+            {% set subPrefLabelTranslation = concept.preferredSubpropertyLabelTranslation(request.lang) %}
+            {% if subPrefLabelTranslation %}
+              {{ subPrefLabelTranslation }}
+            {% elseif custom_labels['skos:prefLabel'] %}
+              {{ custom_labels['skos:prefLabel']['label'][request.contentLang] }}
+            {% else %}
+              {{ 'skos:prefLabel'|trans }}
+            {% endif %}
+          </h3>
         </div>
         {% if concept.foundBy %} {# hit has been found through an alternative label #}
         <span class="versal">{{ concept.foundBy }} ></span>
@@ -90,7 +99,15 @@
         {% if property.getSubPropertyOf != 'skos:hiddenLabel' %}
         <div class="row{% if property.type == 'dc:isReplacedBy' %} replaced-by{% endif%} property prop-{{property.ID}}">
           <div class="property-label">
-            <h3 class="versal{% if property.type == 'rdf:type' %}-bold{% endif %}{% if property.description %} property-click" title="{{ property.description }}{% endif %}">{{ property.label }}</h3>
+            {% if custom_labels[property.type] %}
+              <h3 class="versal{% if property.type == 'rdf:type' %}-bold{% endif %}
+                {% if custom_labels[property.type] and custom_labels[property.type]['description'] and custom_labels[property.type]['description'][request.contentLang] %}property-click" title="{{ custom_labels[property.type]['description'][request.contentLang] }}
+                {% elseif property.description %} property-click" title="{{ property.description }}
+                {% endif %}
+                ">{{ custom_labels[property.type]['label'][request.contentLang] }}</h3>
+            {% else %}
+              <h3 class="versal{% if property.type == 'rdf:type' %}-bold{% endif %}{% if property.description %} property-click" title="{{ property.description }}{% endif %}">{{ property.label }}</h3>
+            {% endif %}
           </div>
           <div class="property-value-column"><div class="property-value-wrapper">
         {% if request.vocab.config.hasMultiLingualProperty(property.type) %}


### PR DESCRIPTION
## Reasons for creating this PR
There was a need for renaming property labels in concept view for certain controlled vocabularies (metatietosanasto, kanto) and classifications. These do not strictly follow the normally assumed naming conventions for the concept properties.

## Link to relevant issue(s), if any
- Closes #806 

## Description of the changes in this PR
- Possibility for adding new property labels via `config.ttl`
- Possibility for adding new tooltips for customized property labels via  `config.ttl`
- Example of the configuration:
```
:vocab 
    skosmos:propertyLabelOverride
        [ skosmos:property skos:prefLabel ;
          rdfs:label "Caption"@en, "Luokka"@fi ],
        [ skosmos:property skos:notation ;
          rdfs:label "UDC number"@en, "UDC-numero"@fi, "UDC-nummer"@sv ;
          schema:description "Class Number"@en ] ;
.
```

## Known problems or uncertainties in this PR
Haven't tested if it's possible to create just new tooltips for existing property labels

## Checklist
- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if not, explain why below)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)