### PR TITLE
Remove PHP 8 from build matrix to avoid hanging CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,6 @@ jobs:
       matrix:
         php_version: [7.2, 7.3, 7.4]
         experimental: [false]
-        include:
-          - php_version: 8.0
-            experimental: true
 
     steps:
     - name: Check out repository code


### PR DESCRIPTION
## Reasons for creating this PR

GitHub Actions CI build jobs are getting stuck on PHP 8. This causes unnecessary CI resource usage and delays the completion of build jobs by 6 hours. 

## Link to relevant issue(s), if any

- Related to #1243

## Description of the changes in this PR

Remove PHP8 from php_versions in the CI build matrix.

## Known problems or uncertainties in this PR

It would be better to get tests to pass on PHP8, but that would take more effort, so as a stopgap measure I'm just disabling them for now.

## Checklist

- [x] phpUnit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if not, explain why below)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)

This is a CI configuration change, no need for new tests.