### PR TITLE
Remove the dependency to deprecated gettext-extractor package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -82,7 +82,6 @@
   },
   "require-dev": {
     "phpunit/phpunit": "8.5.*",
-    "umpirsky/twig-gettext-extractor": "1.3.*",
     "symfony/dom-crawler": "3.4.3",
     "mockery/mockery": "1.3.1"
   },


### PR DESCRIPTION
## Reasons for creating this PR

This PR removes the dependency to twig-gettextExtractor, as it is a package no longer maintained

## Link to relevant issue(s), if any

- Closes #1153

## Known problems or uncertainties in this PR

This PR will not get rid of related and abandoned twig-extensions package, as it is used by the twig translation filters in Skosmos. There is a separate issue of that in #1247

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if not, explain why below)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
