### PR TITLE
More proper fix for language changing link URLs

### DIFF
--- a/model/Request.php
+++ b/model/Request.php
@@ -174,11 +174,16 @@ class Request
 
     /**
      * Returns the relative page url eg. '/yso/fi/search?clang=en&q=cat'
+     * @param string $newlang new UI language to set
      * @return string the relative url of the page
      */
-    public function getLangUrl()
+    public function getLangUrl($newlang=null)
     {
-        return substr(str_replace(str_replace('/index.php', '', $this->getServerConstant('SCRIPT_NAME')), '', $this->getServerConstant('REQUEST_URI')), 1);
+        $langurl = substr(str_replace(str_replace('/index.php', '', $this->getServerConstant('SCRIPT_NAME')), '', $this->getServerConstant('REQUEST_URI')), 1);
+        if ($newlang !== null) {
+            $langurl = preg_replace("#^(.*/)?{$this->lang}/#", "$1{$newlang}/", $langurl);
+        }
+        return $langurl;
     }
 
     public function getLetter()

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -165,4 +165,47 @@ class RequestTest extends PHPUnit\Framework\TestCase
     $version = $this->request->getVersion();
     $this->assertNotEmpty($version);
   }
+
+  /**
+   * @covers Request::getLangUrl
+   */
+  public function testGetLangUrlNoParamRoot() {
+    $this->request->setServerConstant('SCRIPT_NAME', '/Skosmos/index.php');
+    $this->request->setServerConstant('REQUEST_URI', '/Skosmos/en/');
+    $langurl = $this->request->getLangUrl();
+    $this->assertEquals("en/", $langurl);
+  }
+
+  /**
+   * @covers Request::getLangUrl
+   */
+  public function testGetLangUrlNoParamVocab() {
+    $this->request->setServerConstant('SCRIPT_NAME', '/Skosmos/index.php');
+    $this->request->setServerConstant('REQUEST_URI', '/Skosmos/myvocab/en/');
+    $langurl = $this->request->getLangUrl();
+    $this->assertEquals("myvocab/en/", $langurl);
+  }
+
+  /**
+   * @covers Request::getLangUrl
+   */
+  public function testGetLangUrlNewLangRoot() {
+    $this->request->setServerConstant('SCRIPT_NAME', '/Skosmos/index.php');
+    $this->request->setServerConstant('REQUEST_URI', '/Skosmos/en/');
+    $this->request->setLang('en');
+    $langurl = $this->request->getLangUrl("sv");
+    $this->assertEquals("sv/", $langurl);
+  }
+
+  /**
+   * @covers Request::getLangUrl
+   */
+  public function testGetLangUrlNewLangVocab() {
+    $this->request->setServerConstant('SCRIPT_NAME', '/Skosmos/index.php');
+    $this->request->setServerConstant('REQUEST_URI', '/Skosmos/myvocab/en/');
+    $this->request->setLang('en');
+    $langurl = $this->request->getLangUrl("sv");
+    $this->assertEquals("myvocab/sv/", $langurl);
+  }
+
 }

--- a/view/topbar.twig
+++ b/view/topbar.twig
@@ -25,7 +25,7 @@
   <ul class="dropdown-menu dropdown-menu-right">
   {% for langcode, langdata in languages %}
   {% if request.lang != langcode %}
-  <li><a id="language-{{ langcode }}" class="versal" href="{{ request.langurl|replace({("/#{request.lang}/"): "/#{langcode}/"}) }}"> {{langdata.lemma}}</a></li>
+  <li><a id="language-{{ langcode }}" class="versal" href="{{ request.langurl(langcode) }}"> {{langdata.lemma}}</a></li>
   {% endif %}
   {% endfor %}
   </ul>
@@ -34,7 +34,7 @@
 <div id="language"><span class="navigation-font">|</span>
   {% for langcode, langdata in languages %}
   {% if request.lang != langcode %}
-  <a id="language-{{ langcode}}" class="navigation-font" href="{{ request.langurl|replace({("/#{request.lang}/"): "/#{langcode}/"}) }}"> {{langdata.name}}</a>
+  <a id="language-{{ langcode}}" class="navigation-font" href="{{ request.langurl(langcode) }}"> {{langdata.name}}</a>
   {% endif %}
   {% endfor %}
 </div>


### PR DESCRIPTION
## Reasons for creating this PR

The language changing links at the top of the page were no longer working on the front page of Skosmos.

## Link to relevant issue(s), if any

Related to PR #1234 (by @schlawiner ) which broke the language changing links on the front page of Skosmos, while fixing situations where the vocabulary ID ended with a language code (e.g. intress**en**).

## Description of the changes in this PR

* Move the logic to switch the language part of the URL into PHP code (Request->getLangUrl method), so that it can be changed using a regex and tested with unit tests. Make sure to handle both the front page (root URL) case and deeper URLs within Skosmos.
* Add unit tests for the above method.

## Known problems or uncertainties in this PR

n/a

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if not, explain why below)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
