### PR TITLE
The vocabulary list on the frontpage shows the vocabulary names in th…

### DIFF
--- a/view/vocabularylist.twig
+++ b/view/vocabularylist.twig
@@ -15,7 +15,14 @@
       <h3>{{ vocabClassName }}</h3>
       <ul>
       {% for vocab in vocabArray %}
-        <li><a class="navigation-font" href="{{ vocab.id }}/{{ request.lang }}/{% if request.contentLang != request.lang and request.contentLang != '' and request.contentLang in vocab.config.languages %}?clang={{ request.contentLang }}{% endif %}">{{ vocab.title }}</a></li>
+        {% set useDefaultLanguage = null %}
+        {% if request.contentLang not in vocab.config.languages and request.contentLang != '' %}
+          {% set useDefaultLanguage = true %}
+        {% endif %}
+        <li><a class="navigation-font" href="{{ vocab.id }}/{{ request.lang }}/{% if request.contentLang not in vocab.config.languages and request.contentLang != '' %}?clang={{ vocab.config.defaultLanguage }}{% endif %}">
+          {% if useDefaultLanguage is not null %} {{ vocab.title(vocab.config.defaultLanguage) }}
+            {% else %} {{ vocab.title(request.contentLang) }}
+          {% endif %} </a></li>
       {% endfor %}
       </ul>
     </div>


### PR DESCRIPTION
…e default language of the vocabulary

Thanks @henriyli, @osma and @kouralex for your contribution :-)

## Reasons for creating this PR
To follow wishes mentioned in the PR #747 

## Link to relevant issue(s), if any
[#731](https://github.com/NatLibFi/Skosmos/tree/henriyli-henriyli-fix-731)
- Closes #

## Description of the changes in this PR
The vocabulary list on the front page shows the vocabulary names in the default language of the vocabulary

## Known problems or uncertainties in this PR

## Checklist
1. For the vocabulary of your choice, point out the default language in the config.ttl (make sure the dc:title is also defined with respect to the default language)
2. In Skosmos, select the content language not used in the vocabulary
3. On the Skosmos front page check if the vocabulary name in the list is shown in the default language  

When it comes to the phpUnit tests, at the moment I am investigating ways to run PHPUnit tests for Symphony Twig templates. Tests are coming a bit later.

- [ ] phpUnit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if not, explain why below)
- [ ] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
