### PR TITLE
Fix REST search when using zero ('0') as the query parameter

### DIFF
--- a/controller/RestController.php
+++ b/controller/RestController.php
@@ -169,27 +169,30 @@ class RestController extends Controller
      * Performs the search function calls. And wraps the result in a json-ld object.
      * @param Request $request
      */
-    public function search($request)
+    public function search(Request $request): void
     {
         $maxhits = $request->getQueryParam('maxhits');
         $offset = $request->getQueryParam('offset');
         $term = $request->getQueryParamRaw('query');
 
-        if (!$term && (!$request->getQueryParam('group') && !$request->getQueryParam('parent'))) {
-            return $this->returnError(400, "Bad Request", "query parameter missing");
+        if ((!isset($term) || strlen(trim($term)) === 0) && (!$request->getQueryParam('group') && !$request->getQueryParam('parent'))) {
+            $this->returnError(400, "Bad Request", "query parameter missing");
+            return;
         }
         if ($maxhits && (!is_numeric($maxhits) || $maxhits <= 0)) {
-            return $this->returnError(400, "Bad Request", "maxhits parameter is invalid");
+            $this->returnError(400, "Bad Request", "maxhits parameter is invalid");
+            return;
         }
         if ($offset && (!is_numeric($offset) || $offset < 0)) {
-            return $this->returnError(400, "Bad Request", "offset parameter is invalid");
+            $this->returnError(400, "Bad Request", "offset parameter is invalid");
+            return;
         }
 
         $parameters = $this->constructSearchParameters($request);
         $results = $this->model->searchConcepts($parameters);
         $ret = $this->transformSearchResults($request, $results, $parameters);
 
-        return $this->returnJson($ret);
+        $this->returnJson($ret);
     }
 
 /** Vocabulary-specific methods **/

--- a/tests/RestControllerTest.php
+++ b/tests/RestControllerTest.php
@@ -79,6 +79,41 @@ class RestControllerTest extends \PHPUnit\Framework\TestCase
   }
 
   /**
+   * Data provider for testSearchWithZero test.
+   */
+  public function testSearchWithZeroData(): array {
+    return [
+      ['0', true],
+      ['1', true],
+      ['-1', true],
+      ['skosmos', true],
+      ['', false],
+      [' ', false]
+    ];
+  }
+
+  /**
+   * @covers RestController::search
+   * @dataProvider testSearchWithZeroData
+   * @param $query string the search query
+   * @param $isSuccess bool whether the request must succeed or fail
+   */
+  public function testSearchWithZero(string $query, bool $isSuccess) {
+    $request = new Request($this->model);
+    $request->setQueryParam('format', 'application/json');
+    $request->setQueryParam('query', $query);
+    $request->setQueryParam('fields', 'broader relatedMatch');
+    $this->controller->search($request);
+
+    $out = $this->getActualOutput();
+    if ($isSuccess) {
+      $this->assertStringNotContainsString("400 Bad Request", $out, "The REST search call returned an unexpected 400 bad request error!");
+    } else {
+      $this->assertStringContainsString("400 Bad Request", $out, "The REST search call DID NOT returned an expected 400 bad request error!");
+    }
+  }
+
+  /**
    * @covers RestController::indexLetters
    */
   public function testIndexLettersJsonLd() {

--- a/tests/RestControllerTest.php
+++ b/tests/RestControllerTest.php
@@ -109,7 +109,7 @@ class RestControllerTest extends \PHPUnit\Framework\TestCase
     if ($isSuccess) {
       $this->assertStringNotContainsString("400 Bad Request", $out, "The REST search call returned an unexpected 400 bad request error!");
     } else {
-      $this->assertStringContainsString("400 Bad Request", $out, "The REST search call DID NOT returned an expected 400 bad request error!");
+      $this->assertStringContainsString("400 Bad Request", $out, "The REST search call DID NOT return an expected 400 bad request error!");
     }
   }
 


### PR DESCRIPTION
## Reasons for creating this PR

Prevent a string value being treated as a boolean, causing a valid search query to fail.

## Link to relevant issue(s), if any

- Closes #1260

## Description of the changes in this PR

1. added a unit test with some cases where it should pass, and where it should fail. It's using parameters with phpunit, so this can be extended later if needed to cover more cases.
2. fixed the code by using `isset()` and also trimming the value, and checking if the `strlen` returned is `zero`.
3. happy to revert, but the invalid `return`'s have always bothered me in the controller methods :disappointed_relieved: so I also fixed that by using `return`, and annotated the params & method changed with types (I think our minimum version of PHP accepts it? if not, and CI fails, I'll revert this part)

## Known problems or uncertainties in this PR

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if not, explain why below)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
