### PR TITLE
Support PHP 8.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on: [push]
 jobs:
   build-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php_version: [7.2, 7.3, 7.4]
+        php_version: [7.2, 7.3, 7.4, 8.0]
         experimental: [false]
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,10 @@ jobs:
         CC_TEST_REPORTER_ID: fb98170a5c7ea9cc2bbab19ff26268335e6a11a4f8267ca935e5e8ff4624886c
       with:
         prefix: /app
+      # PHPUnit 8.5 doesn't support code coverage for PHP 8
+      if: ${{ matrix.php_version < "8.0" }}
 
     - name: Publish code coverage to Codecov
       uses: codecov/codecov-action@v1
+      # PHPUnit 8.5 doesn't support code coverage for PHP 8
+      if: ${{ matrix.php_version < "8.0" }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,6 @@ jobs:
         php_extensions: gettext intl xsl pcov
         memory_limit: 512M
         configuration: phpunit.xml
-        args: --verbose --debug
 
     - name: Publish code coverage to Code Climate
       uses: paambaati/codeclimate-action@v2.7.5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
         php_extensions: gettext intl xsl pcov
 
     - name: Run PHPUnit tests
-      uses: php-actions/phpunit@91ff02a58932e63741157ea8c04e7e7077233537
+      uses: php-actions/phpunit@v3
       env:
         LANGUAGE: fr
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ jobs:
       matrix:
         php_version: ["7.2", "7.3", "7.4", "8.0"]
         experimental: [false]
+        include:
+          - php_version: "8.1"
+            experimental: true
 
     steps:
     - name: Check out repository code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php_version: [7.2, 7.3, 7.4, 8.0]
+        php_version: [7.2, 7.3, 7.4, 8.0.15]
         experimental: [false]
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,9 +61,9 @@ jobs:
       with:
         prefix: /app
       # PHPUnit 8.5 doesn't support code coverage for PHP 8
-      if: ${{ matrix.php_version < "8.0" }}
+      if: ${{ matrix.php_version < '8.0' }}
 
     - name: Publish code coverage to Codecov
       uses: codecov/codecov-action@v1
       # PHPUnit 8.5 doesn't support code coverage for PHP 8
-      if: ${{ matrix.php_version < "8.0" }}
+      if: ${{ matrix.php_version < '8.0' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,7 @@ jobs:
         php_version: ${{ matrix.php_version }}
         php_extensions: gettext intl xsl pcov
         memory_limit: 512M
+        configuration: phpunit.xml
         args: --verbose --debug
 
     - name: Publish code coverage to Code Climate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php_version: [7.2, 7.3, 7.4, 8.0.15]
+        php_version: ["7.2", "7.3", "7.4", "8.0"]
         experimental: [false]
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,7 @@ jobs:
         php_version: ${{ matrix.php_version }}
         php_extensions: gettext intl xsl pcov
         memory_limit: 512M
+        args: --verbose --debug
 
     - name: Publish code coverage to Code Climate
       uses: paambaati/codeclimate-action@v2.7.5

--- a/composer.json
+++ b/composer.json
@@ -84,7 +84,7 @@
     "phpunit/phpunit": "8.5.*",
     "umpirsky/twig-gettext-extractor": "1.3.*",
     "symfony/dom-crawler": "5.4.*",
-    "mockery/mockery": "1.5.*"
+    "mockery/mockery": "1.3.5"
   },
   "autoload": {
     "classmap": ["controller/", "model/", "model/sparql/"]

--- a/composer.json
+++ b/composer.json
@@ -84,7 +84,7 @@
     "phpunit/phpunit": "8.5.*",
     "umpirsky/twig-gettext-extractor": "1.3.*",
     "symfony/dom-crawler": "3.4.3",
-    "mockery/mockery": "1.3.1"
+    "mockery/mockery": "1.5.*"
   },
   "autoload": {
     "classmap": ["controller/", "model/", "model/sparql/"]

--- a/composer.json
+++ b/composer.json
@@ -83,7 +83,7 @@
   "require-dev": {
     "phpunit/phpunit": "8.5.*",
     "umpirsky/twig-gettext-extractor": "1.3.*",
-    "symfony/dom-crawler": "3.4.3",
+    "symfony/dom-crawler": "5.4.*",
     "mockery/mockery": "1.5.*"
   },
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -65,7 +65,7 @@
     "twig/extensions": "1.5.*",
     "twitter/bootstrap": "3.3.*",
     "twitter/typeahead.js": "v0.10.5",
-    "willdurand/negotiation": "2.3.*",
+    "willdurand/negotiation": "3.0.*",
     "vakata/jstree": "3.3.*",
     "punic/punic": "3.5.1",
     "ml/json-ld": "1.*",

--- a/model/Vocabulary.php
+++ b/model/Vocabulary.php
@@ -423,7 +423,7 @@ class Vocabulary extends DataObject implements Modifiable
      * @param boolean $any set to true if you want to have a label even in case of a correct language one missing.
      * @param string $lang language identifier.
      */
-    public function getConceptTransitiveBroaders($uri, $limit, $any = false, $lang)
+    public function getConceptTransitiveBroaders($uri, $limit, $any, $lang)
     {
         $lang = $lang ? $lang : $this->getEnvLang();
         $fallback = $this->config->getDefaultLanguage();

--- a/model/sparql/GenericSparql.php
+++ b/model/sparql/GenericSparql.php
@@ -1198,13 +1198,13 @@ EOQ;
     /**
      * Query for concepts using a search term.
      * @param array $vocabs array of Vocabulary objects to search; empty for global search
-     * @param array $fields extra fields to include in the result (array of strings). (default: null = none)
-     * @param boolean $unique restrict results to unique concepts (default: false)
-     * @param boolean $showDeprecated whether to include deprecated concepts in the result (default: false)
+     * @param array $fields extra fields to include in the result (array of strings or null).
+     * @param boolean $unique restrict results to unique concepts
      * @param ConceptSearchParameters $params
+     * @param boolean $showDeprecated whether to include deprecated concepts in the result (default: false)
      * @return array query result object
      */
-    public function queryConcepts($vocabs, $fields = null, $unique = false, $params, $showDeprecated = false) {
+    public function queryConcepts($vocabs, $fields, $unique, $params, $showDeprecated = false) {
         $query = $this->generateConceptSearchQuery($fields, $unique, $params,$showDeprecated);
         $results = $this->query($query);
         return $this->transformConceptSearchResults($results, $vocabs, $fields);

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,4 +1,5 @@
-<phpunit colors="true" bootstrap="tests/bootstrap.php" processIsolation="true">
+<phpunit colors="true" bootstrap="tests/bootstrap.php" processIsolation="true"
+         convertDeprecationsToExceptions="true">
   <logging>
     <log type="coverage-html" target="./report" lowUpperBound="35" highLowerBound="70"/>  
     <log type="coverage-clover" target="build/logs/clover.xml"/>

--- a/tests/Http304Test.php
+++ b/tests/Http304Test.php
@@ -26,13 +26,6 @@ class Http304Test extends TestCase
      */
     private $twig;
 
-    /* skip these tests for now, to diagnose PHP 8 issues */
-    protected function setUp() : void
-    {
-        $this->markTestSkipped();
-    }
-
-
     /**
      * Initializes the test objects. Not using setUp here as the $vocabularyName
      * needs to be specified per test.

--- a/tests/Http304Test.php
+++ b/tests/Http304Test.php
@@ -26,6 +26,13 @@ class Http304Test extends TestCase
      */
     private $twig;
 
+    /* skip these tests for now, to diagnose PHP 8 issues */
+    protected function setUp() : void
+    {
+        $this->markTestSkipped();
+    }
+
+
     /**
      * Initializes the test objects. Not using setUp here as the $vocabularyName
      * needs to be specified per test.

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,5 +1,7 @@
 <?php
 
+error_reporting(E_ALL);
+
 // make sure that a SPARQL endpoint is set by an environment variable
 $endpoint = getenv('SKOSMOS_SPARQL_ENDPOINT');
 if (!$endpoint) {


### PR DESCRIPTION
## Reasons for creating this PR

Trying to get Skosmos working on PHP 8.0

## Link to relevant issue(s), if any

- Closes #1243

## Description of the changes in this PR

* upgrade willdurand/negotiation to 3.0.* which supports PHP8
* reenable GitHub Actions CI jobs for PHP 8.0
* upgrade php-actions/phpunit to v3 which is slightly newer than what we used before

## Known problems or uncertainties in this PR

* CI jobs for PHP 8.0 seem to be hanging (again, see #1243) so creating this as a draft PR for now

## Checklist

- [x] phpUnit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if not, explain why below)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)

No new tests are necessary since there is no new functionality.