### PR TITLE
Upgrade to newest Fuseki 4.4.0 for running unit tests

### DIFF
--- a/tests/init_fuseki.sh
+++ b/tests/init_fuseki.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Note: This script must be sourced from within bash, e.g. ". init_fuseki.sh"
 
-FUSEKI_VERSION=${FUSEKI_VERSION:-4.0.0}
+FUSEKI_VERSION=${FUSEKI_VERSION:-4.4.0}
 
 if [ "$FUSEKI_VERSION" = "SNAPSHOT" ]; then
     # find out the latest snapshot version and its download URL by parsing Apache directory listings


### PR DESCRIPTION
## Reasons for creating this PR

Currently unit tests are set up to run with Fuseki 4.0.0 which is rather old. Upgrading to newest version. This should help ensure that Skosmos stays compatible with current versions of Fuseki. The change affects both GitHub Actions CI as well as tests run locally by developers, as long as they use the `init_fuseki.sh` script to set up Fuseki.

## Link to relevant issue(s), if any

n/a

## Description of the changes in this PR

* upgrade the default Fuseki version in `init_fuseki.sh` to 4.4.0 (was: 4.0.0)

## Known problems or uncertainties in this PR

`init_fuseki.sh` also supports running the latest SNAPSHET version of Fuseki, by setting the environment variable `FUSEKI_VERSION` to `SNAPSHOT`. Some time ago (when we were still using Travis CI) the CI tests also did that. This could be enabled again, but that is out of scope for this PR.

## Checklist

- [x] phpUnit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if not, explain why below)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)

No new tests needed.