### PR TITLE
Do not treat 0 as boolean value in the REST controller

### DIFF
--- a/model/ConceptSearchParameters.php
+++ b/model/ConceptSearchParameters.php
@@ -65,10 +65,10 @@ class ConceptSearchParameters
         return null;
     }
 
-    public function getSearchTerm()
+    public function getSearchTerm() : string
     {
         $term = $this->request->getQueryParamRaw('q') ? $this->request->getQueryParamRaw('q') : $this->request->getQueryParamRaw('query');
-        if (!$term && $this->rest)
+        if ((!isset($term) || strlen(trim($term)) === 0) && $this->rest)
             $term = $this->request->getQueryParamRaw('label');
         $term = trim($term); // surrounding whitespace is not considered significant
         $term = Normalizer::normalize( $term, Normalizer::FORM_C ); //Normalize decomposed unicode characters #1184

--- a/tests/ConceptSearchParametersTest.php
+++ b/tests/ConceptSearchParametersTest.php
@@ -87,6 +87,26 @@ class ConceptSearchParametersTest extends PHPUnit\Framework\TestCase
     }
 
     /**
+     * For https://github.com/NatLibFi/Skosmos/issues/1275, to verify
+     * that querying for `0` (zero) does not evaluate it as a boolean
+     * value, causing issues in the SKOSMOS search functionality.
+     *
+     * @covers ConceptSearchParameters::getSearchTerm
+     */
+    public function testGetSearchTermZeroes() {
+        $params = new ConceptSearchParameters($this->request, new GlobalConfig('/../tests/testconfig.ttl'), true);
+        $this->assertEquals('', $params->getSearchTerm());
+        $this->request->method('getQueryParamRaw')->will(
+            $this->returnValueMap([
+                ['q', '0'],
+                ['query', '0'],
+                ['label', '10']
+            ])
+        );
+        $this->assertEquals('0', $params->getSearchTerm());
+    }
+
+    /**
      * @covers ConceptSearchParameters::getTypeLimit
      * @covers ConceptSearchParameters::getDefaultTypeLimit
      */


### PR DESCRIPTION
## Reasons for creating this PR

Prevent `0` being treated as a truthy value in the REST controller. Complements #1261 

## Link to relevant issue(s), if any

- Closes #1275

## Description of the changes in this PR

Same fix as #1261 

## Known problems or uncertainties in this PR

None.

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if not, explain why below)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
