### PR TITLE
Enable GitHub Actions CI runs for pull requests (from forks)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build-test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build-test:


### PR DESCRIPTION
## Reasons for creating this PR

I noticed that CI runs are not being triggered for pull requests from forked repositories, e.g. #1276

## Link to relevant issue(s), if any

n/a

## Description of the changes in this PR

Enable GitHub Actions CI jobs for the `pull_request` event type.

## Known problems or uncertainties in this PR

n/a

## Checklist

- [x] phpUnit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if not, explain why below)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)

no need for new tests