### PR TITLE
Added the possibility to define parameter plugins outside of the orde…

### DIFF
--- a/model/VocabularyConfig.php
+++ b/model/VocabularyConfig.php
@@ -33,7 +33,6 @@ class VocabularyConfig extends BaseConfig
     {
         $this->resource = $resource;
         $this->globalPlugins = $globalPlugins;
-        $this->setParameterizedPlugins();
         $this->setPropertyLabelOverrides();
         $pluginArray = $this->getPluginArray();
         $this->pluginRegister = new PluginRegister($pluginArray);
@@ -45,6 +44,7 @@ class VocabularyConfig extends BaseConfig
      */
     public function getPluginArray() : array
     {
+        $this->setParameterizedPlugins();
         $pluginArray = array();
         $vocabularyPlugins = $this->resource->getResource('skosmos:vocabularyPlugins');
         if (!$vocabularyPlugins instanceof EasyRdf\Collection) {
@@ -62,6 +62,12 @@ class VocabularyConfig extends BaseConfig
         }
         $pluginArray = array_merge($pluginArray, $this->globalPlugins);
 
+        $paramPlugins = $this->resource->allResources('skosmos:useParamPlugin');
+        if ($paramPlugins) {
+            foreach ($paramPlugins as $plugin) {
+                $pluginArray[] = $plugin->getLiteral('skosmos:usePlugin')->getValue();
+            }
+        }
         $plugins = $this->resource->allLiterals('skosmos:usePlugin');
         if ($plugins) {
             foreach ($plugins as $pluginlit) {

--- a/tests/VocabularyConfigTest.php
+++ b/tests/VocabularyConfigTest.php
@@ -552,7 +552,7 @@ class VocabularyConfigTest extends PHPUnit\Framework\TestCase
   public function testGetOrderedPlugins() {
     $vocab = $this->model->getVocabulary('paramPluginTest');
     $plugins = $vocab->getConfig()->getPluginArray();
-    $this->assertEquals(["plugin2", "Bravo", "imaginaryPlugin", "plugin1", "alpha", "charlie", "plugin3"],  $plugins);
+    $this->assertEquals(["plugin2", "Bravo", "plugin1", "alpha", "charlie", "imaginaryPlugin", "plugin3"],  $plugins);
   }
 
   /**

--- a/tests/testconfig.ttl
+++ b/tests/testconfig.ttl
@@ -383,7 +383,7 @@
     skosmos:feedbackRecipient "developer@vocabulary.org";
 	skosmos:groupClass skos:Collection;
 	skosmos:language "en";
-	skosmos:vocabularyPlugins ("plugin2" "Bravo" :parameterizedPlugin "plugin1");
+	skosmos:vocabularyPlugins ("plugin2" "Bravo" "plugin1");
 	skosmos:usePlugin "plugin1" ;
 	skosmos:usePlugin "plugin3" ;
 	skosmos:useParamPlugin :parameterizedPlugin ;


### PR DESCRIPTION
Added the possibility to define parameter plugins outside of the ordered plugin list

## Reasons for creating this PR
After the recent changes with including the option for giving an order for the list of plugins, it was not possible to define parameter plugins without listing them in the ordered list. This was a loss of previous functionality, which this PR aims to revive.

## Link to relevant issue(s), if any

This PR addresses #1148 but does not fix it.

## Description of the changes in this PR

Added the separate handling of parameter plugins to getPluginArray(), as previously it only took account the ordered list of skosmos:vocabularyPlugins and the skosmos:globalPlugins.

## Known problems or uncertainties in this PR



## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if not, explain why below)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
