### PR TITLE
Only shorten URIs of types in the SKOS namespace in the search results

### DIFF
--- a/model/sparql/GenericSparql.php
+++ b/model/sparql/GenericSparql.php
@@ -166,7 +166,8 @@ class GenericSparql {
         if (!array_key_exists($uri, $this->qnamecache)) {
             $res = new EasyRdf\Resource($uri);
             $qname = $res->shorten(); // returns null on failure
-            $this->qnamecache[$uri] = ($qname !== null) ? $qname : $uri;
+            // only URIs in the SKOS namespace are shortened
+            $this->qnamecache[$uri] = ($qname !== null && strpos($qname, "skos:") === 0) ? $qname : $uri;
         }
         return $this->qnamecache[$uri];
     }

--- a/tests/RestControllerTest.php
+++ b/tests/RestControllerTest.php
@@ -190,7 +190,7 @@ EOD;
          "uri":"http://www.skosmos.skos/test/ta117",
          "type":[
             "skos:Concept",
-            "meta:TestClass"
+            "http://www.skosmos.skos/test-meta/TestClass"
          ],
          "prefLabel":"3D Bass",
          "lang":"en",
@@ -200,7 +200,7 @@ EOD;
          "uri":"http://www.skosmos.skos/test/ta116",
          "type":[
             "skos:Concept",
-            "meta:TestClass"
+            "http://www.skosmos.skos/test-meta/TestClass"
          ],
          "prefLabel":"Bass",
          "lang":"en",
@@ -210,7 +210,7 @@ EOD;
          "uri":"http://www.skosmos.skos/test/ta122",
          "type":[
             "skos:Concept",
-            "meta:TestClass"
+            "http://www.skosmos.skos/test-meta/TestClass"
          ],
          "prefLabel":"Black sea bass",
          "lang":"en",
@@ -259,7 +259,7 @@ EOD;
          "uri":"http://www.skosmos.skos/test/ta117",
          "type":[
             "skos:Concept",
-            "meta:TestClass"
+            "http://www.skosmos.skos/test-meta/TestClass"
          ],
          "broader":[
             {
@@ -279,7 +279,7 @@ EOD;
          "uri":"http://www.skosmos.skos/test/ta116",
          "type":[
             "skos:Concept",
-            "meta:TestClass"
+            "http://www.skosmos.skos/test-meta/TestClass"
          ],
          "broader":[
             {
@@ -294,7 +294,7 @@ EOD;
          "uri":"http://www.skosmos.skos/test/ta122",
          "type":[
             "skos:Concept",
-            "meta:TestClass"
+            "http://www.skosmos.skos/test-meta/TestClass"
          ],
          "broader":[
             {


### PR DESCRIPTION
## Reasons for creating this PR

See #1254 - some types are not shown correctly in the autocomplete popup for the search box.

The underlying problem is/was that the REST `search` method can return types either in shortened format (e.g. `skos:Concept`) or as full URIs (e.g. `http://www.yso.fi/onto/yso/yso-meta/Concept`). Those type URIs that can be shortened are, based on the URI namespace prefixes registered to EasyRdf. This includes vocabulary-specific prefixes from the Skosmos configuration file. In the case of Lajisto vocabulary where the problem was first discovered, EasyRdf knows the namespace prefix `lajisto:` (which is used for both regular concepts and types) and is able to shorten type URIs into qnames such as `lajisto:MX.species`. For most other vocabularies with custom types, the types are in a different namespace, e.g. `yso-meta:` for YSO and `rdac:` for KANTO/finaf, and EasyRdf doesn't know about these namespaces so cannot shorten these URIs.

The JS code that populates the autocomplete box attempts to resolve the shortened URIs and expand them back to full URIs. But the expansion is based on the JSON-LD context of the response of the `search` method. The context doesn't include custom prefixes such as `lajisto:`, so expansion will fail and the shortened type URI ends up being displayed in the UI, instead of a human-readable label.

There are at least two approaches to fixing this:

1. Ensure that all prefixes known to EasyRdf are included in the JSON-LD context that the `search` method returns.
2. Avoid shortening type URIs which are not defined in the JSON-LD context.

I chose the 2nd approach, as it was easier and less disruptive. So instead of eagerly trying to shorten type URIs, the `search` method will now return full type URIs, except for types in the SKOS namespace (i.e. `skos:Concept` and `skos:Collection`). The SKOS type URIs are still shortened because not doing so could be disruptive for API clients used to the old behaviour.

## Link to relevant issue(s), if any

- Closes #1254

## Description of the changes in this PR

* Shorten only type URIs in the SKOS namespace, instead of in all namespaces known to EasyRdf
* Modify the tests accordingly

## Known problems or uncertainties in this PR

n/a

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if not, explain why below)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
