### PR TITLE
Issue1148 order of plugin rendering

### DIFF
--- a/model/PluginRegister.php
+++ b/model/PluginRegister.php
@@ -5,6 +5,10 @@ class PluginRegister {
 
     public function __construct($requestedPlugins=array()) {
         $this->requestedPlugins = $requestedPlugins;
+        $this->pluginOrder = array();
+        foreach ($this->requestedPlugins as $index => $value) {
+            $this->pluginOrder[$value] = $index;
+        }
     }
 
     /**
@@ -25,6 +29,16 @@ class PluginRegister {
     }
 
     /**
+     * Sort plugins by order defined in class constructor
+     * @return array
+     */
+    private function sortPlugins($plugins) {
+        $sortedPlugins = array();
+        $sortedPlugins = array_replace($this->pluginOrder, $plugins);
+        return $sortedPlugins;
+    }
+
+    /**
      * Returns the plugin configurations found from plugin folders
      * inside the plugins folder filtered by filetype.
      * @param string $type filetype e.g. 'css', 'js' or 'template'
@@ -33,6 +47,7 @@ class PluginRegister {
      */
     private function filterPlugins($type, $raw=false) {
         $plugins = $this->getPlugins();
+        $plugins = $this->sortPlugins($plugins);
         $ret = array();
         if (!empty($plugins)) {
             foreach ($plugins as $name => $files) {
@@ -150,10 +165,6 @@ class PluginRegister {
     public function getCallbacks() {
         $ret = array();
         $sortedCallbacks = array();
-        $order = array();
-        foreach ($this->requestedPlugins as $index => $value) {
-            $order[$value] = $index;
-        }
         $plugins = $this->getPluginCallbacks($this->requestedPlugins);
         foreach ($plugins as $callbacks) {
             foreach ($callbacks as $callback) {
@@ -161,7 +172,7 @@ class PluginRegister {
                 $sortedCallbacks[$split[1]] = $split[2];
             }
         }
-        $sortedCallbacks = array_replace($order, $sortedCallbacks);
+        $sortedCallbacks = array_replace($this->pluginOrder, $sortedCallbacks);
         foreach ($sortedCallbacks as $callback) {
             $ret[] = $callback;
         }

--- a/model/PluginRegister.php
+++ b/model/PluginRegister.php
@@ -134,7 +134,7 @@ class PluginRegister {
      * @param array $names the plugin name strings (foldernames) in an array
      * @return array
      */
-    public function getPluginsCallbacks($names=null) {
+    public function getPluginCallbacks($names=null) {
         if ($names) {
             $names = array_merge($this->requestedPlugins, $names);
             return $this->filterPluginsByName('callback', $names);
@@ -154,7 +154,7 @@ class PluginRegister {
         foreach ($this->requestedPlugins as $index => $value) {
             $order[$value] = $index;
         }
-        $plugins = $this->getPluginsCallbacks($this->requestedPlugins);
+        $plugins = $this->getPluginCallbacks($this->requestedPlugins);
         foreach ($plugins as $callbacks) {
             foreach ($callbacks as $callback) {
                 $split = explode('/', $callback);

--- a/model/PluginRegister.php
+++ b/model/PluginRegister.php
@@ -130,6 +130,19 @@ class PluginRegister {
     }
 
     /**
+     * Returns an array of plugin callback function names
+     * @param array $names the plugin name strings (foldernames) in an array
+     * @return array
+     */
+    public function getPluginsCallbacks($names=null) {
+        if ($names) {
+            $names = array_merge($this->requestedPlugins, $names);
+            return $this->filterPluginsByName('callback', $names);
+        }
+        return $this->filterPluginsByName('callback', $this->requestedPlugins);
+    }
+
+    /**
      * Returns a sorted array of javascript function names to call when loading pages
      * in order configured with skosmos:vocabularyPlugins
      * @return array
@@ -141,7 +154,7 @@ class PluginRegister {
         foreach ($this->requestedPlugins as $index => $value) {
             $order[$value] = $index;
         }
-        $plugins = $this->filterPluginsByName('callback', $this->requestedPlugins);
+        $plugins = $this->getPluginsCallbacks($this->requestedPlugins);
         foreach ($plugins as $callbacks) {
             foreach ($callbacks as $callback) {
                 $split = explode('/', $callback);
@@ -154,7 +167,7 @@ class PluginRegister {
         }
         return $ret;
     }
- 
+
     /**
      * Returns an array that is flattened from its possibly multidimensional form
      * copied from https://stackoverflow.com/a/1320156

--- a/model/PluginRegister.php
+++ b/model/PluginRegister.php
@@ -130,17 +130,27 @@ class PluginRegister {
     }
 
     /**
-     * Returns an array of javascript function names to call when loading pages
+     * Returns a sorted array of javascript function names to call when loading pages
+     * in order configured with skosmos:vocabularyPlugins
      * @return array
      */
     public function getCallbacks() {
         $ret = array();
+        $sortedCallbacks = array();
+        $order = array();
+        foreach ($this->requestedPlugins as $index => $value) {
+            $order[$value] = $index;
+        }
         $plugins = $this->filterPluginsByName('callback', $this->requestedPlugins);
         foreach ($plugins as $callbacks) {
             foreach ($callbacks as $callback) {
                 $split = explode('/', $callback);
-                $ret[] = $split[2];
+                $sortedCallbacks[$split[1]] = $split[2];
             }
+        }
+        $sortedCallbacks = array_replace($order, $sortedCallbacks);
+        foreach ($sortedCallbacks as $callback) {
+            $ret[] = $callback;
         }
         return $ret;
     }

--- a/tests/PluginRegisterTest.php
+++ b/tests/PluginRegisterTest.php
@@ -74,6 +74,7 @@ class PluginRegisterTest extends PHPUnit\Framework\TestCase
    * @covers PluginRegister::getPluginsJS
    * @covers PluginRegister::filterPlugins
    * @covers PluginRegister::filterPluginsByName
+   * @covers PluginRegister::sortPlugins
    */
   public function testGetPluginsJSInOrder()
   {
@@ -93,6 +94,7 @@ class PluginRegisterTest extends PHPUnit\Framework\TestCase
    * @covers PluginRegister::getPluginsJS
    * @covers PluginRegister::filterPlugins
    * @covers PluginRegister::filterPluginsByName
+   * @covers PluginRegister::sortPlugins
    */
   public function testGetPluginsJSWithName()
   {
@@ -105,6 +107,7 @@ class PluginRegisterTest extends PHPUnit\Framework\TestCase
    * @covers PluginRegister::getPluginsJS
    * @covers PluginRegister::filterPlugins
    * @covers PluginRegister::filterPluginsByName
+   * @covers PluginRegister::sortPlugins
    */
   public function testGetPluginsJSWithGlobalPlugin()
   {
@@ -125,6 +128,7 @@ class PluginRegisterTest extends PHPUnit\Framework\TestCase
    * @covers PluginRegister::getPluginsCSS
    * @covers PluginRegister::filterPlugins
    * @covers PluginRegister::filterPluginsByName
+   * @covers PluginRegister::sortPlugins
    */
   public function testGetPluginsCSSWithName()
   {
@@ -136,6 +140,7 @@ class PluginRegisterTest extends PHPUnit\Framework\TestCase
    * @covers PluginRegister::getPluginCallbacks
    * @covers PluginRegister::filterPlugins
    * @covers PluginRegister::filterPluginsByName
+   * @covers PluginRegister::sortPlugins
    */
   public function testGetPluginCallbacks()
   {

--- a/tests/PluginRegisterTest.php
+++ b/tests/PluginRegisterTest.php
@@ -8,9 +8,44 @@ class PluginRegisterTest extends PHPUnit\Framework\TestCase
 
   protected function setUp() : void
   {
-    $this->mockpr = $this->getMockBuilder('PluginRegister')->setConstructorArgs(array(array('global-plugin')))->setMethods(array('getPlugins'))->getMock();
-    $stubplugs = array ('test-plugin' => array ( 'js' => array ( 0 => 'first.js', 1 => 'second.min.js', ), 'css' => array ( 0 => 'stylesheet.css', ), 'templates' => array ( 0 => 'template.html', ), ), 'only-css' => array ( 'css' => array ( 0 => 'super.css')), 'global-plugin' => array('js' => array('everywhere.js')));
-    $this->mockpr->method('getPlugins')->will($this->returnValue($stubplugs));
+    $this->mockpr = $this->getMockBuilder('PluginRegister')->setConstructorArgs(array(array('test-plugin2',
+                                                                                            'global-plugin-Bravo',
+                                                                                            'imaginary-plugin',
+                                                                                            'test-plugin1',
+                                                                                            'global-plugin-alpha',
+                                                                                            'global-plugin-charlie',
+                                                                                            'test-plugin3'
+                                                                                            )))
+                                                           ->setMethods(['getPlugins'])
+                                                           ->getMock();
+    $this->stubplugs = array ('imaginary-plugin' => array ( 'js' => array ( 0 => 'imaginaryPlugin.js', ),
+                                                 'css' => array ( 0 => 'stylesheet.css', ),
+                                                 'templates' => array ( 0 => 'template.html', ),
+                                                 'callback' => array ( 0 => 'imaginaryPlugin')
+                        ),
+                        'test-plugin1' => array ( 'js' => array ( 0 => 'plugin1.js', 1 => 'second.min.js'),
+                                                 'css' => array ( 0 => 'stylesheet.css', ),
+                                                 'templates' => array ( 0 => 'template.html', ),
+                                                 'callback' => array ( 0 => 'callplugin1')
+                        ),
+                        'test-plugin2' => array ( 'js' => array ( 0 => 'plugin2.js', ),
+                                                 'css' => array ( 0 => 'stylesheet.css', ),
+                                                 'templates' => array ( 0 => 'template.html', ),
+                                                 'callback' => array ( 0 => 'callplugin2')
+                        ),
+                        'test-plugin3' => array ( 'js' => array ( 0 => 'plugin3.js', ),
+                                                 'css' => array ( 0 => 'stylesheet.css', ),
+                                                 'templates' => array ( 0 => 'template.html', ),
+                                                 'callback' => array ( 0 => 'callplugin3')
+                        ),
+                        'only-css' => array ( 'css' => array ( 0 => 'super.css')),
+                        'global-plugin-alpha' => array('js' => array('alpha.js'),
+                                                  'callback' => array ( 0 => 'alpha')),
+                        'global-plugin-Bravo' => array('js' => array('Bravo.js'),
+                                                  'callback' => array ( 0 => 'bravo')),
+                        'global-plugin-charlie' => array('js' => array('charlie.js'),
+                                                  'callback' => array ( 0 => 'charlie')));
+    $this->mockpr->method('getPlugins')->will($this->returnValue($this->stubplugs));
     $this->model = new Model(new GlobalConfig('/../tests/testconfig.ttl'));
     $this->vocab = $this->model->getVocabulary('test');
   }
@@ -42,7 +77,8 @@ class PluginRegisterTest extends PHPUnit\Framework\TestCase
    */
   public function testGetPluginsJSWithName()
   {
-    $this->assertEquals(array('global-plugin' => array('plugins/global-plugin/everywhere.js'), 'test-plugin' => array('plugins/test-plugin/first.js', 'plugins/test-plugin/second.min.js')), $this->mockpr->getPluginsJS(array('test-plugin')));
+    $this->assertEquals($this->mockpr->getPluginsJS()['test-plugin1'],
+                        array('plugins/test-plugin1/plugin1.js', 'plugins/test-plugin1/second.min.js'));
   }
 
   /**
@@ -53,7 +89,8 @@ class PluginRegisterTest extends PHPUnit\Framework\TestCase
    */
   public function testGetPluginsJSWithGlobalPlugin()
   {
-    $this->assertEquals(array('global-plugin' => array('plugins/global-plugin/everywhere.js')), $this->mockpr->getPluginsJS());
+    $this->assertEquals($this->mockpr->getPluginsJS()['global-plugin-alpha'],
+                        array('plugins/global-plugin-alpha/alpha.js'));
   }
 
   /**
@@ -73,7 +110,8 @@ class PluginRegisterTest extends PHPUnit\Framework\TestCase
   public function testGetPluginsCSSWithName()
   {
     $plugins = new PluginRegister();
-    $this->assertEquals(array('test-plugin' => array('plugins/test-plugin/stylesheet.css')), $this->mockpr->getPluginsCSS(array('test-plugin')));
+    $this->assertEquals($this->mockpr->getPluginsCSS()['test-plugin1'],
+                        array('plugins/test-plugin1/stylesheet.css'));
   }
 
   /**
@@ -99,8 +137,9 @@ class PluginRegisterTest extends PHPUnit\Framework\TestCase
    */
   public function testGetCallbacks()
   {
-    $plugins = new PluginRegister();
-    $this->assertEquals(array(), $plugins->getCallbacks());
+    $this->assertEquals($this->mockpr->getCallbacks(),
+                        array('callplugin2', 'bravo', 'imaginaryPlugin', 'callplugin1', 'alpha', 'charlie', 'callplugin3')
+    );
   }
 
 }

--- a/tests/PluginRegisterTest.php
+++ b/tests/PluginRegisterTest.php
@@ -75,10 +75,29 @@ class PluginRegisterTest extends PHPUnit\Framework\TestCase
    * @covers PluginRegister::filterPlugins
    * @covers PluginRegister::filterPluginsByName
    */
+  public function testGetPluginsJSInOrder()
+  {
+    $this->assertEquals(['test-plugin2',
+                         'global-plugin-Bravo',
+                         'imaginary-plugin',
+                         'test-plugin1',
+                         'global-plugin-alpha',
+                         'global-plugin-charlie',
+                         'test-plugin3'],
+                        array_keys($this->mockpr->getPluginsJS()));
+
+  }
+
+  /**
+   * @covers PluginRegister::getPlugins
+   * @covers PluginRegister::getPluginsJS
+   * @covers PluginRegister::filterPlugins
+   * @covers PluginRegister::filterPluginsByName
+   */
   public function testGetPluginsJSWithName()
   {
-    $this->assertEquals($this->mockpr->getPluginsJS()['test-plugin1'],
-                        array('plugins/test-plugin1/plugin1.js', 'plugins/test-plugin1/second.min.js'));
+    $this->assertEquals(array('plugins/test-plugin1/plugin1.js', 'plugins/test-plugin1/second.min.js'),
+                        $this->mockpr->getPluginsJS()['test-plugin1']);
   }
 
   /**
@@ -89,8 +108,8 @@ class PluginRegisterTest extends PHPUnit\Framework\TestCase
    */
   public function testGetPluginsJSWithGlobalPlugin()
   {
-    $this->assertEquals($this->mockpr->getPluginsJS()['global-plugin-alpha'],
-                        array('plugins/global-plugin-alpha/alpha.js'));
+    $this->assertEquals(array('plugins/global-plugin-alpha/alpha.js'),
+                        $this->mockpr->getPluginsJS()['global-plugin-alpha']);
   }
 
   /**
@@ -109,8 +128,8 @@ class PluginRegisterTest extends PHPUnit\Framework\TestCase
    */
   public function testGetPluginsCSSWithName()
   {
-    $this->assertEquals($this->mockpr->getPluginsCSS()['test-plugin1'],
-                        array('plugins/test-plugin1/stylesheet.css'));
+    $this->assertEquals(array('plugins/test-plugin1/stylesheet.css'),
+                        $this->mockpr->getPluginsCSS()['test-plugin1']);
   }
 
   /**
@@ -121,8 +140,8 @@ class PluginRegisterTest extends PHPUnit\Framework\TestCase
   public function testGetPluginCallbacks()
   {
     $plugins = new PluginRegister();
-    $this->assertEquals($this->mockpr->getPluginCallbacks()['test-plugin1'],
-                        array('plugins/test-plugin1/callplugin1'));
+    $this->assertEquals(array('plugins/test-plugin1/callplugin1'),
+                        $this->mockpr->getPluginCallbacks()['test-plugin1']);
   }
 
   /**
@@ -148,8 +167,8 @@ class PluginRegisterTest extends PHPUnit\Framework\TestCase
    */
   public function testGetCallbacks()
   {
-    $this->assertEquals($this->mockpr->getCallbacks(),
-                        array('callplugin2', 'bravo', 'imaginaryPlugin', 'callplugin1', 'alpha', 'charlie', 'callplugin3')
+    $this->assertEquals(array('callplugin2', 'bravo', 'imaginaryPlugin', 'callplugin1', 'alpha', 'charlie', 'callplugin3'),
+                        $this->mockpr->getCallbacks()
     );
   }
 

--- a/tests/PluginRegisterTest.php
+++ b/tests/PluginRegisterTest.php
@@ -109,9 +109,20 @@ class PluginRegisterTest extends PHPUnit\Framework\TestCase
    */
   public function testGetPluginsCSSWithName()
   {
-    $plugins = new PluginRegister();
     $this->assertEquals($this->mockpr->getPluginsCSS()['test-plugin1'],
                         array('plugins/test-plugin1/stylesheet.css'));
+  }
+
+  /**
+   * @covers PluginRegister::getPluginCallbacks
+   * @covers PluginRegister::filterPlugins
+   * @covers PluginRegister::filterPluginsByName
+   */
+  public function testGetPluginCallbacks()
+  {
+    $plugins = new PluginRegister();
+    $this->assertEquals($this->mockpr->getPluginCallbacks()['test-plugin1'],
+                        array('plugins/test-plugin1/callplugin1'));
   }
 
   /**

--- a/tests/VocabularyConfigTest.php
+++ b/tests/VocabularyConfigTest.php
@@ -541,7 +541,7 @@ class VocabularyConfigTest extends PHPUnit\Framework\TestCase
    * @covers VocabularyConfig::getPluginParameters
    */
   public function testGetPluginParameters() {
-    $vocab = $this->model->getVocabulary('paramPluginTest');
+    $vocab = $this->model->getVocabulary('paramPluginOrderTest');
     $params = $vocab->getConfig()->getPluginParameters();
     $this->assertEquals(array('imaginaryPlugin' => array('poem_fi' => "Roses are red", 'poem' => "Violets are blue", 'color' => "#800000")), $params);
   }
@@ -550,7 +550,7 @@ class VocabularyConfigTest extends PHPUnit\Framework\TestCase
    * @covers VocabularyConfig::getPluginArray
    */
   public function testGetOrderedPlugins() {
-    $vocab = $this->model->getVocabulary('paramPluginTest');
+    $vocab = $this->model->getVocabulary('paramPluginOrderTest');
     $plugins = $vocab->getConfig()->getPluginArray();
     $this->assertEquals(["plugin2", "Bravo", "plugin1", "alpha", "charlie", "imaginaryPlugin", "plugin3"],  $plugins);
   }
@@ -559,7 +559,7 @@ class VocabularyConfigTest extends PHPUnit\Framework\TestCase
    * @covers VocabularyConfig::getPluginArray
    */
   public function testGetUnorderedVocabularyPlugins() {
-    $vocab = $this->model->getVocabulary('paramPluginOrderTest');
+    $vocab = $this->model->getVocabulary('paramPluginTest');
     $plugins = $vocab->getConfig()->getPluginArray();
     $arrayElements = ["plugin2", "Bravo", "imaginaryPlugin", "plugin1", "alpha", "charlie", "plugin3"];
     $this->assertEquals(sort($arrayElements), sort($plugins));

--- a/tests/testconfig.ttl
+++ b/tests/testconfig.ttl
@@ -362,7 +362,7 @@
     skosmos:sparqlGraph <http://www.skosmos.skos/test-notation-sort/>;
     skosmos:mainConceptScheme test:notationMainConceptScheme .
 
-:paramPluginOrderTest a skosmos:Vocabulary, void:Dataset ;
+:paramPluginTest a skosmos:Vocabulary, void:Dataset ;
 	dc:title "Test plugin order"@en ;
 	void:dataDump <http://skosmos.skos/dump/test/> ;
 	void:uriSpace "http://www.skosmos.skos/test/";
@@ -371,7 +371,7 @@
 	skosmos:usePlugin "plugin3" ;
 	skosmos:useParamPlugin :parameterizedPlugin .
 
-:paramPluginTest a skosmos:Vocabulary, void:Dataset ;
+:paramPluginOrderTest a skosmos:Vocabulary, void:Dataset ;
 	dc:title "Test plugin parameters"@en ;
 	dc:subject :cat_science ;
     dc:type mdrtype:ONTOLOGY ;

--- a/view/concept-shared.twig
+++ b/view/concept-shared.twig
@@ -12,6 +12,7 @@
       <p class="language-alert">{% trans %}There is no term for this concept in this language{% endtrans %}</p>
     </div>
     {% endif %}
+    <div id="concept-info-before"></div>
     <div class="concept-info{% if concept.deprecated %} deprecated-concept{% endif %}">
       <div class="concept-main">
       {% if bread_crumbs is defined %}
@@ -208,6 +209,7 @@
           >
       </div>
     </div>
+    <div id="concept-info-after"></div>
     {% endfor %}
 
   {% else %}


### PR DESCRIPTION
## Reasons for creating this PR
Fixes reopened issue #1148. Orders also callback names of plugins in the same order as sorted in VocabularyConfig.php and configured in skosmos:vocabularyPlugins.

## Link to relevant issue(s), if any
- Closes #1148

## Description of the changes in this PR
Plugin order is configured with skosmos:vocabularyPlugins. PR #1201 made it possible to define order of plugins in configuration. PluginRegister class reorders the plugins in alphabetical order of plugin file names, but this fix rearranges the callback names to the same order as in skosmos:vocabularyPlugins. PR also adds the possibility to define parameter plugins outside of the ordered plugin list

## Known problems or uncertainties in this PR
Plugin rendering order is reverse than the order configured in skosmos:vocabularyPlugins. To solve this, Skosmos HTML template could have additional empty div element (e.g. `<div id="concept-info-after"></div>`), which serves as a location for widgets. Each widget could then reserve own empty div element during callback with JQuery `$('#concept-info-after').append(...)`. Then the rendering would be done in same order as in skosmos:vocabularyPlugins.

In same way a similar div element (e.g. `<div id="concept-info-before">`) could be added for widgets with message (e.g. https://github.com/NatLibFi/Skosmos-widget-message) above the concept info.