### PR TITLE
Replace #concept-info-before div element with more generic #content-top

### DIFF
--- a/view/concept-shared.twig
+++ b/view/concept-shared.twig
@@ -208,7 +208,6 @@
           >
       </div>
     </div>
-    <div id="concept-info-after"></div>
     {% endfor %}
 
   {% else %}

--- a/view/concept-shared.twig
+++ b/view/concept-shared.twig
@@ -12,7 +12,6 @@
       <p class="language-alert">{% trans %}There is no term for this concept in this language{% endtrans %}</p>
     </div>
     {% endif %}
-    <div id="concept-info-before"></div>
     <div class="concept-info{% if concept.deprecated %} deprecated-concept{% endif %}">
       <div class="concept-main">
       {% if bread_crumbs is defined %}

--- a/view/light.twig
+++ b/view/light.twig
@@ -180,6 +180,7 @@
         {% include 'vocabularylist.twig' %}
       {% endif %}
       <div class="{% if global_search %}global-{% elseif request.page == 'vocab' and not request.vocab.config.showAlphabeticalIndex and not request.vocab.config.showTopConcepts and not request.vocab.config.showChangeList %}wide-{% endif %}content">
+        <div id="content-top"></div>
       {% block content %}
       {% endblock %}
       </div>

--- a/view/light.twig
+++ b/view/light.twig
@@ -181,8 +181,9 @@
       {% endif %}
       <div class="{% if global_search %}global-{% elseif request.page == 'vocab' and not request.vocab.config.showAlphabeticalIndex and not request.vocab.config.showTopConcepts and not request.vocab.config.showChangeList %}wide-{% endif %}content">
         <div id="content-top"></div>
-      {% block content %}
-      {% endblock %}
+        {% block content %}
+        {% endblock %}
+        <div id="content-bottom"></div>
       </div>
     </main>
     {% endblock %}


### PR DESCRIPTION
## Reasons for creating this PR

In PR #1285, new empty DIV elements `#concept-info-before` and `#concept-info-after` were added as placeholders so that plugins can add widgets into these predefined slots. But these are specific to the concept page and not available on other page types such as the vocabulary home page. This PR replaces those DIVs with more generic ones `#content-top` and `#content-bottom` which can be used on all (?) page types.

## Link to relevant issue(s), if any

- Follow-up fix to #1285

## Description of the changes in this PR

* remove `#concept-info-before` and `#concept-info-after` DIV elements
* add `#content-top` and `#content-bottom` DIV elements
* some reindentation

## Known problems or uncertainties in this PR

n/a

## Checklist

- [ ] phpUnit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if not, explain why below)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)

Tests are not relevant since only Twig templates were changed.