### PR TITLE
Permit GitHub Actions CI to write Packages, needed for php-build caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on: [push, pull_request, workflow_dispatch]
 jobs:
   build-test:
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     timeout-minutes: 10
     continue-on-error: ${{ matrix.experimental }}
     strategy:


### PR DESCRIPTION
## Reasons for creating this PR

I'm trying to get tests on GitHub Actions CI working again. This PR fixes part of the problem - the permission issue preventing php-build from caching PHP containers as Packages.

## Link to relevant issue(s), if any

- Related to #1288 but doesn't fix everything

## Description of the changes in this PR

Allow Actions to write Packages according to [GitHub documentation](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs)

## Known problems or uncertainties in this PR

Tests are still broken on PHP 7.x (see #1288) but at least the PHP containers get built and stored as Packages and tests on PHP 8.0 are passing.

## Checklist

- [ ] phpUnit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if not, explain why below)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
