### PR TITLE
drop useless SKOSMOS_VERSION build arg from Dockerfile

### DIFF
--- a/dockerfiles/Dockerfile.ubuntu
+++ b/dockerfiles/Dockerfile.ubuntu
@@ -4,8 +4,6 @@ LABEL maintainer="National Library of Finland"
 LABEL version="0.1"
 LABEL description="A Docker image for Skosmos with Apache httpd."
 
-ARG SKOSMOS_VERSION=v.2.9
-
 ARG DEBIAN_FRONTEND=noninteractive
 
 # git is necessary for some composer packages e.g. davidstutz/bootstrap-multiselect


### PR DESCRIPTION
## Reasons for creating this PR

I noticed that the Dockerfile for Skosmos declares a build argument SKOSMOS_VERSION which isn't actually used and the default value `v.2.9` refers to an old version of Skosmos. This PR simply removes it. 

## Link to relevant issue(s), if any

n/a

## Description of the changes in this PR

Drop the line with the SKOSMOS_VERSION declaration in Dockerfile

## Known problems or uncertainties in this PR

n/a

## Checklist

- [ ] phpUnit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if not, explain why below)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
