### PR TITLE
Pin versions of Docker images, update comment

### DIFF
--- a/dockerfiles/docker-compose.yml
+++ b/dockerfiles/docker-compose.yml
@@ -4,24 +4,23 @@ services:
   fuseki:
     container_name: skosmos-fuseki
     hostname: fuseki
-    image: stain/jena-fuseki
+    image: stain/jena-fuseki:4.0.0
     environment:
       - ADMIN_PASSWORD=admin
       - JVM_ARGS=-Xmx2g
     ports:
       - 9030:3030
-  # You can uncomment the line below to have a local volume bound onto the container, or
-  # visit https://hub.docker.com/r/stain/jena-fuseki/ for other alternatives
-  # volumes:
-  #  - ${PWD}/fuseki:/fuseki
     volumes:
       - type: bind
         source: ./config/skosmos.ttl
         target: /fuseki/configuration/skosmos.ttl
+      # The example below shows how to bind a volume to persist the Jena Fuseki data.
+      # Visit https://hub.docker.com/r/stain/jena-fuseki/ for more options.
+      # - ${PWD}/fuseki:/fuseki
   fuseki-cache:
     container_name: skosmos-fuseki-cache
     hostname: fuseki-cache
-    image: varnish
+    image: varnish:6.0.10
     ports:
       - 9031:80
     volumes:


### PR DESCRIPTION
## Reasons for creating this PR

From the linked discussion, looks like Varnish changed the image and now it cannot be used with its default port `80`. This pull request pins the versions of the images, instead of using the `latest` tag, in Docker Compose.

Also updates the commented text to avoid YAML errors.

## Link to relevant issue(s), if any

- https://groups.google.com/g/skosmos-users/c/9mrL0UhPpco
- https://github.com/varnish/docker-varnish/issues/42

## Description of the changes in this PR

## Known problems or uncertainties in this PR

## Checklist

- [ ] phpUnit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if not, explain why below)
- [ ] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
