### PR TITLE
drop unused URI.js dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,18 +4,6 @@
   "type": "project",
   "license": "MIT",
   "repositories": { 
-    "urijs-unofficial": {
-      "type": "package",
-      "package": {
-        "name": "medialize/uri.js",
-        "version": "1.19.0",
-        "source": {
-          "url": "https://github.com/medialize/URI.js.git",
-          "type": "git",
-          "reference": "v1.19.0"
-        }
-      }
-    },
     "lscache": {
       "type": "package",
       "package": {
@@ -69,7 +57,6 @@
     "vakata/jstree": "3.3.*",
     "punic/punic": "3.5.1",
     "ml/json-ld": "1.*",
-    "medialize/uri.js": "1.19.0",
     "ext-gettext": "*",
     "ext-intl": "*",
     "ext-mbstring": "*",

--- a/view/scripts.twig
+++ b/view/scripts.twig
@@ -56,7 +56,6 @@ var pluginParameters = {{ plugin_params|raw }};
 <script src="vendor/components/handlebars.js/handlebars.min.js"></script>
 <script src="vendor/vakata/jstree/dist/jstree.min.js"></script>
 <script src="vendor/twitter/typeahead.js/dist/typeahead.bundle.min.js"></script>
-<script src="vendor/medialize/uri.js/src/URI.min.js"></script>
 <script src="vendor/davidstutz/bootstrap-multiselect/dist/js/bootstrap-multiselect.min.js"></script>
 <script src="vendor/twbs/bootstrap/dist/js/bootstrap.bundle.js"></script>
 <script src="vendor/grimmlink/qtip2/dist/jquery.qtip.min.js"></script>


### PR DESCRIPTION
## Reasons for creating this PR

As noted in #1297, the URI.js dependency is unnecessary. In addition the version Skosmos depends on is outdated and has multiple security issues.

## Link to relevant issue(s), if any

- Closes #1297

## Description of the changes in this PR

Drop the dependency to URI.js

## Known problems or uncertainties in this PR

n/a

## Checklist

- [x] phpUnit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if not, explain why below)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)

(JS dependencies don't affect tests)