### PR TITLE
Refactoring 2022 03 31

### DIFF
--- a/model/VocabularyConfig.php
+++ b/model/VocabularyConfig.php
@@ -63,7 +63,7 @@ class VocabularyConfig extends BaseConfig
     }
 
     /**
-     * Get a resouce if if skosmos:vocabularyPlugins is set
+     * Get a resouce if skosmos:vocabularyPlugins is set
      * @return EasyRdf\Resource object
      */
     public function getVocabularyPlugins() {

--- a/model/VocabularyConfig.php
+++ b/model/VocabularyConfig.php
@@ -39,11 +39,19 @@ class VocabularyConfig extends BaseConfig
     }
 
     /**
-     * Get a literal value if skosmos:usePlugin is set
-     * @return \EasyRdf\Literal value
+     * Get the resources if skosmos:parameters is used
+     * @return EasyRdf\Resource objects as an array
      */
-    public function getUsePluginAsLiteral($plugin) {
-        return $plugin->getLiteral('skosmos:usePlugin')->getValue();
+    public function getParameters(EasyRdf\Resource $res) : array {
+        return $res->allResources('skosmos:parameters');
+    }
+
+    /**
+     * Get a literal value if skosmos:usePlugin is set
+     * @return \EasyRdf\Literal value as a string
+     */
+    public function getUsePluginAsLiteral($plugin) : string {
+        return (string) $plugin->getLiteral('skosmos:usePlugin')->getValue();
     }
 
     /**
@@ -58,16 +66,24 @@ class VocabularyConfig extends BaseConfig
      * Get an array of resources if skosmos:useParamPlugin is set
      * @return array of resources
      */
-    public function getUseParamPlugin() : array {
+    public function getUseParamPluginArray() : array {
         return array_values(array_unique($this->resource->allResources('skosmos:useParamPlugin')));
     }
 
     /**
-     * Get a resouce if skosmos:vocabularyPlugins is set
+     * Get a resource if skosmos:vocabularyPlugins is set
      * @return EasyRdf\Resource object
      */
     public function getVocabularyPlugins() {
         return $this->resource->getResource('skosmos:vocabularyPlugins');
+    }
+
+    /**
+     * Get a resouce if skosmos:vocabularyPlugins is set
+     * @return array of resources
+     */
+    public function getVocabularyPluginsArray() {
+        return $this->resource->all('skosmos:vocabularyPlugins');
     }
 
     /**
@@ -94,7 +110,7 @@ class VocabularyConfig extends BaseConfig
         }
         $pluginArray = array_merge($pluginArray, $this->globalPlugins);
 
-        $paramPlugins = $this->getUseParamPlugin();
+        $paramPlugins = $this->getUseParamPluginArray();
         if ($paramPlugins) {
             foreach ($paramPlugins as $plugin) {
                 $pluginArray[] = $this->getUsePluginAsLiteral($plugin);
@@ -116,10 +132,9 @@ class VocabularyConfig extends BaseConfig
     private function setParameterizedPlugins() : void
     {
         $this->pluginParameters = array();
-
-        $vocabularyPlugins = $this->resource->getResource('skosmos:vocabularyPlugins');
+        $vocabularyPlugins = $this->getVocabularyPlugins();
         if (!$vocabularyPlugins instanceof EasyRdf\Collection) {
-            $vocabularyPlugins = $this->resource->all('skosmos:vocabularyPlugins');
+            $vocabularyPlugins = $this->getVocabularyPluginsArray();
         }
         if ($vocabularyPlugins) {
             foreach ($vocabularyPlugins as $plugin) {
@@ -128,8 +143,7 @@ class VocabularyConfig extends BaseConfig
                 }
             }
         }
-//        $pluginResources = $this->resource->allResources('skosmos:useParamPlugin');
-        $pluginResources = $this->getUseParamPlugin();
+        $pluginResources = $this->getUseParamPluginArray();
         if ($pluginResources) {
             foreach ($pluginResources as $pluginResource) {
                 $this->setPluginParameters($pluginResource);
@@ -144,10 +158,10 @@ class VocabularyConfig extends BaseConfig
      */
     private function setPluginParameters(Easyrdf\Resource $pluginResource) : void
     {
-        $pluginName = $pluginResource->getLiteral('skosmos:usePlugin')->getValue();
+        $pluginName = $this->getUsePluginAsLiteral($pluginResource);
         $this->pluginParameters[$pluginName] = array();
 
-        $pluginParams = $pluginResource->allResources('skosmos:parameters');
+        $pluginParams = $this->getParameters($pluginResource);
         foreach ($pluginParams as $parameter) {
 
             $paramLiterals = $parameter->allLiterals('schema:value');

--- a/model/VocabularyConfig.php
+++ b/model/VocabularyConfig.php
@@ -39,7 +39,7 @@ class VocabularyConfig extends BaseConfig
     }
 
     /**
-     * Get a literal value if skosmos:usePlugin is defined
+     * Get a literal value if skosmos:usePlugin is set
      * @return \EasyRdf\Literal value
      */
     public function getUsePluginAsLiteral($plugin) {
@@ -47,7 +47,7 @@ class VocabularyConfig extends BaseConfig
     }
 
     /**
-     * Get an array of literal values if skosmos:usePlugin is defined
+     * Get an array of literal values if skosmos:usePlugin is set
      * @return array of literal values
      */
     public function getUsePluginAsArray(EasyRdf\Resource $res) {
@@ -55,7 +55,7 @@ class VocabularyConfig extends BaseConfig
     }
 
     /**
-     * Get an array of resources if skosmos:useParamPlugin is used
+     * Get an array of resources if skosmos:useParamPlugin is set
      * @return array of resources
      */
     public function getUseParamPlugin() : array {
@@ -63,7 +63,7 @@ class VocabularyConfig extends BaseConfig
     }
 
     /**
-     * Get a resouce if if skosmos:vocabularyPlugins is used
+     * Get a resouce if if skosmos:vocabularyPlugins is set
      * @return EasyRdf\Resource object
      */
     public function getVocabularyPlugins() {

--- a/model/VocabularyConfig.php
+++ b/model/VocabularyConfig.php
@@ -39,6 +39,38 @@ class VocabularyConfig extends BaseConfig
     }
 
     /**
+     * Get a literal value if skosmos:usePlugin is defined
+     * @return \EasyRdf\Literal value
+     */
+    public function getUsePluginAsLiteral($plugin) {
+        return $plugin->getLiteral('skosmos:usePlugin')->getValue();
+    }
+
+    /**
+     * Get an array of literal values if skosmos:usePlugin is defined
+     * @return array of literal values
+     */
+    public function getUsePluginAsArray(EasyRdf\Resource $res) {
+        return $res->allLiterals('skosmos:usePlugin');
+    }
+
+    /**
+     * Get an array of resources if skosmos:useParamPlugin is used
+     * @return array of resources
+     */
+    public function getUseParamPlugin() : array {
+        return array_values(array_unique($this->resource->allResources('skosmos:useParamPlugin')));
+    }
+
+    /**
+     * Get a resouce if if skosmos:vocabularyPlugins is used
+     * @return EasyRdf\Resource object
+     */
+    public function getVocabularyPlugins() {
+        return $this->resource->getResource('skosmos:vocabularyPlugins');
+    }
+
+    /**
      * Get an ordered array of plugin names with order configured in skosmos:vocabularyPlugins
      * @return array of plugin names
      */
@@ -46,9 +78,9 @@ class VocabularyConfig extends BaseConfig
     {
         $this->setParameterizedPlugins();
         $pluginArray = array();
-        $vocabularyPlugins = $this->resource->getResource('skosmos:vocabularyPlugins');
+        $vocabularyPlugins = $this->getVocabularyPlugins();
         if (!$vocabularyPlugins instanceof EasyRdf\Collection) {
-            $vocabularyPlugins = $this->resource->all('skosmos:vocabularyPlugins');
+            $vocabularyPlugins = $this->getVocabularyPlugins();
         }
         if ($vocabularyPlugins) {
             foreach ($vocabularyPlugins as $plugin) {
@@ -56,19 +88,19 @@ class VocabularyConfig extends BaseConfig
                     $pluginArray[] = $plugin->getValue();
                 }
                 else {
-                    $pluginArray[] = $plugin->getLiteral('skosmos:usePlugin')->getValue();
+                    $pluginArray[] = $plugin->getLiteral($this->getUsePluginAsLiteral());
                 }
             }
         }
         $pluginArray = array_merge($pluginArray, $this->globalPlugins);
 
-        $paramPlugins = $this->resource->allResources('skosmos:useParamPlugin');
+        $paramPlugins = $this->getUseParamPlugin();
         if ($paramPlugins) {
             foreach ($paramPlugins as $plugin) {
-                $pluginArray[] = $plugin->getLiteral('skosmos:usePlugin')->getValue();
+                $pluginArray[] = $this->getUsePluginAsLiteral($plugin);
             }
         }
-        $plugins = $this->resource->allLiterals('skosmos:usePlugin');
+        $plugins = $this->getUsePluginAsArray($this->resource);
         if ($plugins) {
             foreach ($plugins as $pluginlit) {
                 $pluginArray[] = $pluginlit->getValue();
@@ -96,7 +128,8 @@ class VocabularyConfig extends BaseConfig
                 }
             }
         }
-        $pluginResources = $this->resource->allResources('skosmos:useParamPlugin');
+//        $pluginResources = $this->resource->allResources('skosmos:useParamPlugin');
+        $pluginResources = $this->getUseParamPlugin();
         if ($pluginResources) {
             foreach ($pluginResources as $pluginResource) {
                 $this->setPluginParameters($pluginResource);


### PR DESCRIPTION
## Reasons for creating this PR
Property values in the Skosmos or vocabulary configuration, got by a key should not be called directly, therefore the properties need separate interfaces (methods). This makes it easier to debug the code and the structure of the code will be easier to read, understand and maintain.

## Link to relevant issue(s), if any

- Closes #

## Description of the changes in this PR
Refactored those parts of the code in the VocabularyConfig.php where properties were called without dedicated methods. Added methods for the properties without an API.

Tests are needed but they will be made after the first review, after the implementation and the quality of the code have been checked.

Tests are needed but they will be made after the first review, after the idea and the quality of the code is checked.


## Known problems or uncertainties in this PR

## Checklist

- [ ] phpUnit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if not, explain why below)
- [ ] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
