### PR TITLE
Fix typeahead and handlebars template.

### DIFF
--- a/resource/css/styles.css
+++ b/resource/css/styles.css
@@ -159,6 +159,7 @@ a, a.versal, .nav-link, .nav-link.active, .jstree-node > .jstree-anchor {
 
 .replaced {
   font-style: italic;
+  color: var(--gray-900) !important;
 }
 
 .nav-link:link,.nav-link:visited,.nav-link:active,.nav-link:hover,.nav-link:focus {
@@ -2073,9 +2074,8 @@ span.date-info {
   overflow: hidden;
 }
 
-p.autocomplete-label {
+.autocomplete-label > span {
   color: var(--medium-color);
-  display: block;
   margin: 0;
 }
 

--- a/resource/js/docready.js
+++ b/resource/js/docready.js
@@ -749,11 +749,13 @@ $(function() { // DOCUMENT READY
   concepts.initialize();
 
   var autocompleteTemplate =[
-    '{{# if matched }}<p>{{matched}}{{# if lang}} ({{lang}}){{/if}} = </p>{{/if}}',
-    '{{# if replaced }}<p class="replaced">{{replaced}}{{# if lang}} ({{lang}}){{/if}} &rarr; </p>{{/if}}',
-    '{{# if notation }}<p>{{notation}}</p>{{/if}}',
-    '<p class="autocomplete-label">{{label}}{{# if lang}}{{# unless matched }}<p>({{lang}})</p>{{/unless}}{{/if}}</p>',
+    '<div class="autocomplete-label">',
+    '{{# if matched }}<span>{{matched}}{{# if lang}} ({{lang}}){{/if}} = </span>{{/if}}',
+    '{{# if replaced }}<span class="replaced">{{replaced}}{{# if lang}} ({{lang}}){{/if}} &rarr; </span>{{/if}}',
+    '{{# if notation }}<span>{{notation}}</span>{{/if}}',
+    '<span>{{label}}{{# if lang}}{{# unless matched }}<span>({{lang}})</span>{{/unless}}{{/if}}</span>',
     '{{# if typeLabel }}<span class="concept-type">{{typeLabel}}</span>{{/if}}',
+    '</div>',
     '<div class="vocab">{{vocabLabel}}</div>'
   ].join('');
 
@@ -761,11 +763,11 @@ $(function() { // DOCUMENT READY
     var dark = ($('#search-field').val().length > 0) ? ' clear-search-dark' : '';
     var clearButton = '<span class="versal clear-search' + dark + '">&#215;</span>';
 
-    var $typeahead = $('#search-field').typeahead({ hint: false, highlight: true, minLength: autocomplete_activation },
+    var $typeahead = $('#search-field').typeahead({hint: false, highlight: true, minLength: autocomplete_activation},
       {
         name: 'concept',
         limit: autocomplete_limit,
-        displayKey: 'label',
+        display: 'label',
         templates: {
           empty: Handlebars.compile([
             '<div><p class="autocomplete-no-results">{{#noresults}}{{/noresults}}</p></div>'
@@ -773,9 +775,9 @@ $(function() { // DOCUMENT READY
           suggestion: Handlebars.compile(autocompleteTemplate)
         },
         source: concepts.ttAdapter()
-    }).on('typeahead:cursorchanged', function() {
+      }).on('typeahead:cursorchanged', function () {
       $('.tt-dropdown-menu').mCustomScrollbar("scrollTo", '.tt-cursor');
-    }).on('typeahead:selected', onSelection).on('focus', function() {
+    }).on('typeahead:selected', onSelection).on('focus', function () {
       $('#search-field').typeahead('open');
     }).after(clearButton).on('keypress', function() {
       if ($typeahead.val().length > 0 && $(this).hasClass('clear-search-dark') === false) {
@@ -1060,7 +1062,7 @@ $(function() { // DOCUMENT READY
   if ($replaced.length > 0) {
     var $replacedElem = $('.replaced-by h3');
     var undoUppercasing = $replacedElem.text().substr(0,1) + $replacedElem.text().substr(1).toLowerCase();
-    var html = ''
+    var html = '';
     for (var i = 0; i < $replaced.length; i++) {
         var replacedBy = '<a href="' + $replaced[i] + '">' + $replaced[i].innerHTML + '</a>';
         html += '<p class="alert-replaced">' + undoUppercasing + ': ' + replacedBy + '</p>';


### PR DESCRIPTION
## Reasons for creating this PR

Fix styles and UI behavior, broken in #1182 

## Link to relevant issue(s), if any

- Closes #1301 

## Description of the changes in this PR

I noticed that the data was present for Typeahead to display it, but for some reason we only saw part of the data when values were replaced (e.g. Catalans & Catalan People). I couldn't find anything in the Typeahead docs, but then it occurred to me that it could be now handling templates the same way Vue.js does, by forcing to have a single root-node.

I moved things under a `<div>` in the template rendered for each autocomplete entry, and then it finally display all the information received and used in the template.

## Known problems or uncertainties in this PR

1. I left a question in #1301 asking about the color of the text. This is a 1 minute change, just pending a reply over there :+1: 

2. @osma I couldn't understand why my types are not being replaced by shorter text. I wonder if it's because I have been using old vocabularies I exported from finto and/or finto.dev?

I set a few breakpoints, and after clearing my local storage, I can confirm the UI is sending a request to `http://localhost:9090/rest/v1/types?lang=en` to retrieve types, and is also using the `@context` returned from the autocomplete request.

But the right-most information is still using the URI instead of a value like "General Concept" as in your screenshot attached to #1301. See my screenshot below for an example:

![Screenshot from 2022-04-25 17-18-55](https://user-images.githubusercontent.com/304786/165025840-2ee45e86-b2e3-4019-a039-06056fb4fe4f.png)

It shows skos:Concept, and other URI's instead of a simpler text :disappointed: . Thanks!

## Checklist

- [x] phpUnit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if not, explain why below)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
