### PR TITLE
Fix font color and size after Bootstrap 5 upgrade

### DIFF
--- a/resource/css/styles.css
+++ b/resource/css/styles.css
@@ -219,6 +219,10 @@ ul {
   list-style: none;
 }
 
+.btn {
+  font-size: var(--font-size);
+}
+
 /**
  * Bootstrap 5 added a margin in the :after element of the caret. This removes the extra space.
  */
@@ -822,13 +826,6 @@ ul.dropdown-menu > li:last-child > input {
 
 .form-control {
   display: table-cell;
-}
-
-.form-control:focus {
-  background-color: var(--gray-100);
-  color: var(--medium-color);
-  border: none;
-  resize: none;
 }
 
 .input-group-btn {


### PR DESCRIPTION
## Reasons for creating this PR

Fix minor CSS issues found after the Bootstrap upgrade (#1182)

## Link to relevant issue(s), if any

- Closes #1301 

## Description of the changes in this PR

* set the font size on the buttons next to the search box back to 14px
* remove the CSS block that changed the color of text typed into the search box

## Known problems or uncertainties in this PR

Hoping this won't have any adverse effects on other parts of the UI...

## Checklist

- [x] phpUnit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if not, explain why below)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
