### PR TITLE
Sanitize language switching URLs

### DIFF
--- a/model/Request.php
+++ b/model/Request.php
@@ -185,7 +185,7 @@ class Request
             $langurl = preg_replace("#^(.*/)?{$this->lang}/#", "$1{$newlang}/", $langurl);
         }
         // make sure that the resulting URL doesn't contain suspicious characters
-        $langurl = preg_replace("#[^a-zA-Z0-9-/]#", "", $langurl);
+        $langurl = preg_replace("#[^a-zA-Z0-9/-]#", "", $langurl);
         return $langurl;
     }
 

--- a/model/Request.php
+++ b/model/Request.php
@@ -179,10 +179,13 @@ class Request
      */
     public function getLangUrl($newlang=null)
     {
-        $langurl = substr(str_replace(str_replace('/index.php', '', $this->getServerConstant('SCRIPT_NAME')), '', $this->getServerConstant('REQUEST_URI')), 1);
+        $script_name = str_replace('/index.php', '', $this->getServerConstant('SCRIPT_NAME'));
+        $langurl = substr(str_replace($script_name, '', $this->getServerConstant('REQUEST_URI')), 1);
         if ($newlang !== null) {
             $langurl = preg_replace("#^(.*/)?{$this->lang}/#", "$1{$newlang}/", $langurl);
         }
+        // make sure that the resulting URL doesn't contain suspicious characters
+        $langurl = preg_replace("#[^a-zA-Z0-9-/]#", "", $langurl);
         return $langurl;
     }
 

--- a/model/Request.php
+++ b/model/Request.php
@@ -184,8 +184,8 @@ class Request
         if ($newlang !== null) {
             $langurl = preg_replace("#^(.*/)?{$this->lang}/#", "$1{$newlang}/", $langurl);
         }
-        // make sure that the resulting URL doesn't contain suspicious characters
-        $langurl = preg_replace("#[^a-zA-Z0-9/-]#", "", $langurl);
+        // make sure that the resulting URL isn't interpreted as an absolute URL
+        $langurl = str_replace(":", "", $langurl);
         return $langurl;
     }
 

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -229,4 +229,15 @@ class RequestTest extends PHPUnit\Framework\TestCase
     $this->assertEquals("myvocab/sv/index", $langurl);
   }
 
+  /**
+   * @covers Request::getLangUrl
+   */
+  public function testGetLangUrlSanitizeSpecialChars() {
+    $this->request->setServerConstant('SCRIPT_NAME', '/Skosmos/index.php');
+    $this->request->setServerConstant('REQUEST_URI', '/Skosmos/http://example.com');
+    $this->request->setLang('en');
+    $langurl = $this->request->getLangUrl();
+    $this->assertEquals("http//examplecom", $langurl);
+  }
+
 }

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -189,6 +189,16 @@ class RequestTest extends PHPUnit\Framework\TestCase
   /**
    * @covers Request::getLangUrl
    */
+  public function testGetLangUrlNoParamVocabIndex() {
+    $this->request->setServerConstant('SCRIPT_NAME', '/Skosmos/index.php');
+    $this->request->setServerConstant('REQUEST_URI', '/Skosmos/myvocab/en/index');
+    $langurl = $this->request->getLangUrl();
+    $this->assertEquals("myvocab/en/index", $langurl);
+  }
+
+  /**
+   * @covers Request::getLangUrl
+   */
   public function testGetLangUrlNewLangRoot() {
     $this->request->setServerConstant('SCRIPT_NAME', '/Skosmos/index.php');
     $this->request->setServerConstant('REQUEST_URI', '/Skosmos/en/');
@@ -206,6 +216,17 @@ class RequestTest extends PHPUnit\Framework\TestCase
     $this->request->setLang('en');
     $langurl = $this->request->getLangUrl("sv");
     $this->assertEquals("myvocab/sv/", $langurl);
+  }
+
+  /**
+   * @covers Request::getLangUrl
+   */
+  public function testGetLangUrlNewLangVocabIndex() {
+    $this->request->setServerConstant('SCRIPT_NAME', '/Skosmos/index.php');
+    $this->request->setServerConstant('REQUEST_URI', '/Skosmos/myvocab/en/index');
+    $this->request->setLang('en');
+    $langurl = $this->request->getLangUrl("sv");
+    $this->assertEquals("myvocab/sv/index", $langurl);
   }
 
 }

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -237,7 +237,7 @@ class RequestTest extends PHPUnit\Framework\TestCase
     $this->request->setServerConstant('REQUEST_URI', '/Skosmos/http://example.com');
     $this->request->setLang('en');
     $langurl = $this->request->getLangUrl();
-    $this->assertEquals("http//examplecom", $langurl);
+    $this->assertEquals("http//example.com", $langurl);
   }
 
 }


### PR DESCRIPTION
## Reasons for creating this PR

See issue #1289 - it was possible to trick Skosmos to generate links to an arbitrary URL. This could be a potential security issue together with some social engineering (instruct users to click on the link).

## Link to relevant issue(s), if any

- Closes #289

## Description of the changes in this PR

1. add some more unit tests for Request->getLangUrl method (to make sure all relevant cases are covered)
2. sanitize the URL string returned by Request->getLangUrl so it won't contain special characters 

The sanitizing will cause the "smuggled" URLs to stop working, for example `http://example.com` becomes `http//examplecom` and thus the links won't work anymore.

## Known problems or uncertainties in this PR

The language switching links on the 404 page generated for a page such as `/Skosmos/http://example.com` will be broken. It's no worse than before though, since they were already broken, now they are just less harmful.

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if not, explain why below)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
