### PR TITLE
Store current Skosmos version in composer.json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,9 @@ jobs:
 
     steps:
     - name: Check out repository code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
 
     - name: Cache Fuseki installation
       uses: actions/cache@v2

--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
   "description": "Thesaurus and controlled vocabulary browser using SKOS and SPARQL",
   "type": "project",
   "license": "MIT",
+  "version": "2.15-dev",
   "repositories": { 
     "lscache": {
       "type": "package",

--- a/model/Model.php
+++ b/model/Model.php
@@ -76,11 +76,7 @@ class Model
      */
     public function getVersion() : string
     {
-        $ver = null;
-        if (file_exists('.git')) {
-            $ver = rtrim(shell_exec('git describe --tags --always'));
-        }
-
+        $ver = \Composer\InstalledVersions::getRootPackage()['pretty_version'];
         if ($ver === null) {
             return "unknown";
         }

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -35,7 +35,10 @@ class ModelTest extends PHPUnit\Framework\TestCase
    */
   public function testGetVersion() {
     $version = $this->model->getVersion();
-    $this->assertNotEmpty($version);
+    // make sure that the returned version (which comes from composer.json)
+    // matches the version from git tags
+    $git_tag = rtrim(shell_exec('git describe --tags --always'));
+    $this->assertStringStartsWith("v" . $version, $git_tag);
   }
 
   /**


### PR DESCRIPTION
## Reasons for creating this PR

Skosmos has been using git tags to infer the current version, which is shown on the About page and in the Generator field in the embedded HTML metadata. This has never worked on Docker containers (which don't have access to the full git repository) and recently it has been broken also in some regular installs.

This PR implements another mechanism, suggested by @kinow in #1202, where the version number is kept in `composer.json` and read via the Composer runtime API. This ensures that the version information is always available. On the downside, it requires some manual housekeeping to make sure that the version in `composer.json` is up to date. For now, I think we will do this manually. There are tools that can automate this (see https://github.com/NatLibFi/Skosmos/issues/1202#issuecomment-1105079666) but they didn't look very promising. I will add the necessary steps to the [Release Process](https://github.com/NatLibFi/Skosmos/wiki/Release-Process) documentation. I also added a unit test that verifies that the version from composer.json matches the version determined from git tags.

## Link to relevant issue(s), if any

- Closes #1202

## Description of the changes in this PR

* add version number (here, `2.15-dev` - I don't think the `v` prefix is necessary) to `composer.json`
* use Composer runtime API to access the version number, instead of git operations
* add a unit test that verifies that the version from composer.json matches version determined using git tags
* adjust GitHub Actions configuration so that git version history (including tags) is checked out from the repo, so that the above test has a chance to succeed

## Known problems or uncertainties in this PR

I hope the new processes around release will work out well, but we'll find out soon.

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if not, explain why below)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
