### PR TITLE
fix font size of autocomplete entries after Bootstrap 5 upgrade

### DIFF
--- a/resource/css/styles.css
+++ b/resource/css/styles.css
@@ -2614,7 +2614,7 @@ body, .versal, h1, h2, h3, p, .versal-bold {
     font-size: 24px;
   }
 
-  .alphabetical-search-results li, li, .versal, .versal-bold, p, .search-result > .prefLabel, .search-result > .notation, .property-values > .prefLabel, td > a {
+  .alphabetical-search-results li, li, .versal, .versal-bold, p, .autocomplete-label, .search-result > .prefLabel, .search-result > .notation, .property-values > .prefLabel, td > a {
     font-size: 16px;
   }
 


### PR DESCRIPTION
## Reasons for creating this PR

The font size in autocomplete entries decreased to 14px in the Bootstrap 5 upgrade due to changes in HTML structure. This PR increases it back to 16px.

## Link to relevant issue(s), if any

- adjustment after #1182

## Description of the changes in this PR

* adjust CSS rules to match entries in autocomplete list

## Known problems or uncertainties in this PR

n/a
