### PR TITLE
Upgrade to PHPUnit 9, drop PHP 7.2 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php_version: ["7.2", "7.3", "7.4", "8.0"]
+        php_version: ["7.3", "7.4", "8.0"]
         experimental: [false]
         include:
           - php_version: "8.1"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,10 +67,6 @@ jobs:
         CC_TEST_REPORTER_ID: fb98170a5c7ea9cc2bbab19ff26268335e6a11a4f8267ca935e5e8ff4624886c
       with:
         prefix: /app
-      # PHPUnit 8.5 doesn't support code coverage for PHP 8
-      if: ${{ matrix.php_version < '8.0' }}
 
     - name: Publish code coverage to Codecov
       uses: codecov/codecov-action@v1
-      # PHPUnit 8.5 doesn't support code coverage for PHP 8
-      if: ${{ matrix.php_version < '8.0' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
       env:
         LANGUAGE: fr
       with:
-        version: 8.5
+        version: 9.5
         php_version: ${{ matrix.php_version }}
         php_extensions: gettext intl xsl pcov
         memory_limit: 512M

--- a/composer.json
+++ b/composer.json
@@ -69,7 +69,7 @@
     "grimmlink/qtip2": "3.0.3"
   },
   "require-dev": {
-    "phpunit/phpunit": "8.5.*",
+    "phpunit/phpunit": "9.5.*",
     "umpirsky/twig-gettext-extractor": "1.3.*",
     "symfony/dom-crawler": "5.4.*",
     "mockery/mockery": "1.3.5"

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,22 +1,23 @@
-<phpunit colors="true" bootstrap="tests/bootstrap.php" processIsolation="true"
-         convertDeprecationsToExceptions="true">
-  <logging>
-    <log type="coverage-html" target="./report" lowUpperBound="35" highLowerBound="70"/>  
-    <log type="coverage-clover" target="build/logs/clover.xml"/>
-  </logging>
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" bootstrap="tests/bootstrap.php" processIsolation="true" convertDeprecationsToExceptions="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">controller</directory>
+      <directory suffix=".php">model</directory>
+      <directory suffix=".php">model/sparql</directory>
+    </include>
+    <exclude>
+      <directory>vendor</directory>
+    </exclude>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+      <html outputDirectory="./report" lowUpperBound="35" highLowerBound="70"/>
+    </report>
+  </coverage>
+  <logging/>
   <testsuites>
     <testsuite name="tests">
       <directory suffix=".php">tests</directory>
     </testsuite>
   </testsuites>
-  <filter>
-    <whitelist processUncoveredFilesFromWhitelist="true">
-        <directory suffix=".php">controller</directory>
-        <directory suffix=".php">model</directory>
-        <directory suffix=".php">model/sparql</directory>
-        <exclude>
-          <directory>vendor</directory>
-        </exclude>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/tests/ConceptTest.php
+++ b/tests/ConceptTest.php
@@ -307,7 +307,7 @@ class ConceptTest extends PHPUnit\Framework\TestCase
    * @covers ConceptPropertyValueLiteral::getLabel
    */
   public function testGetTimestampInvalidWarning() {
-    $this->expectException(PHPUnit\Framework\Error\Error::class);
+    $this->expectError();
     $vocab = $this->model->getVocabulary('test');
     $concepts = $vocab->getConceptInfo("http://www.skosmos.skos/test/ta114", "en");
     $concept = $concepts[0];

--- a/tests/VocabularyConfigTest.php
+++ b/tests/VocabularyConfigTest.php
@@ -328,7 +328,7 @@ class VocabularyConfigTest extends PHPUnit\Framework\TestCase
   }
 
   /**
-   * @covers VocabularyConfig::sortByNotation
+   * @covers VocabularyConfig::getSortByNotation
    * @covers VocabularyConfig::getBoolean
    */
   public function testShowSortByNotationDefaultValue() {


### PR DESCRIPTION
## Reasons for creating this PR

We want to upgrade to PHPUnit 9 in order to stay up to date. It requires at minimum PHP 7.3, so this PR will also drop support for PHP 7.2.

## Link to relevant issue(s), if any

- Closes #1291

## Description of the changes in this PR

* upgrade to PHPUnit 9.5.* (from 8.5.*) in `composer.json` and in GitHub Actions CI workflow
* migrate `phpunit.xml` configuration file using PHPUnit built in migration tool
* avoid using the deprecated expectException with PHP Errors, use expectError instead
* fix an invalid coverage annotation that wasn't previously noticed
* disable running GitHub Actions CI tests under PHP 7.2
* remove the rules that prevented collecting code coverage on PHP 8.0 (it didn't work under PHPUnit 8 but now works)

## Known problems or uncertainties in this PR

none so far :crossed_fingers: 

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if not, explain why below)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
