### PR TITLE
fix 'Any language' choice in language selection menu

### DIFF
--- a/resource/js/docready.js
+++ b/resource/js/docready.js
@@ -558,12 +558,12 @@ $(function() { // DOCUMENT READY
   var langPretty;
 
   if (search_lang === 'anything' || getUrlParams().anylang === 'on') {
-    $('#lang-dropdown-toggle').html($('.lang-button-all').html() + ' <span class="caret"></span>');
+    $('#lang-dropdown-toggle').html($('#lang-button-all').html() + ' <span class="caret"></span>');
     qlang = "";
   } else if (!search_lang) {
       langPretty = $('a[hreflang=' + lang + ']').html();
       search_lang = lang;
-      if (!langPretty) { langPretty = $('.lang-button-all').html(); }
+      if (!langPretty) { langPretty = $('#lang-button-all').html(); }
       $('#lang-dropdown-toggle').html(langPretty + ' <span class="caret"></span>');
       qlang = lang;
   }
@@ -574,7 +574,7 @@ $(function() { // DOCUMENT READY
   });
 
   if (!search_lang_possible && search_lang !== 'anything') {
-    langPretty = $('.lang-button-all').html();
+    langPretty = $('#lang-button-all').html();
     $('#lang-dropdown-toggle').html(langPretty + ' <span class="caret"></span>');
     qlang = '';
     createCookie('SKOSMOS_SEARCH_LANG', qlang, 365);
@@ -588,7 +588,7 @@ $(function() { // DOCUMENT READY
     if (concepts) { concepts.clear(); }
   });
 
-  $('.lang-button, .lang-button-all').on('click', function() {
+  $('.lang-button, #lang-button-all').on('click', function() {
     $('#search-field').focus();
   });
 

--- a/view/headerbar.twig
+++ b/view/headerbar.twig
@@ -68,7 +68,7 @@
               {%- if term %}&q={{ term }}{% endif -%}
               {%- if vocabs %}&vocabs={{ vocabs }}{% endif -%}
               "
-              class="lang-button lang-button-all">
+              class="lang-button" id="lang-button-all">
               {%- trans "Search language: any" -%}
             </a>
             <input name="anylang" type="checkbox"


### PR DESCRIPTION
## Reasons for creating this PR

The "Any language" option in the content language selector was not working properly, probably because of changes caused by the Bootstrap 5 upgrade (#1182). When the user selected "Any language", the text changed to "undefined". This PR restores the original functionality.

## Link to relevant issue(s), if any

- cleanup after #1182

## Description of the changes in this PR

* use `id="lang-button-all"` instead of `class="lang-button-all"` because Bootstrap 5 seems to overwrite the class attribute but the `id` is preserved

## Known problems or uncertainties in this PR

n/a

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works (if not, explain why below)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
