### PR TITLE
Use explicit $.parseHTML() to avoid JS syntax error

### DIFF
--- a/resource/js/hierarchy.js
+++ b/resource/js/hierarchy.js
@@ -432,7 +432,7 @@ function nodeLabelSortKey(node) {
 
   // parse the HTML code in node.text and return just the label as a lower case value for sorting
   // should look like '<span class="tree-notation">12.3</span> <span class="tree-label">Hello</span>'
-  var label = $(node.text.toLowerCase()).filter('.tree-label').text();
+  var label = $($.parseHTML(node.text.toLowerCase())).filter('.tree-label').text();
 
   return domain + " " + label;
 }


### PR DESCRIPTION
## Reasons for creating this PR

The hierarchy in the IPTC vocabulary wasn't working - it gave a JS parse error. This PR fixes the problem by explicitly calling the jQuery function `$.parseHTML()` instead of relying on the magic `$()` function.

## Link to relevant issue(s), if any

- Closes #1270

## Description of the changes in this PR

* use explicit `$.parseHTML()` call

## Known problems or uncertainties in this PR

n/a

## Checklist

- [x] phpUnit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if not, explain why below)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
