### PR TITLE
minor CSS tweaks after Bootstrap 5 update

### DIFF
--- a/resource/css/styles.css
+++ b/resource/css/styles.css
@@ -404,6 +404,7 @@ ul {
   border-radius: 0;
   color: var(--dark-color) !important;
   padding: 0;
+  font-size: 16px;
 }
 
 #language > .dropdown-toggle:hover, #language > .dropdown-toggle:focus, #language > .dropdown-toggle:active, #language > .dropdown-toggle:visited {
@@ -464,6 +465,10 @@ ul {
 }
 
 /* Drop down to search from a specific vocabulary */
+
+#search-from-vocabularies .dropdown-item {
+  white-space: normal;
+}
 
 #search-from-vocabularies > button.show:focus {
   color: #333;
@@ -1122,6 +1127,7 @@ span.xl-pref-label > img {
   color: var(--medium-color);
   margin-bottom: 10px;
   resize: none;
+  font-size: var(--font-size);
 }
 
 .feedback-thanks {
@@ -1980,6 +1986,7 @@ span.date-info {
 
 .prop-preflabel .copy-clipboard {
   font-size: 20px;
+  vertical-align: 5%;
 }
 
 .copy-clipboard:active, .copy-clipboard:focus, .copy-clipboard:active:focus {


### PR DESCRIPTION
## Reasons for creating this PR

Fix some minor layout issues found after the Bootstrap 5 update (PR #1182) by @kouralex .

## Link to relevant issue(s), if any

- cleanup after #1182

## Description of the changes in this PR

- adjust text size for the language selection (dropdown style selector)
- make sure the "from all vocabularies" choice wraps so part of the text is not obscured
- decrease the size of the placeholder text on the feedback form
- tweak the vertical alignment of the copy to clipboard icon to make @MikkoAleksanteri happy

## Known problems or uncertainties in this PR

n/a

## Checklist

- [x] phpUnit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if not, explain why below)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
