### PR TITLE
Fix typeahead templates in the search auto-complete

### DIFF
--- a/resource/css/styles.css
+++ b/resource/css/styles.css
@@ -2126,7 +2126,7 @@ span.date-info {
   float: right;
 }
 
-.tt-selectable > .concept-type {
+.tt-selectable > .concept-type, .autocomplete-label > div:first-child > span.concept-type {
   float: right;
   height: auto;
 }

--- a/resource/css/styles.css
+++ b/resource/css/styles.css
@@ -2135,7 +2135,7 @@ span.date-info {
   overflow: hidden;
 }
 
-.autocomplete-label > span {
+.autocomplete-label > div:first-child > span:first-child, .autocomplete-label > div:first-child > span.replaced + span {
   color: var(--medium-color);
   margin: 0;
 }

--- a/resource/js/docready.js
+++ b/resource/js/docready.js
@@ -754,7 +754,7 @@ $(function() { // DOCUMENT READY
     '{{# if matched }}<span>{{matched}}{{# if lang}} ({{lang}}){{/if}} = </span>{{/if}}',
     '{{# if replaced }}<span class="replaced">{{replaced}}{{# if lang}} ({{lang}}){{/if}} &rarr; </span>{{/if}}',
     '{{# if notation }}<span>{{notation}}</span>{{/if}}',
-    '<span class="autocomplete-label">{{label}}{{# if lang}}{{# unless matched }}<span>({{lang}})</span>{{/unless}}{{/if}}</span>',
+    '<span>{{label}}{{# if lang}}{{# unless matched }}<span>({{lang}})</span>{{/unless}}{{/if}}</span>',
     '{{# if typeLabel }}<span class="concept-type">{{typeLabel}}</span>{{/if}}',
     '<p class="vocab">{{vocabLabel}}</p>',
     '</div>',

--- a/resource/js/docready.js
+++ b/resource/js/docready.js
@@ -750,13 +750,16 @@ $(function() { // DOCUMENT READY
 
   var autocompleteTemplate =[
     '<div class="autocomplete-label">',
+    '<div>',
     '{{# if matched }}<span>{{matched}}{{# if lang}} ({{lang}}){{/if}} = </span>{{/if}}',
     '{{# if replaced }}<span class="replaced">{{replaced}}{{# if lang}} ({{lang}}){{/if}} &rarr; </span>{{/if}}',
     '{{# if notation }}<span>{{notation}}</span>{{/if}}',
-    '<span>{{label}}{{# if lang}}{{# unless matched }}<span>({{lang}})</span>{{/unless}}{{/if}}</span>',
+    '<span class="autocomplete-label">{{label}}{{# if lang}}{{# unless matched }}<span>({{lang}})</span>{{/unless}}{{/if}}</span>',
     '{{# if typeLabel }}<span class="concept-type">{{typeLabel}}</span>{{/if}}',
+    '<p class="vocab">{{vocabLabel}}</p>',
     '</div>',
-    '<div class="vocab">{{vocabLabel}}</div>'
+    '<div class="vocab">{{vocabLabel}}</div>',
+    '</div>'
   ].join('');
 
   if ($('.headerbar').length > 0) {

--- a/resource/js/docready.js
+++ b/resource/js/docready.js
@@ -756,7 +756,6 @@ $(function() { // DOCUMENT READY
     '{{# if notation }}<span>{{notation}}</span>{{/if}}',
     '<span>{{label}}{{# if lang}}{{# unless matched }}<span>({{lang}})</span>{{/unless}}{{/if}}</span>',
     '{{# if typeLabel }}<span class="concept-type">{{typeLabel}}</span>{{/if}}',
-    '<p class="vocab">{{vocabLabel}}</p>',
     '</div>',
     '<div class="vocab">{{vocabLabel}}</div>',
     '</div>'


### PR DESCRIPTION
The template appears to be more or less like the previous one. One thing that I noticed is that we have two `div`'s (in both 2.14, and current version). So my first guess appears to be correct, that Twitter Typeahead drops the second div, instead of displaying it as before.

- [x] Use a single div to keep the Vocabulary information
- [x] Fix the CSS style (colors, font)
- [ ] Fix the concept mapping (for some reason we are showing the URI only)

## Reasons for creating this PR

After #1182 , apparently we got a regression in the search auto-complete.

## Link to relevant issue(s), if any

- Closes #1323 

## Description of the changes in this PR

Trying to match the previous design/appearance as much as possible.

## Known problems or uncertainties in this PR

## Checklist

- [ ] phpUnit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if not, explain why below)
- [ ] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
