### PR TITLE
Combine default graph and optional graphs via UNION to return all the types available in the dataset

### DIFF
--- a/model/Model.php
+++ b/model/Model.php
@@ -124,10 +124,10 @@ class Model
      * Return all types (RDFS/OWL classes) present in the specified vocabulary or all vocabularies.
      * @return array Array with URIs (string) as key and array of (label, superclassURI) as value
      */
-    public function getTypes($vocid = null, $lang = null)
+    public function getTypes(string $vocid = null, string $lang = null): array
     {
         $sparql = (isset($vocid)) ? $this->getVocabulary($vocid)->getSparql() : $this->getDefaultSparql();
-        $result = $sparql->queryTypes($lang);
+        $result = $sparql->queryTypes($lang, $vocid);
 
         foreach ($result as $uri => $values) {
             if (empty($values)) {

--- a/tests/GenericSparqlTest.php
+++ b/tests/GenericSparqlTest.php
@@ -491,7 +491,10 @@ class GenericSparqlTest extends PHPUnit\Framework\TestCase
       'http://www.skosmos.skos/test-meta/TestClass' => array(
         'superclass' => 'http://www.w3.org/2004/02/skos/core#Concept',
         'label' => 'Test class'
-      )
+      ),
+      'http://www.w3.org/2004/02/skos/core#Collection' => array(),
+      'http://purl.org/iso25964/skos-thes#ThesaurusArray' => array(),
+      'http://purl.org/iso25964/skos-thes#ConceptGroup' => array()
     );
     $this->assertEquals($expected, $actual);
   }

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -183,7 +183,14 @@ class ModelTest extends PHPUnit\Framework\TestCase
    */
   public function testGetTypesWithoutParams() {
     $result = $this->model->getTypes();
-    $this->assertEquals(array('http://www.w3.org/2004/02/skos/core#Concept', 'http://www.w3.org/2004/02/skos/core#Collection', 'http://purl.org/iso25964/skos-thes#ConceptGroup', 'http://purl.org/iso25964/skos-thes#ThesaurusArray', 'http://www.skosmos.skos/test-meta/TestClass'), array_keys($result));
+    $this->assertEquals(
+        array(
+            'http://www.w3.org/2004/02/skos/core#Concept',
+            'http://www.w3.org/2004/02/skos/core#Collection',
+            'http://purl.org/iso25964/skos-thes#ThesaurusArray',
+            'http://purl.org/iso25964/skos-thes#ConceptGroup',
+            'http://www.skosmos.skos/test-meta/TestClass'),
+        array_keys($result));
   }
 
   /**


### PR DESCRIPTION
## Reasons for creating this PR

Only the types of the default graph are returned in the REST API, unless the user enables the option in Jena that includes all graphs.

## Link to relevant issue(s), if any

- Closes #678

## Description of the changes in this PR

In the parts of the query where it references types (like rdfs label, or a subclass, etc) I have added a sibling `UNION` that includes the `GRAPH ?g { same_statement }`, to simulate what Jena does with that setting.

With the changes in this branch, after clearing the Local Storage in my browser, I can see all the types in both the REST response, and also in the UI (e.g. search auto-complete, see #1323 ), without needing to enable that option to merge the default graph in Jena Fuseki.

## Known problems or uncertainties in this PR

Does it need a test? Does it sound like a valid solution? I thought about doing a simpler `{ { query_as_is } UNION { GRAPH ?g { query _as is } } }` but since the query wasn't very long I opted for this current approach.

## Checklist

- [ ] phpUnit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works (if not, explain why below)
- [ ] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
