### PR TITLE
Fix highlighting of the New tab after Bootstrap 5 upgrade

### DIFF
--- a/view/changes.twig
+++ b/view/changes.twig
@@ -19,9 +19,9 @@
     <li id="groups" class="nav-item"><a class="{{ css_class|join(' ') }}" href="{{ request.vocabid }}/{{ request.lang }}/groups{% if request.contentLang != request.lang %}?clang={{ request.contentLang }}{% endif %}">{% trans "Group-nav" %}</a></li>
     {% endif %}
     {% if vocab.config.showChangeList %}
-    {% if vocab.config.showDeprecatedChanges %}
     {% set css_class = ['nav-link'] %}
     {% set css_class = css_class|merge(['active']) %}
+    {% if vocab.config.showDeprecatedChanges %}
     <h3 class="sr-only">{% trans "List vocabulary concepts by newest additions including removed" %}</h3>
     <li id="changes" class="nav-item"><a class="{{ css_class|join(' ') }}" href="{{ request.vocabid }}/{{ request.lang }}/new{% if request.contentLang != request.lang %}?clang={{ request.contentLang }}{% endif %}">{% trans "Changes-and-deprecations-nav" %}</a></li>
     {% else %}

--- a/view/group-contents.twig
+++ b/view/group-contents.twig
@@ -20,11 +20,11 @@
     <li id="groups" class="nav-item"><a class="{{ css_class|join(' ') }}" href="{{ request.vocabid }}/{{ request.lang }}/groups{% if request.contentLang != request.lang %}?clang={{ request.contentLang }}{% endif %}">{% trans "Group-nav" %}</a></li>
     {% endif %}
     {% if vocab.config.showChangeList %}
+    {% set css_class = ['nav-link'] %}
     {% if vocab.config.showDeprecatedChanges %}
     <h3 class="sr-only">{% trans "List vocabulary concepts by newest additions including removed" %}</h3>
     <li id="changes"><a href="{{ request.vocabid }}/{{ request.lang }}/new{% if request.contentLang != request.lang %}?clang={{ request.contentLang }}{% endif %}">{% trans "Changes-and-deprecations-nav" %}</a></li>
     {% else %}
-    {% set css_class = ['nav-link'] %}
     <h3 class="sr-only">{% trans "List vocabulary concepts by newest additions" %}</h3>
     <li id="changes" class="nav-item"><a class="{{ css_class|join(' ') }}" href="{{ request.vocabid }}/{{ request.lang }}/new{% if request.contentLang != request.lang %}?clang={{ request.contentLang }}{% endif %}">{% trans "Changes-nav" %}</a></li>
     {% endif %}

--- a/view/group-index.twig
+++ b/view/group-index.twig
@@ -19,11 +19,11 @@
     <li id="groups" class="nav-item"><a class="{{ css_class|join(' ') }}" href="{{ request.vocabid }}/{{ request.lang }}/groups{% if request.contentLang != request.lang %}?clang={{ request.contentLang }}{% endif %}">{% trans "Group-nav" %}</a></li>
     {% endif %}
     {% if vocab.config.showChangeList %}
+    {% set css_class = ['nav-link'] %}
     {% if vocab.config.showDeprecatedChanges %}
     <h3 class="sr-only">{% trans "List vocabulary concepts by newest additions including removed" %}</h3>
     <li id="changes"><a href="{{ request.vocabid }}/{{ request.lang }}/new{% if request.contentLang != request.lang %}?clang={{ request.contentLang }}{% endif %}">{% trans "Changes-and-deprecations-nav" %}</a></li>
     {% else %}
-    {% set css_class = ['nav-link'] %}
     <h3 class="sr-only">{% trans "List vocabulary concepts by newest additions" %}</h3>
     <li id="changes" class="nav-item"><a class="{{ css_class|join(' ') }}" href="{{ request.vocabid }}/{{ request.lang }}/new{% if request.contentLang != request.lang %}?clang={{ request.contentLang }}{% endif %}">{% trans "Changes-nav" %}</a></li>
     {% endif %}

--- a/view/light.twig
+++ b/view/light.twig
@@ -68,8 +68,8 @@
           <li id="groups" class="nav-item"><a class="{{ css_class|join(' ') }}" href="{{ request.vocabid }}/{{ request.lang }}/groups{% if request.contentLang != request.lang %}?clang={{ request.contentLang }}{% endif %}">{% trans "Group-nav" %}</a></li>
           {% endif %}
           {% if vocab.config.showChangeList %}
-          {% if vocab.config.showDeprecatedChanges %}
           {% if active_tab == 'new' %}{% set css_class = css_class|merge(['active']) %}{%  endif %}
+          {% if vocab.config.showDeprecatedChanges %}
           <h3 class="sr-only">{% trans "List vocabulary concepts by newest additions including removed" %}</h3>
           <li id="changes" class="nav-item"><a class="{{ css_class|join(' ') }}" href="{{ request.vocabid }}/{{ request.lang }}/new{% if request.contentLang != request.lang %}?clang={{ request.contentLang }}{% endif %}">{% trans "Changes-and-deprecations-nav" %}</a></li>
           {% else %}


### PR DESCRIPTION
## Reasons for creating this PR

The New tab wasn't properly highlighted after changes made in the Bootstrap 5 upgrade (#1182). Note that the "New and deprecated" tab variant was working OK.

Before:

![image](https://user-images.githubusercontent.com/1132830/171598206-cf0e46fc-3d62-4ef5-ba98-073ba730ec35.png)

After:

![image](https://user-images.githubusercontent.com/1132830/171598418-e800aaa1-bc76-4c37-8e41-6bd0d6a868b4.png)


## Link to relevant issue(s), if any

- related to #1182

## Description of the changes in this PR

* make sure the "active" CSS class is properly applied for the New tab
* move some variable declarations to a more proper place in the twig templates

## Known problems or uncertainties in this PR

The template code for rendering the tabs is duplicated in five(!) different Twig templates: `changes.twig`, `group-contents.twig`, `group-index.twig`, `light.twig` and `vocab.twig`. This should really be refactored and implemented in just one place. I will open a separate issue about this.

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
