### PR TITLE
Avoid introducing extra whitespace around literal values on the concept page

### DIFF
--- a/view/concept-shared.twig
+++ b/view/concept-shared.twig
@@ -159,9 +159,9 @@
                     </div>
                   {% endif %}
                   <span{% if property.type == 'skos:altLabel' %} class="replaced"{% endif %}>
-                    {% if propval.containsHtml %}{{ propval.label|raw }}{% else %}{{ propval.label }}{% endif %}
-                    {% if propval.lang and (request.contentLang and propval.lang != request.contentLang or explicit_langcodes) %} ({{ propval.lang }}){% endif %}
-                    {% if propval.datatype %} ({{ propval.datatype }}){% endif %}
+                    {%- if propval.containsHtml %}{{ propval.label|raw }}{% else %}{{ propval.label }}{% endif %}
+                    {%- if propval.lang and (request.contentLang and propval.lang != request.contentLang or explicit_langcodes) %} ({{ propval.lang }}){% endif %}
+                    {%- if propval.datatype %} ({{ propval.datatype }}){% endif -%}
                   </span>
               {% endif %}
             {% endif %}


### PR DESCRIPTION
## Reasons for creating this PR

After changes made in #1317, there is now some extra whitespace around literal property values (e.g. scope notes) shown on the concept page. This happened when a Twig single-line expression was broken up for readability. The extra whitespace causes problems e.g. when copying and pasting values.

This PR simply adds `-` modifiers to the Twig `if` tags, swallowing the extra whitespace around.

(reported by @kouralex who also assisted with the proper fix)

## Link to relevant issue(s), if any

- related to #1317

## Description of the changes in this PR

* add `-` modifiers to Twig tags to swallow unnecessary whitespace

## Known problems or uncertainties in this PR

None, but probably more fixes like this would be appropriate.

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
