### PR TITLE
API docs: Add 'uri' parameter to groupMembers

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -1237,6 +1237,13 @@
             "type": "string"
           },
           {
+            "name": "uri",
+            "in": "query",
+            "description": "URI of the group to return members from",
+            "required": true,
+            "type": "string"
+          },
+          {
             "name": "lang",
             "in": "query",
             "description": "label language, e.g. \"en\" or \"fi\"",


### PR DESCRIPTION
The `uri` parameter was listed in https://github.com/NatLibFi/Skosmos/wiki/REST-API#vocidgroupmembers , but seems like it didn't make it over to the swagger format.

