### PR TITLE
Fix header bar search form

### DIFF
--- a/resource/js/docready.js
+++ b/resource/js/docready.js
@@ -942,7 +942,7 @@ $(function() { // DOCUMENT READY
   // activating the custom autocomplete
   function updateVocabParam() {
     vocabSelectionString = '';
-    var $vocabs = $('li > a.active input');
+    var $vocabs = $('button.active input');
     $.each($vocabs,
       function(index, ob) {
         if (ob.value === 'multiselect-all') {

--- a/resource/js/docready.js
+++ b/resource/js/docready.js
@@ -580,7 +580,7 @@ $(function() { // DOCUMENT READY
     createCookie('SKOSMOS_SEARCH_LANG', qlang, 365);
   }
 
-  $('.lang-button').on('click', function() {
+  $('a.dropdown-item').on('click', function() {
     qlang = $(this)[0].attributes.hreflang ? $(this)[0].attributes.hreflang.value : 'anything';
     $('#lang-dropdown-toggle').html($(this).html() + ' <span class="caret"></span>');
     $('#lang-input').val(qlang);

--- a/resource/js/docready.js
+++ b/resource/js/docready.js
@@ -1008,6 +1008,10 @@ $(function() { // DOCUMENT READY
       }
       updateVocabParam();
     },
+    onSelectAll: function() {
+      selectedVocabs = [];
+      updateVocabParam();
+    },
     maxHeight: 300
   });
 

--- a/resource/js/scripts.js
+++ b/resource/js/scripts.js
@@ -16,7 +16,7 @@ function createCookie(name,value,days) {
     date.setTime(date.getTime() + (days*24*60*60*1000));
     expires = "; expires=" + date.toGMTString();
   }
-  document.cookie = name + "=" + value + expires + "; path=/";
+  document.cookie = name + "=" + value + expires + "; path=/; SameSite=None; Secure";
 }
 
 function readCookie(name) {

--- a/resource/js/scripts.js
+++ b/resource/js/scripts.js
@@ -16,7 +16,7 @@ function createCookie(name,value,days) {
     date.setTime(date.getTime() + (days*24*60*60*1000));
     expires = "; expires=" + date.toGMTString();
   }
-  document.cookie = name + "=" + value + expires + "; path=/; SameSite=None; Secure";
+  document.cookie = name + "=" + value + expires + "; path=/; SameSite=Lax";
 }
 
 function readCookie(name) {

--- a/view/headerbar.twig
+++ b/view/headerbar.twig
@@ -36,8 +36,8 @@
               ?clang={{langcode}}
               {%- set paramSeparator = '&' -%}
             {%- endif %}
-            {%- if term %}{{ paramSeparator }}q={{ term }}{% set paramSeparor = '&' %}{% endif -%}
-            {%- if vocabs %}{{ paramSepartor }}vocabs={{ vocabs }}{% endif -%}
+            {%- if term %}{{ paramSeparator }}q={{ term }}{% set paramSeparator = '&' %}{% endif -%}
+            {%- if vocabs %}{{ paramSeparator }}vocabs={{ vocabs }}{% endif -%}
             " class="lang-button" hreflang="{{ langcode }}">{{ langcode | lang_name(request.lang) }}</a></li>
           {% endfor %}
         {% endif %}


### PR DESCRIPTION
## Reasons for creating this PR

Cookies are not set correctly for things like multiple vocabulary selection in the global search field. This would break the global search UI element, restricting the use of global search to only skosmos API or writing the search parameters directly to the URL.

## Link to relevant issue(s), if any

- Closes #1345 

## Description of the changes in this PR

- scripts.js sets the cookie correctly, using the newly required SameSite attribute (http and https are considered to be different websites)
  - More info: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
- docready.js reads the selected vocabulary values correctly
- headerbar.twig passes parameter separators correctly

## Known problems or uncertainties in this PR

The search vocabulary parameter for "all vocabularies" is not set correctly in the cookie.

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
