### PR TITLE
Graceful handling of partial SKOS XL data for concept labels

### DIFF
--- a/model/Concept.php
+++ b/model/Concept.php
@@ -163,12 +163,10 @@ class Concept extends VocabularyDataObject implements Modifiable
         return "";
     }
 
-    public function hasXlLabel($prop = 'prefLabel')
+    public function hasXlLabel()
     {
-        if ($this->resource->hasProperty('skosxl:' . $prop)) {
-            return true;
-        }
-        return false;
+        $xlLabel = $this->getXlLabel();
+        return ($xlLabel !== null && !empty($xlLabel->getProperties()));
     }
 
     public function getXlLabel()

--- a/model/ConceptPropertyValueLiteral.php
+++ b/model/ConceptPropertyValueLiteral.php
@@ -87,9 +87,8 @@ class ConceptPropertyValueLiteral extends VocabularyDataObject
 
     public function hasXlProperties()
     {
-        $graph = $this->resource->getGraph();
-        $resources = $graph->resourcesMatching('skosxl:literalForm', $this->literal);
-        return !empty($resources);
+        $xlLabel = $this->getXlLabel();
+        return ($xlLabel !== null && !empty($xlLabel->getProperties()));
     }
 
     public function getXlLabel()

--- a/model/LabelSkosXL.php
+++ b/model/LabelSkosXL.php
@@ -24,8 +24,11 @@ class LabelSkosXL extends DataObject
         $ret = array();
         $props = $this->resource->properties();
         foreach($props as $prop) {
-            if ($prop !== 'skosxl:prefLabel') {
-                $ret[$prop] = $this->resource->get($prop);
+            if ($prop !== 'rdf:type' && $prop !== 'skosxl:literalForm') {
+                // make sure to use the correct gettext keys for DC namespace
+                $propkey = str_starts_with($prop, 'dc11:') ?
+                    str_replace('dc11:', 'dc:', $prop) : $prop;
+                $ret[$propkey] = $this->resource->get($prop);
             }
         }
         return $ret;

--- a/tests/ConceptPropertyValueLiteralTest.php
+++ b/tests/ConceptPropertyValueLiteralTest.php
@@ -200,7 +200,7 @@ public function testGetLabelForDatatypeIfNull() {
       {
         $reified_vals = $val->getXlLabel()->getProperties();
       }
-    $this->assertArrayHasKey('skosxl:literalForm', $reified_vals);
+    $this->assertArrayNotHasKey('skosxl:literalForm', $reified_vals);
     $this->assertArrayHasKey('skosxl:labelRelation', $reified_vals);
   }
 }

--- a/tests/ConceptTest.php
+++ b/tests/ConceptTest.php
@@ -636,4 +636,47 @@ class ConceptTest extends PHPUnit\Framework\TestCase
     $modifiedDate = $concept->getModifiedDate();
     $this->assertEquals(new DateTime("2014-10-01T16:29:03+00:00"), $modifiedDate);
   }
+
+  /**
+   * @covers Concept::hasXlLabel
+   */
+  public function testHasXlLabelTrue() {
+    $vocab = $this->model->getVocabulary('xl');
+    $concept = $vocab->getConceptInfo('http://www.skosmos.skos/xl/c1', 'en')[0];
+    $this->assertTrue($concept->hasXlLabel());
+  }
+
+  /**
+   * @covers Concept::hasXlLabel
+   */
+  public function testHasXlLabelFalse() {
+    $vocab = $this->model->getVocabulary('test');
+    $concept = $vocab->getConceptInfo('http://www.skosmos.skos/test/ta111', 'en')[0];
+    $this->assertFalse($concept->hasXlLabel());
+  }
+
+  /**
+   * @covers Concept::getXlLabel
+   * @covers LabelSkosXL::getProperties
+   */
+  public function testGetXlLabel() {
+    $vocab = $this->model->getVocabulary('xl');
+    $concept = $vocab->getConceptInfo('http://www.skosmos.skos/xl/c1', 'en')[0];
+    $label = $concept->getXlLabel();
+    $props = $label->getProperties();
+    $this->assertArrayHasKey('skosxl:labelRelation', $props);
+    $this->assertArrayHasKey('dc:modified', $props);
+    $this->assertArrayNotHasKey('skosxl:literalForm', $props);
+    $this->assertArrayNotHasKey('rdf:type', $props);
+  }
+
+  /**
+   * @covers Concept::getXlLabel
+   */
+  public function testGetXlLabelNull() {
+    $vocab = $this->model->getVocabulary('test');
+    $concept = $vocab->getConceptInfo('http://www.skosmos.skos/test/ta111', 'en')[0];
+    $this->assertNull($concept->getXlLabel());
+  }
+
 }

--- a/view/concept-shared.twig
+++ b/view/concept-shared.twig
@@ -69,11 +69,9 @@
         </span>
         <div class="reified-tooltip">
           {% for key, val in concept.xlLabel.properties %}
-            {% if key != 'rdf:type' and key != 'skosxl:literalForm' %}
             <p>{{ key|trans }}:
               <span class="versal">{{ val }}</span>
             </p>
-            {% endif %}
           {% endfor %}
         </div>
         <span class="prefLabel" id="pref-label">{{ concept.xlLabel }}</span>
@@ -150,11 +148,9 @@
                   <span class="reified-property-value xl-label"><img alt="{{ "Information" | trans }}" src="resource/pics/about.png"></span>
                     <div class="reified-tooltip">
                     {% for key, val in propval.xlLabel.properties %}
-                      {% if key != 'rdf:type' and key != 'skosxl:literalForm' %}
                       <p>{{ key|trans }}:
                         <span class="versal">{{ val }}</span>
                       </p>
-                      {% endif %}
                     {% endfor %}
                     </div>
                   {% endif %}


### PR DESCRIPTION
## Reasons for creating this PR

This PR changes the way SKOS XL data for labels is handled. The old code expected that if a concept has _some_ SKOS XL labels, it will have SKOS XL data for **all** labels. This isn't the case in current YSO where SKOS XL information is added only for a small number of labels. This PR makes the checks for SKOS XL data more careful. Result now looks like this (compare with issue #1346):

![image](https://user-images.githubusercontent.com/1132830/188806937-304c729b-2ca4-448b-b96b-c34267a7f376.png)

## Link to relevant issue(s), if any

- Closes #1346

## Description of the changes in this PR

* Concept.hasXlLabel() and ConceptPropertyValueLiteral.hasXlLabel() methods changed to be more specific so that they only return `true` when there is non-trivial SKOS XL data available specifically for that concept (prefLabel) / literal value
* some logic (filtering of trivial properties `rdf:type` and `skosxl:literalForm`) moved from Twig templates to PHP code
* use `dc:` namespace for gettext lookups for properties in the `dc11:` namespace also for properties of SKOS XL Labels (this is already done for e.g. regular properties on concepts and it fixes issues displaying the correct labels for Dublin Core metadata)

## Known problems or uncertainties in this PR

* when displaying properties of SKOS XL labels with literal values (e.g. `dc:source "Kansalliskirjasto"@fi` in above screenshot), there is no mechanism for trying to find and select the value with the correct language tag; so if there were many similar values in different languages, only one of them would be shown
* I noticed that if I hover over the "info" symbol many times, eventually the tooltip will become empty; this could be a bug in qtip2 but it should go a way if/when we replace it with CSS (see PR #1324)

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
