### PR TITLE
Use the --font-size variable for versal, and set width: auto for the restore-breadcrumbs link

### DIFF
--- a/resource/css/styles.css
+++ b/resource/css/styles.css
@@ -1627,11 +1627,13 @@ li.sub-group {
 
 .restore-breadcrumbs {
   background-color: var(--white-color);
-  float: right;
+  width: auto;
+  position: absolute;
+  right: 0;
+  display: inline;
 }
 
 .crumb-path {
-  float:left;
   width: 100%;
 }
 
@@ -1646,6 +1648,7 @@ li.sub-group {
 
 .concept-main > .row, .concept-appendix > .row {
   padding-top: 5px;
+  position: relative;
 }
 
 .concept-main > .row > .property-value-column {
@@ -2359,7 +2362,7 @@ body, .versal, h1, h2, h3, p, .versal-bold {
   }
 
   .concept-main > .row, .concept-appendix > .row {
-    padding-top: 0px;
+    padding-top: 0;
   }
 
   .row:nth-of-type(2) > .property-value-column {
@@ -2679,7 +2682,7 @@ body, .versal, h1, h2, h3, p, .versal-bold {
   }
 
   .alphabetical-search-results li, li, .versal, .versal-bold, p, .autocomplete-label, .search-result > .prefLabel, .search-result > .notation, .property-values > .prefLabel, td > a {
-    font-size: 16px;
+    font-size: var(--font-size);
   }
 
   .search-result > div > span.uri-input-box {

--- a/resource/js/scripts.js
+++ b/resource/js/scripts.js
@@ -250,6 +250,9 @@ function hideCrumbs() {
       $($crumbs[i]).addClass('hidden-path');
     }
     if ($('.restore-breadcrumbs').length === 0) {
+      // We attach the link to display all breadcrumbs after the zero-th element
+      // to force the browser to re-arrange the elements. If we moved that to the
+      // bottom, then we wouldn't have an easy way to re-arrange it at the top.
       $($crumbs[0]).after('<a class="versal restore-breadcrumbs" href="#">[' + expand_paths.replace('#',($crumbs.length)) + ']</a>');
     }
   }


### PR DESCRIPTION
## Reasons for creating this PR

Wrong formatting for the link to show more breadcrumbs.

## Link to relevant issue(s), if any

- Closes #1355 

## Description of the changes in this PR

## Known problems or uncertainties in this PR

## Checklist

- [x] phpUnit tests pass locally with my changes
- [ ] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
