### PR TITLE
Add failure message explaining how to fix Composer/git version mismatch

### DIFF
--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -38,7 +38,9 @@ class ModelTest extends PHPUnit\Framework\TestCase
     // make sure that the returned version (which comes from composer.json)
     // matches the version from git tags
     $git_tag = rtrim(shell_exec('git describe --tags --always'));
-    $this->assertStringStartsWith("v" . $version, $git_tag);
+    $this->assertStringStartsWith("v" . $version, $git_tag,
+      "Composer version '$version' doesn't match git tag '$git_tag'.\n" .
+      "Please run 'composer update' to update the Composer version.");
   }
 
   /**


### PR DESCRIPTION
## Reasons for creating this PR

ModelTest.testGetVersion() (added in PR #1308 which moved the version information to Composer) was failing for me when I ran it locally. It turned out that I hadn't run `composer update` in a while, but the reason wasn't obvious at first. This PR adds a helpful failure message to the test explaining how to fix it (run composer update).

## Link to relevant issue(s), if any

- Follow-up improvement for #1308

## Description of the changes in this PR

Add failure message when there is a version mismatch, like this:

```
There was 1 failure:

1) ModelTest::testGetVersion
Composer version '2.15-dev' doesn't match git tag 'v2.16-dev-4-g5e6da4b3'.
Please run 'composer update' to update the Composer version.
Failed asserting that 'v2.16-dev-4-g5e6da4b3' starts with "v2.15-dev".

/var/www/html/Skosmos/tests/ModelTest.php:43
```


## Known problems or uncertainties in this PR

none

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
