### PR TITLE
fix display of DC properties in reified property value tooltips

### DIFF
--- a/model/ConceptPropertyValue.php
+++ b/model/ConceptPropertyValue.php
@@ -158,13 +158,15 @@ class ConceptPropertyValue extends VocabularyDataObject
         $props = $this->resource->propertyUris();
         foreach($props as $prop) {
             $prop = (EasyRdf\RdfNamespace::shorten($prop) !== null) ? EasyRdf\RdfNamespace::shorten($prop) : $prop;
+            $propkey = str_starts_with($prop, 'dc11:') ?
+                str_replace('dc11:', 'dc:', $prop) : $prop;
             foreach ($this->resource->allLiterals($prop) as $val) {
                 if ($prop !== 'rdf:value') { // shown elsewhere
-                    $ret[gettext($prop)] = new ConceptPropertyValueLiteral($this->model, $this->vocab, $this->resource, $val, $prop);
+                    $ret[gettext($propkey)] = new ConceptPropertyValueLiteral($this->model, $this->vocab, $this->resource, $val, $prop);
                 }
             }
             foreach ($this->resource->allResources($prop) as $val) {
-                $ret[gettext($prop)] = new ConceptPropertyValue($this->model, $this->vocab, $val, $prop, $this->clang);
+                $ret[gettext($propkey)] = new ConceptPropertyValue($this->model, $this->vocab, $val, $prop, $this->clang);
             }
         }
         return $ret;

--- a/tests/ConceptPropertyValueTest.php
+++ b/tests/ConceptPropertyValueTest.php
@@ -177,5 +177,9 @@ class ConceptPropertyValueTest extends PHPUnit\Framework\TestCase
     $val = reset($vals);
     $reified_vals = $val->getReifiedPropertyValues();
     $this->assertCount(2, $reified_vals);
+    $this->assertArrayHasKey('Source', $reified_vals);
+    $this->assertEquals('https://en.wikipedia.org/wiki/Concept', $reified_vals['Source']->getLabel());
+    $this->assertArrayHasKey('Last modified', $reified_vals);
+    $this->assertEquals('4/13/18', $reified_vals['Last modified']->getLabel());
   }
 }

--- a/tests/test-vocab-data/xl.ttl
+++ b/tests/test-vocab-data/xl.ttl
@@ -1,5 +1,6 @@
 @prefix xl: <http://www.skosmos.skos/xl/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix dc: <http://purl.org/dc/elements/1.1/>.
 @prefix dct: <http://purl.org/dc/terms/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
@@ -25,4 +26,4 @@ xl:l2 a skosxl:Label ;
 xl:d1
     rdf:value "Unit of thought"@en ;
     dct:modified "2018-04-13T10:29:03+00:00"^^xsd:dateTime ;
-    dct:source <https://en.wikipedia.org/wiki/Concept> .
+    dc:source <https://en.wikipedia.org/wiki/Concept> .


### PR DESCRIPTION
## Reasons for creating this PR

While doing review for PR #1324 , I noticed that Dublin Core properties are wrongly displayed for reified property values (e.g. skos:description with a resource value that has attached DC properties).

## Link to relevant issue(s), if any

- similar to a fix already made for SKOS XL properties in #1356 

## Description of the changes in this PR

* make sure that a gettext key like dc:something is used also for properties in the old DC elements 1.1 namespace (which EasyRdf shortens as dc11:)
* add more careful checks to the unit test for ConceptPropertyValue.getReifiedPropertyValues()

Result looks like this:
![image](https://user-images.githubusercontent.com/1132830/190635494-d85fffc0-caa8-49ce-8546-c4a21e58554d.png)

(before this PR, the text was `dc11:source: internet`)

## Known problems or uncertainties in this PR

The tooltip has wrong colors, but that's out of scope for this PR.

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
