### PR TITLE
Remove jQuery UI dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,6 @@
   },
   "require": {
     "components/jquery": "3.6.*",
-    "components/jqueryui": "1.12.*",
     "components/handlebars.js": "v4.7.7",
     "davidstutz/bootstrap-multiselect": "v1.1.1",
     "easyrdf/easyrdf": "1.1.*",

--- a/view/light.twig
+++ b/view/light.twig
@@ -4,7 +4,6 @@
 <base href="{{ BaseHref }}">
 <link rel="shortcut icon" href="favicon.ico">
 {% include 'meta.twig' %}
-<link href="vendor/components/jqueryui/themes/cupertino/jquery-ui.min.css" media="screen, print" rel="stylesheet" type="text/css">
 <link href="vendor/twbs/bootstrap/dist/css/bootstrap.min.css" media="screen, print" rel="stylesheet" type="text/css">
 <link href="vendor/vakata/jstree/dist/themes/default/style.min.css" media="screen, print" rel="stylesheet" type="text/css">
 <link href="vendor/davidstutz/bootstrap-multiselect/dist/css/bootstrap-multiselect.min.css" media="screen, print" rel="stylesheet" type="text/css">

--- a/view/scripts.twig
+++ b/view/scripts.twig
@@ -53,7 +53,6 @@ var pluginParameters = {{ plugin_params|raw }};
 </script>
 <script src="vendor/components/jquery/jquery.min.js"></script>
 <script src="https://code.jquery.com/jquery-migrate-3.4.0.js"></script>
-<script src="vendor/components/jqueryui/jquery-ui.min.js"></script>
 <script src="vendor/components/handlebars.js/handlebars.min.js"></script>
 <script src="vendor/vakata/jstree/dist/jstree.min.js"></script>
 <script src="vendor/twitter/typeahead.js/dist/typeahead.bundle.min.js"></script>


### PR DESCRIPTION
## Reasons for creating this PR

The jQuery Migrate plugins prints deprecation warnings about jQuery UI. We are currently using jQuery UI 1.12.1.

It would be possible to upgrade to jQuery UI 1.13.x, but it is not available via Packagist / Composer.

But it turns out we're not actually using any(?) functionality of jQuery UI. It was probably used in the past, but since then, UI widgets have been rewritten using other libraries. So this PR simply removes jQuery UI.

## Link to relevant issue(s), if any

- related to #1151

## Description of the changes in this PR

* drop jQuery UI dependency in composer.json
* drop references to jQuery UI JS and CSS files from HTML templates

## Known problems or uncertainties in this PR

Not 100% sure there isn't some functionality that is still based on jQuery UI that I just didn't find.

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
