### PR TITLE
upgrade Twig to 2.15.3 or newer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     "easyrdf/easyrdf": "1.1.*",
     "etdsolutions/waypoints": "4.0.0",
     "symfony/polyfill-php80": "1.*",
-    "twig/twig": "2.14.*",
+    "twig/twig": "^2.15.3",
     "twig/extensions": "1.5.*",
     "twbs/bootstrap": "5.1.*",
     "twitter/typeahead.js": "v0.11.*",


### PR DESCRIPTION
## Reasons for creating this PR

Dependabot complains about a potential security issue in Twig <2.15.3. This PR upgrades Twig to `^2.15.3` (meaning: 2.15.3 or newer, but must still be 2.15)

AFAICT, the security issue doesn't really affect us, as we're not using templates where the name is derived from user input. But it's better to be sure and to get rid of warnings from vulnerability scanning tools.

## Link to relevant issue(s), if any

- Closes [#3](https://github.com/NatLibFi/Skosmos/security/dependabot/3)

## Description of the changes in this PR

* upgrade to Twig 2.15.3

## Known problems or uncertainties in this PR

n/a

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
