### PR TITLE
Tooltips are now conditional on the hierarchy

### DIFF
--- a/view/changes.twig
+++ b/view/changes.twig
@@ -12,7 +12,10 @@
     {% endif %}
     <h3 class="sr-only">{% trans "List vocabulary concepts hierarchically" %}</h3>
     {% if active_tab == 'hierarchy' %}{% set css_class = css_class|merge(['active']) %}{% endif %}
-    <li id="hierarchy{% if not vocab.config.showHierarchy %}-disabled{% endif %}" class="nav-item"><a class="{{ css_class|join(' ') }} skosmos-tooltip-wrapper skosmos-tooltip t-bottom" href="#" id="hier-trigger"{% if not vocab.config.showHierarchy %} data-title="{% trans 'hierarchy-disabled-help' %}"{% endif %}>{% trans "Hier-nav" %}</a></li>
+    {% if not vocab.config.showHierarchy %}
+      {% set css_class = css_class|merge(['skosmos-tooltip-wrapper', 'skosmos-tooltip', 't-bottom']) %}
+    {%  endif %}
+    <li id="hierarchy{% if not vocab.config.showHierarchy %}-disabled{% endif %}" class="nav-item"><a class="{{ css_class|join(' ') }}" href="#" id="hier-trigger"{% if not vocab.config.showHierarchy %} data-title="{% trans 'hierarchy-disabled-help' %}"{% endif %}>{% trans "Hier-nav" %}</a></li>
     {% if vocab.config.groupClassURI %}
     {% set css_class = ['nav-link'] %}
     <h3 class="sr-only">{% trans "List vocabulary concepts and groupings hierarchically" %}</h3>

--- a/view/group-contents.twig
+++ b/view/group-contents.twig
@@ -13,7 +13,10 @@
     <li id="alpha" class="nav-item"><a class="{{ css_class|join(' ') }}" href="{{ request.vocabid }}/{{ request.lang }}/index{% if request.contentLang != request.lang %}?clang={{ request.contentLang }}{% endif %}">{% if vocab.config.showChangeList and vocab.config.groupClassURI %}{% trans 'A-Z' %}{% else %}{% trans "Alpha-nav" %}{% endif %}</a></li>
     {% endif %}
     <h3 class="sr-only">{% trans "List vocabulary concepts hierarchically" %}</h3>
-    <li id="hierarchy{% if not vocab.config.showHierarchy %}-disabled{% endif %}" class="nav-item"><a class="{{ css_class|join(' ') }} skosmos-tooltip-wrapper skosmos-tooltip t-bottom" href="#" id="hier-trigger"{% if not vocab.config.showHierarchy %} data-title="{% trans 'hierarchy-disabled-help' %}"{% endif %}>{% trans "Hier-nav" %}</a></li>
+    {% if not vocab.config.showHierarchy %}
+      {% set css_class = css_class|merge(['skosmos-tooltip-wrapper', 'skosmos-tooltip', 't-bottom']) %}
+    {%  endif %}
+    <li id="hierarchy{% if not vocab.config.showHierarchy %}-disabled{% endif %}" class="nav-item"><a class="{{ css_class|join(' ') }}" href="#" id="hier-trigger"{% if not vocab.config.showHierarchy %} data-title="{% trans 'hierarchy-disabled-help' %}"{% endif %}>{% trans "Hier-nav" %}</a></li>
     {% if vocab.config.groupClassURI %}
     <h3 class="sr-only">{% trans "List vocabulary concepts and groupings hierarchically" %}</h3>
     {% if search_results|first.isGroup %}{% set css_class = css_class|merge(['active']) %}{% endif %}

--- a/view/group-index.twig
+++ b/view/group-index.twig
@@ -12,7 +12,10 @@
     <li id="alpha" class="nav-item"><a class="{{ css_class|join(' ') }}" href="{{ request.vocabid }}/{{ request.lang }}/index{% if request.contentLang != request.lang %}?clang={{ request.contentLang }}{% endif %}">{% if vocab.config.showChangeList and vocab.config.groupClassURI %}{% trans 'A-Z' %}{% else %}{% trans "Alpha-nav" %}{% endif %}</a></li>
     {% endif %}
     <h3 class="sr-only">{% trans "List vocabulary concepts hierarchically" %}</h3>
-    <li id="hierarchy{% if not vocab.config.showHierarchy %}-disabled{% endif %}" class="nav-item"><a class="{{ css_class|join(' ') }} skosmos-tooltip-wrapper skosmos-tooltip t-bottom" href="#" id="hier-trigger"{% if not vocab.config.showHierarchy %} data-title="{% trans 'hierarchy-disabled-help' %}"{% endif %}>{% trans "Hier-nav" %}</a></li>
+    {% if not vocab.config.showHierarchy %}
+      {% set css_class = css_class|merge(['skosmos-tooltip-wrapper', 'skosmos-tooltip', 't-bottom']) %}
+    {%  endif %}
+    <li id="hierarchy{% if not vocab.config.showHierarchy %}-disabled{% endif %}" class="nav-item"><a class="{{ css_class|join(' ') }}" href="#" id="hier-trigger"{% if not vocab.config.showHierarchy %} data-title="{% trans 'hierarchy-disabled-help' %}"{% endif %}>{% trans "Hier-nav" %}</a></li>
     {% if vocab.config.groupClassURI %}
     <h3 class="sr-only">{% trans "List vocabulary concepts and groupings hierarchically" %}</h3>
     {% set css_class = css_class|merge(['active']) %}

--- a/view/light.twig
+++ b/view/light.twig
@@ -51,10 +51,13 @@
           {% endif %}
           {% set css_class = ['nav-link'] %}
           {% set disabledHierarchy = not vocab.config.showHierarchy and not search_results|length == 1 %}
+          {%  if disabledHierarchy %}
+            {% set css_class = css_class|merge(['skosmos-tooltip-wrapper', 'skosmos-tooltip', 't-bottom']) %}
+          {%  endif %}
           <h3 class="sr-only">{% trans "List vocabulary concepts hierarchically" %}</h3>
           {% if search_results|length == 1 and not term %}{% set css_class = css_class|merge(['active']) %}{% endif %}
           <li id="hierarchy{%- if disabledHierarchy %}-disabled{% endif -%}" class="nav-item">
-            <a class="{{ css_class|join(' ') }} skosmos-tooltip-wrapper skosmos-tooltip t-bottom" href="#" id="hier-trigger"
+            <a class="{{ css_class|join(' ') }}" href="#" id="hier-trigger"
             {% if disabledHierarchy%} data-title="{% trans 'hierarchy-disabled-help' %}"{% endif %}
             >{% trans "Hier-nav" %}
             </a>

--- a/view/vocab.twig
+++ b/view/vocab.twig
@@ -15,7 +15,10 @@
     <h3 class="sr-only">{% trans "List vocabulary concepts hierarchically" %}</h3>
     {% set css_class = ['nav-link'] %}
     {% if active_tab == 'hierarchy' %}{% set css_class = css_class|merge(['active']) %}{% endif %}
-    <li id="hierarchy{% if not vocab.config.showHierarchy %}-disabled{% endif %}" class="nav-item"><a class="{{ css_class|join(' ') }} skosmos-tooltip-wrapper skosmos-tooltip t-bottom" href="#" id="hier-trigger"{% if not vocab.config.showHierarchy %} data-title="{% trans 'hierarchy-disabled-help' %}"{% endif %}>{% trans "Hier-nav" %}</a></li>
+    {% if not vocab.config.showHierarchy %}
+      {% set css_class = css_class|merge(['skosmos-tooltip-wrapper', 'skosmos-tooltip', 't-bottom']) %}
+    {%  endif %}
+    <li id="hierarchy{% if not vocab.config.showHierarchy %}-disabled{% endif %}" class="nav-item"><a class="{{ css_class|join(' ') }}" href="#" id="hier-trigger"{% if not vocab.config.showHierarchy %} data-title="{% trans 'hierarchy-disabled-help' %}"{% endif %}>{% trans "Hier-nav" %}</a></li>
     {% if vocab.config.groupClassURI %}
     <h3 class="sr-only">{% trans "List vocabulary concepts and groupings hierarchically" %}</h3>
     <li id="groups" class="nav-item"><a class="{{ css_class|join(' ') }}" href="{{ request.vocabid }}/{{ request.lang }}/groups{% if request.contentLang != request.lang %}?clang={{ request.contentLang }}{% endif %}">{% trans "Group-nav" %}</a></li>


### PR DESCRIPTION
## Reasons for creating this PR

## Link to relevant issue(s), if any

- Addresses https://github.com/NatLibFi/Skosmos/pull/1324#issuecomment-1266708112

## Description of the changes in this PR

Hierarchy is not always available. When it is not, we want to display a tooltip with a warning/note about it. However, the tooltips were always enabled, causing an empty tooltip sometimes.

## Known problems or uncertainties in this PR

Hard to test. I looked at the previous modified files in the linked PR, then repeated the same fix. Tested on Firefox with the :hover modified on the hierarchy tab. In one case the tooltip is displayed as hierarchy is disabled, and in the other nothing is shown.

![image](https://user-images.githubusercontent.com/304786/193801948-03d34525-b238-42ca-b8d3-b2656574f11b.png)
![image](https://user-images.githubusercontent.com/304786/193801988-428a90e3-1601-4e9d-9dac-23c182639d99.png)


Hopefully that fixes the issue. Sorry!

## Checklist

- [x] phpUnit tests pass locally with my changes
- [ ] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
