### PR TITLE
fix auto-scrolling and highlighting current concept in hierarchy

### DIFF
--- a/resource/js/hierarchy.js
+++ b/resource/js/hierarchy.js
@@ -36,19 +36,13 @@ function invokeParentTree(tree) {
     // TODO: a good fix would mean fixing the underlying DOM structure
     $('.jstree-container-ul').parent().addClass('jstree-default');
 
+    var $leafProper = $('.jstree-leaf-proper');
+    if ($leafProper.length > 0) {
+      var $sidebarGrey = $(".sidebar-grey");
+      $sidebarGrey.jstree('select_node', $leafProper.toArray());
+      $leafProper[0].scrollIntoView({block: 'center', behavior: 'smooth'});
+    }
   });
-}
-  
-function getLeafOffset() {
-  var containerHeight = $('.sidebar-grey').height();
-  var conceptCount = Math.floor((containerHeight * 0.66) / 18);
-  var scrollAmount = 18 * conceptCount;
-  var $leafProper = $('.jstree-leaf-proper');
-  if ($leafProper.length) {
-    var newOffset = $leafProper[0].offsetTop-scrollAmount;
-    if (newOffset > 0) // only scrolls the view if the concept isn't already at the top.
-      return newOffset;
-  }
 }
 
 function getLabel(object) {


### PR DESCRIPTION
## Reasons for creating this PR

The custom scrollbar implementation was removed in PR #1360. But the PR also removed some functionality from the hierarchy tree: highlighting the current concept and automatically scrolling so that the current concept (or at least one of the places where it appears) is visible. This PR restores those functionalities. It also cleans up some leftover JS code.

## Link to relevant issue(s), if any

- Follow-up fix to #1360

## Description of the changes in this PR

* select the active node(s) in the hierachy after the page has loaded
* automatically scroll the hierarchy display so that the active node is visible and centered (this is now done using the standard [Element.scrollIntoView](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView) method instead of using mCustomScrollbar methods)
* remove the getLeafOffset method that was used by the previous scrolling method but is now unnecessary

## Known problems or uncertainties in this PR

The auto-scrolling now works a bit differently than in 2.15: it may not scroll exactly the same amount, and the scrolling is smooth instead of instant. I like the smooth scrolling better but this can be easily disabled by adjusting the `behavior` option of `scrollIntoView`.

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)