### PR TITLE
scroll hierarchy to selected concept instead of children

### DIFF
--- a/resource/js/hierarchy.js
+++ b/resource/js/hierarchy.js
@@ -40,7 +40,7 @@ function invokeParentTree(tree) {
     if ($leafProper.length > 0) {
       var $sidebarGrey = $(".sidebar-grey");
       $sidebarGrey.jstree('select_node', $leafProper.toArray());
-      $leafProper[0].scrollIntoView({block: 'center', behavior: 'smooth'});
+      $leafProper.find('span')[0].scrollIntoView({block: 'center', behavior: 'smooth'});
     }
   });
 }


### PR DESCRIPTION
## Reasons for creating this PR

Follow-up fix to #1372. The scrolling was off if the concept has many descendants in the hierarchy. This PR adjusts the selector so that the scrolling ends up in the right position.

## Link to relevant issue(s), if any

- follow-up to #1372 and #1360

## Description of the changes in this PR

* adjust jQuery selector used to determine auto-scroll position
 
## Known problems or uncertainties in this PR

n/a

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
