### PR TITLE
Refactor sorting code for hierarchical and groups tabs

### DIFF
--- a/resource/js/docready.js
+++ b/resource/js/docready.js
@@ -428,25 +428,29 @@ $(function() { // DOCUMENT READY
   $(document).on('click','div.group-hierarchy a',
       function(event) {
         $.ajaxQ.abortContentQueries();
+        var targetUrl = event.target.href || event.target.parentElement.href;
+        $('#hier-trigger').attr('href', targetUrl);
         var $content = $('.content').empty().append($delayedSpinner.hide());
         var loading = delaySpinner();
         // ajaxing the sidebar content
         $.ajax({
-            url : event.target.href,
+            url : targetUrl,
             req_kind: $.ajaxQ.requestKind.CONTENT,
+
             complete: function() { clearTimeout(loading); },
             success : function(data) {
+              $content.empty();
+              var response = $('.content', data).html();
+              if (window.history.pushState) { window.history.pushState({url: targetUrl}, '', targetUrl); }
               initHierarchyTooltip();
-              $('#hier-trigger').attr('href', event.target.href);
+              $content.append(response);
+              updateJsonLD(data);
               updateTitle(data);
               updateTopbarLang(data);
-              $content.empty().append($('.content', data).html());
-              $('.nav').scrollTop(0);
-              if (window.history.pushState) { window.history.pushState({}, null, event.target.href); }
-              updateTitle(data);
               ajaxConceptMapping(data);
               // take the content language buttons from the response
               $('.header-float .dropdown-menu').empty().append($('.header-float .dropdown-menu', data).html());
+              $('.nav').scrollTop(0);
             }
         });
         return false;

--- a/resource/js/groups.js
+++ b/resource/js/groups.js
@@ -52,7 +52,7 @@ function invokeGroupTree() {
 
   $treeObject.jstree({
     'plugins' : ['sort'],
-    'sort' : function (a,b) { return naturalCompare(this.get_text(a).toLowerCase(), this.get_text(b).toLowerCase()); },
+    'sort' : hierarchySort,
     'core' : { 
       'data' : 
         function(node, cb) { 
@@ -69,12 +69,19 @@ function invokeGroupTree() {
                 var children = [];
                 for (var i in response.members) {
                   var member = response.members[i];
-                  var child = {'text' : member.prefLabel,'parent' : node.a_attr['data-uri'], children : false, a_attr : { 'data-uri' : member.uri, "href" : getHrefForUri(member.uri, true) }};
+                  var child = {
+                    text: getLabel(member),
+                    label: pickLabel(member),
+                    parent: node.a_attr['data-uri'],
+                    notation: member.notation,
+                    children: false,
+                    a_attr: {
+                      'data-uri': member.uri,
+                      "href": getHrefForUri(member.uri, true)
+                    }
+                  };
                   if (member.hasMembers || member.isSuper) {
                     child.children = true;
-                  }
-                  if (showNotation && member.notation) {
-                    child.text = '<span class="tree-notation">' + member.notation + '</span> ' + child.text;
                   }
                   children.push(JSON.parse(JSON.stringify(child)));
                 }
@@ -91,12 +98,19 @@ function invokeGroupTree() {
 }
 
 function createGroupNode(uri, groupObject) {
-  var node = {children : [], a_attr : {'data-uri' : uri, "href" : getHrefForUri(uri, true), "class" : "group" }};
-  node.text = groupObject.prefLabel;
+  var node = {
+    text: getLabel(groupObject),
+    label: pickLabel(groupObject),
+    notation: groupObject.notation,
+    children: [],
+    a_attr: {
+      'data-uri': uri,
+      "href": getHrefForUri(uri, true),
+      "class": "group"
+    }
+  };
   if (groupObject.hasMembers || groupObject.isSuper)
     node.children = true;
-  if (showNotation && groupObject.notation)
-    node.text = '<span class="tree-notation">' + groupObject.notation + '</span> ' + node.text;
   return node;
 }
 

--- a/resource/js/hierarchy.js
+++ b/resource/js/hierarchy.js
@@ -45,17 +45,6 @@ function invokeParentTree(tree) {
   });
 }
 
-function getLabel(object) {
-  var labelProp = 'prefLabel';
-  if (!object.prefLabel) {
-    labelProp = 'label';
-  }
-  if (window.showNotation && object.notation) {
-    return '<span class="tree-notation">' + object.notation + '</span> <span class="tree-label">' + escapeHtml(object[labelProp]) + '</span>';
-  }
-  return '<span class="tree-label">' + escapeHtml(object[labelProp]) + '</span>';
-}
-
 function createObjectsFromChildren(conceptData, conceptUri) {
   var childArray = [];
   for (var i = 0; i < conceptData.narrower.length; i++) {
@@ -258,17 +247,6 @@ function getParams(node) {
   return $.param({'uri' : nodeId, 'lang' : clang});
 }
 
-function pickLabel(entity) {
-  var label = '';
-  if (entity.prefLabel)
-    label = entity.prefLabel;
-  else if (entity.label)
-    label = entity.label;
-  else if (entity.title)
-    label = entity.title;
-  return label;
-}
-
 function schemeRoot(schemes) {
   var topArray = [];
 
@@ -407,19 +385,6 @@ function topConceptsToSchemes(topConcepts, schemes) {
   return childArray;
 }
 
-/*
- * Return a sort key suitable for sorting hierarchy nodes mainly by label.
- * Nodes with domain class will be sorted first, followed by non-domain nodes.
- */
-function nodeLabelSortKey(node) {
-  // make sure the tree nodes with class 'domain' are sorted before the others
-  // domain will be "0" if the node has a domain class, else "1"
-  var domain = (node.original.a_attr['class'] == 'domain') ? "0" : "1";
-  var label = node.original.label.toLowerCase();
-
-  return domain + " " + label;
-}
-
 /* 
  * Gives you the Skosmos default jsTree configuration.
  */
@@ -500,36 +465,7 @@ function getTreeConfiguration() {
         }
     },
     'plugins' : ['sort'],
-    'sort' : function (a,b) {
-        var aNode = this.get_node(a);
-        var bNode = this.get_node(b);
-
-        // sort on notation if requested, and notations exist
-        if (window.sortByNotation) {
-            var aNotation = aNode.original.notation;
-            var bNotation = bNode.original.notation;
-
-            if (aNotation) {
-                if (bNotation) {
-                    if (window.sortByNotation == "lexical") {
-                        if (aNotation < bNotation) {
-                            return -1;
-                        }
-                        else if (aNotation > bNotation) {
-                            return 1;
-                        }
-                    } else { // natural
-                        return naturalCompare(aNotation, bNotation);
-                    }
-                }
-                else return -1;
-            }
-            else if (bNotation) return 1;
-            // NOTE: if no notations found, fall back on label comparison below
-        }
-        // no sorting on notation requested, or notations don't exist
-        return naturalCompare(nodeLabelSortKey(aNode), nodeLabelSortKey(bNode));
-    }
+    'sort' : hierarchySort
   });
 }
 


### PR DESCRIPTION
## Reasons for creating this PR
Tackling issues described in #1390 
## Link to relevant issue(s), if any
- Closes #1390 
## Description of the changes in this PR
This PR changes the code base via refactoring as some methods (namely: getLabel, pickLabel, nodeLabelSortKey, hierarchySort) and their respective code lines have been transferred from `hierarchy.js` to `scripts.js` so that they can be utilized in both `hierarchy.js`and `groups.js`.

Additional changes were made to how `$(document).on('click','div.group-hierarchy a', ...` (clicking groups) was handled as there were apparent issues that stood out whilst testing the now-refactored code. A careful research and comparison with `  $(document).on('click', '.concept-hierarchy a',` (clicking the hierarchy concepts) revealed that the code for clicking groups lacked some features the more-tested clicking hierarchy concepts had so I added them - now the jsTree hiearchy in groups tab seems to be working as expected.
## Known problems or uncertainties in this PR
I noticed that autocomplete shows notation codes even after applying `skosmos:showNotation "false"` setting and this is how it is working in https://finto.fi/yso-aika/fi/. It may be OK for YSO-aika vocabulary, but for the vocabulary I am currently testing it certainly is not. However, fixing the aforementioned is out of the scope of this PR.
## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
