### PR TITLE
Adjust skosmos:showNotation setting to be obeyed in autocomplete dropdown

### DIFF
--- a/resource/js/docready.js
+++ b/resource/js/docready.js
@@ -665,6 +665,8 @@ $(function() { // DOCUMENT READY
             if (item.hiddenLabel && hasNonHiddenMatch[item.uri]) { return null; }
             // do not show the label language when it's same or in the same subset as the ui language.
             if (item.lang && (item.lang === qlang || item.lang.indexOf(qlang + '-') === 0)) { delete(item.lang); }
+            // do not show notation code if is not requested
+            if (false === window.showNotation && 'notation' in item) { delete(item.notation); }
             if (item.type) {
               var toBeRemoved = null;
               item.typeLabel = item.type;


### PR DESCRIPTION
## Reasons for creating this PR
Whilst working on #1380 (#1335), I noticed that the `skos:showNotation` setting is not respected in autocomplete dropdown. Whilst this is somewhat [documented](https://github.com/NatLibFi/Skosmos/wiki/Configuration), I dare to say it could make more sense to have this setting enabled more globally, e.g., also in the autocomplete dropdown, too (as in all other places it is already respected in such a way).
## Description of the changes in this PR
This PR simply does not show the notation code if it is required to be hidden via `skosmos:showNotation "false"` setting.
## Known problems or uncertainties in this PR
This changes the way autocomplete search results are shown in, e.g., https://dev.finto.fi/yso-aika/fi/. This change of behavior may be a problem for that vocabulary, for example, in which case there should be another setting for this use case. As @joelit has created this vocabulary, I will set him as the reviewer of this PR so that he can make a good review of this problem and PR.
## Checklist
- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
