### PR TITLE
Fix running git commands in CI tests under GitHub Actions

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -9,5 +9,12 @@ if (!$endpoint) {
     putenv('SKOSMOS_SPARQL_ENDPOINT=http://localhost:13030/skosmos-test/sparql');
 }
 
+# Allow running git commands in the php-actions/phpunit container
+# (prevent "dubious ownership" error; /app is owned by another user, not root)
+if (getenv('GITHUB_ACTIONS') === 'true' ) {
+  mkdir('/home/runner');
+  exec('git config --global --add safe.directory /app');
+}
+
 require_once(__DIR__ . '/../vendor/autoload.php');
 require_once(__DIR__ . '/../model/Model.php');


### PR DESCRIPTION
## Reasons for creating this PR

GitHub Actions CI builds are currently failing because some tests are executing git commands, but git refuses to run because of a "dubious ownership" error. The error happens because the PHPUnit tests are run within a container as the root user, but the /app directory is owned by another user (uid 1001).

Here is `whoami` under the container:

```
uid=0(root) gid=0(root) groups=0(root),1(bin),2(daemon),3(sys),4(adm),6(disk),10(wheel),11(floppy),20(dialout),26(tape),27(video)
```

Here is `ls -l /app`:

```
drwxr-xr-x   15 1001     ntp           4096 Dec 15 13:57 /app
```

## Link to relevant issue(s), if any

- Closes #1394

## Description of the changes in this PR

The PR fixes the problem by first creating the directory `/home/runner` which doesn't exist within the container, even though it is the value of the `HOME` environment variable. Then it executes the command `git config --global --add safe.directory /app`, which will prevent `git` from complaining about dubious ownership; this will be stored in the configuration file `/home/runner/.gitconfig` where subsequent git commands (run from PHPUnit tests) will see it.

## Known problems or uncertainties in this PR

n/a

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
