### PR TITLE
Increased table width to 600px

### DIFF
--- a/resource/css/styles.css
+++ b/resource/css/styles.css
@@ -1784,7 +1784,7 @@ tr.replaced-by > td > ul > li > a {
 
 #counts { max-width: 300px; }
 
-#statistics { max-width: 450px; }
+#statistics { max-width: 600px; }
 
 #statistics .property-divider, #counts .property-divider {
   margin: 0;


### PR DESCRIPTION
## Reasons for creating this PR

Some languages have longer names for the different labels used in SKOS. The label statistics table can run out of column width with the header texts wrapping over to a second row, for example in Northern-Sami.

## Link to relevant issue(s), if any

None.

## Description of the changes in this PR

Increase the label statistics table to 600px. This is in line with the vocabulary statistics being 300px with half the amount of columns.

## Known problems or uncertainties in this PR

None.

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [X] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
