### PR TITLE
Update BARTOC Skosmos URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@
         <h3 id="users">Examples of current users</h3>
         <ul>
           <li><a href="http://finto.fi/en/">Finto</a></li>
-          <li>Basel University Library <a href="https://bartoc-skosmos.unibas.ch/en/">BARTOC vocabularies</a></li>
+          <li>VZG / <a href="https://skosmos.bartoc.org/">BARTOC vocabularies</a></li>
           <li>CESSDA / <a href="https://thesauri.cessda.eu/elsst">ELLST thesaurus</a></li>
           <li>CNRS / <a href="https://www.loterre.fr/skosmos/">Loterre</a>, a multidisciplinary terminology platform</li>
           <li>FAO / <a href="https://agrovoc.uniroma2.it/agrovoc/agrovoc/en/">AGROVOC</a></li>


### PR DESCRIPTION
BARTOC Skosmos is currently being moved from Basel to VZG with new domain https://skosmos.bartoc.org/.