### PR TITLE
Don't crash on incomplete vocabulary configuration

### DIFF
--- a/model/Vocabulary.php
+++ b/model/Vocabulary.php
@@ -71,7 +71,10 @@ class Vocabulary extends DataObject implements Modifiable
     {
         if ($this->urispace === null) // initialize cache
         {
-            $this->urispace = $this->resource->getLiteral('void:uriSpace')->getValue();
+            $urispace = $this->resource->getLiteral('void:uriSpace');
+            if ($urispace) {
+                $this->urispace = $urispace->getValue();
+            }
         }
 
         return $this->urispace;

--- a/view/scripts.twig
+++ b/view/scripts.twig
@@ -31,6 +31,8 @@ var prefLabels = [{"lang": "{{ search_results|first.label.lang }}","label": "{{ 
 {% endif %}
 {% if request.vocab and request.vocab.uriSpace %}
 var uriSpace = "{{ request.vocab.uriSpace }}";
+{% else %}
+var uriSpace = null;
 {% endif %}
 var showNotation = {% if request.vocab and not request.vocab.config.showNotation %}false{% else %}true{% endif %};
 {% if request.vocab  %}


### PR DESCRIPTION
If a vocabulary configuration has no `void:uriSpace`, an error message should be shown instead of crashing. This closes #1408.
