### PR TITLE
Edited the link so that it leads to the templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,4 +38,4 @@ For information about released versions, see
 ## Reporting issues
 
 If you have found a bug please create a new issue using the provided template:
-[Report an issue](https://github.com/NatLibFi/Skosmos/issues/new)
+[Report an issue](https://github.com/NatLibFi/Skosmos/issues/new/choose)


### PR DESCRIPTION
Previously the link in README led to a new issue directly, now it goes to the template selection.

## Reasons for creating this PR

I think the current text in README indicates that this is the right link we want.

## Link to relevant issue(s), if any

-

## Description of the changes in this PR

Just this one link, or the end of it.

## Known problems or uncertainties in this PR

-

## Checklist

- [x] The link worked in my fork 