### PR TITLE
fix conversion of DateTime to string in getContainsHtml

### DIFF
--- a/model/ConceptPropertyValueLiteral.php
+++ b/model/ConceptPropertyValueLiteral.php
@@ -57,7 +57,7 @@ class ConceptPropertyValueLiteral extends VocabularyDataObject
     }
 
     public function getContainsHtml() {
-        return preg_match("/\/[a-z]*>/i", $this->literal->getValue()) != 0;
+        return preg_match("/\/[a-z]*>/i", $this->getLabel()) != 0;
     }
 
     public function getLabel()

--- a/tests/ConceptPropertyValueLiteralTest.php
+++ b/tests/ConceptPropertyValueLiteralTest.php
@@ -176,6 +176,17 @@ public function testGetLabelForDatatypeIfNull() {
   /**
    * @covers ConceptPropertyValueLiteral::getContainsHtml
    */
+  public function testGetContainsHtmlWhenValueIsDate() {
+    $litmock = $this->getMockBuilder('EasyRdf\Literal\Date')->disableOriginalConstructor()->getMock();
+    $litmock->method('getValue')->will($this->returnValue(DateTime::createFromFormat('Y-m-d', '2013-10-14')));
+    $resmock = $this->getMockBuilder('EasyRdf\Resource')->disableOriginalConstructor()->getMock();
+    $lit = new ConceptPropertyValueLiteral($this->model, $this->vocab, $resmock, $litmock, 'skosmos:testType');
+    $this->assertFalse($lit->getContainsHtml());
+  }
+
+  /**
+   * @covers ConceptPropertyValueLiteral::getContainsHtml
+   */
   public function testGetContainsHtml() {
     $litmock = $this->getMockBuilder('EasyRdf\Literal')->disableOriginalConstructor()->getMock();
     $litmock->method('getValue')->will($this->returnValue('a <a href=\"http://skosmos.org\">literal</a> with valid html'));


### PR DESCRIPTION
## Reasons for creating this PR

There is a recently surfaced (probably PHP 8.x related) problem in the YSO-aika (YSO Time) vocabulary. Concept pages failed to display and instead we got this message in the error log:

    [Wed Mar 22 09:53:30.124150 2023] [php:error] [pid 709825] [client 127.0.0.1:38096] PHP Fatal error:  Uncaught TypeError: preg_match(): Argument #2 ($subject) must be of type string, DateTime given in /var/www/html/Skosmos/model/ConceptPropertyValueLiteral.php:60

The reason is pretty simple: if a concept has a property with a datetime value, it cannot be implicitly casted to a string value. This PR fixes the problem by relying on the getLabel() method in the same class, which already handles DateTime to string conversion.

## Link to relevant issue(s), if any

(not reported as an issue, I decided to fix this directly)

## Description of the changes in this PR

* fix DateTime to string conversion in ConceptPropertyValueLiteral.getContainsHtml() by relying on .getLabel()
* add unit test for verifying above conversion

## Known problems or uncertainties in this PR

none

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
