### PR TITLE
Fix for #1389 checking that skosxl properties are only shown for correct language

### DIFF
--- a/model/ConceptPropertyValueLiteral.php
+++ b/model/ConceptPropertyValueLiteral.php
@@ -88,7 +88,7 @@ class ConceptPropertyValueLiteral extends VocabularyDataObject
     public function hasXlProperties()
     {
         $xlLabel = $this->getXlLabel();
-        return ($xlLabel !== null && !empty($xlLabel->getProperties()));
+        return ($xlLabel !== null && !empty($xlLabel->getProperties()) && $this->getLang() == $xlLabel->getLang());
     }
 
     public function getXlLabel()

--- a/model/ConceptPropertyValueLiteral.php
+++ b/model/ConceptPropertyValueLiteral.php
@@ -88,7 +88,7 @@ class ConceptPropertyValueLiteral extends VocabularyDataObject
     public function hasXlProperties()
     {
         $xlLabel = $this->getXlLabel();
-        return ($xlLabel !== null && !empty($xlLabel->getProperties()) && $this->getLang() == $xlLabel->getLang());
+        return ($xlLabel !== null && !empty($xlLabel->getProperties()));
     }
 
     public function getXlLabel()
@@ -96,7 +96,10 @@ class ConceptPropertyValueLiteral extends VocabularyDataObject
         $graph = $this->resource->getGraph();
         $labelResources = $graph->resourcesMatching('skosxl:literalForm', $this->literal);
         foreach($labelResources as $labres) {
-            return new LabelSkosXL($this->model, $labres);
+          $xlLabel = new LabelSkosXL($this->model, $labres);
+          if ($xlLabel->getLang() == $this->getLang()) {
+            return $xlLabel;
+          }
         }
         return null;
     }

--- a/model/LabelSkosXL.php
+++ b/model/LabelSkosXL.php
@@ -34,6 +34,10 @@ class LabelSkosXL extends DataObject
         return $ret;
     }
 
+    public function getLang() {
+      return $this->resource->getLiteral('skosxl:literalForm')->getLang();
+    }
+
     public function getLiteral() {
         return $this->resource->getLiteral('skosxl:literalForm')->getValue();
     }

--- a/tests/ConceptPropertyValueLiteralTest.php
+++ b/tests/ConceptPropertyValueLiteralTest.php
@@ -203,4 +203,38 @@ public function testGetLabelForDatatypeIfNull() {
     $this->assertArrayNotHasKey('skosxl:literalForm', $reified_vals);
     $this->assertArrayHasKey('skosxl:labelRelation', $reified_vals);
   }
+
+  /**
+   * @covers ConceptPropertyValueLiteral::getXlLabel
+   * @covers ConceptPropertyValueLiteral::hasXlProperties
+   */
+  public function testGetXlPropertiesByLang() {
+    $voc = $this->model->getVocabulary('xl');
+    $conc = $voc->getConceptInfo('http://www.skosmos.skos/xl/c2', 'en')[0];
+    $props = $conc->getProperties();
+    $vals = $props['skos:altLabel']->getValues();
+    $val = reset($vals);
+
+    $reified_vals = array();
+    if ($val->hasXlProperties())
+      {
+        $reified_vals = $val->getXlLabel()->getProperties();
+      }
+    $this->assertArrayHasKey('dc:source', $reified_vals);
+    $this->assertArrayHasKey('dc:modified', $reified_vals);
+    $this->assertCount(2, $reified_vals);
+
+    // testing that XlProperties are only shown for matching language
+    $conc = $voc->getConceptInfo('http://www.skosmos.skos/xl/c2', 'fi')[0];
+    $props = $conc->getProperties();
+    $vals = $props['skos:altLabel']->getValues();
+    $val = reset($vals);
+
+    $reified_vals = array();
+    if ($val->hasXlProperties())
+      {
+        $reified_vals = $val->getXlLabel()->getProperties();
+      }
+    $this->assertEmpty($reified_vals);
+  }
 }

--- a/tests/ConceptPropertyValueLiteralTest.php
+++ b/tests/ConceptPropertyValueLiteralTest.php
@@ -207,6 +207,7 @@ public function testGetLabelForDatatypeIfNull() {
   /**
    * @covers ConceptPropertyValueLiteral::getXlLabel
    * @covers ConceptPropertyValueLiteral::hasXlProperties
+   * @covers LabelSkosXL::getLang
    */
   public function testGetXlPropertiesByLang() {
     $voc = $this->model->getVocabulary('xl');

--- a/tests/test-vocab-data/xl.ttl
+++ b/tests/test-vocab-data/xl.ttl
@@ -27,3 +27,13 @@ xl:d1
     rdf:value "Unit of thought"@en ;
     dct:modified "2018-04-13T10:29:03+00:00"^^xsd:dateTime ;
     dc:source <https://en.wikipedia.org/wiki/Concept> .
+
+xl:c2 a skos:Concept ;
+    skos:prefLabel "Ontology"@en, "Ontologia"@fi ;
+    skos:altLabel "Onto"@en, "Onto"@fi ;
+    skosxl:altLabel xl:l3 .
+
+xl:l3 a skosxl:Label ;
+    skosxl:literalForm "Onto"@en ;
+    dct:modified "2018-04-13T10:29:03+00:00"^^xsd:dateTime ;
+    dc:source <https://en.wikipedia.org/wiki/Ontology> .


### PR DESCRIPTION
## Reasons for creating this PR
Bugfix

## Link to relevant issue(s), if any

- Closes #1389 

## Description of the changes in this PR

Adding a language check for displaying the skosxl properties to prevent showing properties for labels in other than intended language.

## Known problems or uncertainties in this PR

## Checklist

- [x ] phpUnit tests pass locally with my changes
- [x ] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x ] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x ] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
