### PR TITLE
First JS variables under SKOSMOS namespace.

### DIFF
--- a/src/view/scripts.inc
+++ b/src/view/scripts.inc
@@ -1,0 +1,48 @@
+<!-- Namespace for Skosmos variables -->
+<script>
+  let SKOSMOS = (function () {
+    var content_lang = "{{ request.contentLang }}";
+    var explicitLangCodes = {{ explicit_langcodes ? 'true' : 'false' }};
+    var lang = "{{ request.lang }}";
+    var vocab = "{{ request.vocabid }}";
+    var waypoint_results = {{ parameters ? parameters.searchLimit : NULL }};
+
+    {% if request.page == 'page' and search_results and search_results|length == 1 %}
+      var prefLabels = [{"lang": "{{ search_results|first.label.lang }}","label": "{{ search_results|first.label }}"}{% for lang in search_results|first.foreignLabels %}{% for literal in lang %}{% if literal.type == 'skos:prefLabel' %},{"lang": "{{literal.lang}}", "label": "{{literal.label}}"}{% endif %}{% endfor %}{% endfor %}];
+      var uri = "{{ search_results|first.uri }}";
+    {% endif %}
+
+    {% if request.vocab  %}
+      var languageOrder = [{% for lang in request.vocab.config.languageOrder(request.contentLang) %}"{{ lang }}"{% if not loop.last %},{% endif %}{% endfor %}];
+      var showNotation = {{ not request.vocab.config.showNotation ? false : true }}
+      var sortByNotation = {% if request.vocab.config.sortByNotation %}"{{ request.vocab.config.sortByNotation }}"{% else %}null{% endif %};
+      var uriSpace = {{ request.vocab.uriSpace ? "{{ request.vocab.uriSpace }}" : null }}
+      var vocShortName = "{{ request.vocab.config.shortname }}";
+    {% endif %}
+
+    {% if plugin_params %}
+      var pluginParameters = {{ plugin_params|raw }};
+    {% endif %}
+    {% if request.plugins.callbacks %}
+      var pluginCallbacks = [{% for function in request.plugins.callbacks %}{% if not loop.first %}, {% endif %}"{{ function }}"{% endfor %}];
+    {% endif %}
+    
+    return {
+       Name: "Skosmos global variables",
+    };
+  })();
+</script>
+
+<!-- Search result data -->
+<script type="application/ld+json">
+  {% if search_results and search_results|length == 1 %}
+    {{ search_results|first.dumpJsonLd|raw }}
+  {% else %}
+    {}
+  {% endif %}
+</script>
+
+<!-- Plugin JS sources -->
+{% for files in request.plugins.pluginsJS %}
+  {% for file in files %}<script src="{{ file }}"></script>{% endfor %}
+{% endfor %}


### PR DESCRIPTION
## Reasons for creating this PR
 - This is part of the twig overhaul
## Link to relevant issue(s), if any
- Part of #1436 

## Description of the changes in this PR
- Tidying up twig templates that produce JS variables
- Putting the Skosmos JS variables under SKOSMOS namespace
## Known problems or uncertainties in this PR
- This PR does not have CSP nonce implemented
- This PR omits the variables generated with translation components
- This PR hasn't been tested

## Checklist

- [ ] phpUnit tests pass locally with my changes
- [ ] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [ ] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
