### PR TITLE
Add vue components for vocab statistics

### DIFF
--- a/resource/js/term-counts.js
+++ b/resource/js/term-counts.js
@@ -1,0 +1,45 @@
+const termCountsApp = Vue.createApp({
+  data () {
+    return {
+      languages: []
+    }
+  },
+  mounted () {
+    fetch('https://api.finto.fi/rest/v1/yso/labelStatistics?lang=fi') /* What should this be? */
+      .then(data => {
+        return data.json()
+      })
+      .then(data => {
+        console.log('term count', data)
+        this.languages = data.languages
+      })
+  },
+  template: `
+    <h3 class="fw-bold py-3">Term counts by language</h3>
+    <table class="table" id="statistics">
+      <tbody>
+        <tr>
+          <th class="main-table-label fw-bold">Concept language</th>
+          <th class="main-table-label fw-bold">Preferred terms</th>
+          <th class="main-table-label fw-bold">Alternate terms</th>
+          <th class="main-table-label fw-bold">Hidden terms</th>
+        </tr>
+        <term-counts :languages="languages"></term-counts>
+      </tbody>
+    </table>
+  `
+})
+
+termCountsApp.component('term-counts', {
+  props: ['languages'],
+  template: `
+    <tr v-for="l in languages">
+      <td>{{ l.literal }}</td>
+      <td>{{ l.properties.find(a => a.property === 'skos:prefLabel').labels }}</td>
+      <td>{{ l.properties.find(a => a.property === 'skos:altLabel').labels }}</td>
+      <td>{{ l.properties.find(a => a.property === 'skos:hiddenLabel').labels }}</td>
+    </tr>
+  `
+})
+
+termCountsApp.mount('#term-counts')

--- a/resource/js/term-counts.js
+++ b/resource/js/term-counts.js
@@ -5,7 +5,7 @@ const termCountsApp = Vue.createApp({
     }
   },
   mounted () {
-    fetch('https://api.finto.fi/rest/v1/yso/labelStatistics?lang=fi') /* What should this be? */
+    fetch('rest/v1/yso/labelStatistics?lang=fi')
       .then(data => {
         return data.json()
       })
@@ -16,7 +16,7 @@ const termCountsApp = Vue.createApp({
   },
   template: `
     <h3 class="fw-bold py-3">Term counts by language</h3>
-    <table class="table" id="statistics">
+    <table class="table" id="term-stats">
       <tbody>
         <tr>
           <th class="main-table-label fw-bold">Concept language</th>

--- a/resource/js/vocab-counts.js
+++ b/resource/js/vocab-counts.js
@@ -1,0 +1,54 @@
+const resourceCountsApp = Vue.createApp({
+  data () {
+    return {
+      concepts: {},
+      subTypes: {},
+      conceptGroups: {}
+    }
+  },
+  mounted () {
+    fetch('https://api.finto.fi/rest/v1/yso/vocabularyStatistics?lang=fi') /* What should this be? */
+      .then(data => {
+        return data.json()
+      })
+      .then(data => {
+        console.log('resource count', data)
+        this.concepts = data.concepts
+        this.subTypes = data.subTypes
+        this.conceptGroups = data.conceptGroups
+      })
+  },
+  template: `
+    <h3 class="fw-bold py-3">Resource counts by type</h3>
+    <table class="table" id="counts">
+      <tbody>
+        <tr><th class="versal">Type</th><th class="versal">Count</th></tr>
+        <resource-counts :concepts="concepts" :subTypes="subTypes" :conceptGroups="conceptGroups"></resource-counts>
+      </tbody>
+    </table>
+  `
+})
+
+resourceCountsApp.component('resource-counts', {
+  props: ['concepts', 'subTypes', 'conceptGroups'],
+  template: `
+    <tr>
+      <td>{{ concepts.label }}</td>
+      <td>{{ concepts.count }}</td>
+    </tr>
+    <tr v-for="st in subTypes">
+      <td>* {{ st.label }}</td>
+      <td>{{ st.count }}</td>
+    </tr>
+    <tr>
+      <td>* Käytöstä poistettu käsite</td>
+      <td>{{ concepts.deprecatedCount }}</td>
+    </tr>
+    <tr>
+      <td>{{ conceptGroups.label }}</td>
+      <td>{{ conceptGroups.count }}</td>
+    </tr>
+  `
+})
+
+resourceCountsApp.mount('#resource-counts')

--- a/resource/js/vocab-counts.js
+++ b/resource/js/vocab-counts.js
@@ -7,7 +7,7 @@ const resourceCountsApp = Vue.createApp({
     }
   },
   mounted () {
-    fetch('https://api.finto.fi/rest/v1/yso/vocabularyStatistics?lang=fi') /* What should this be? */
+    fetch('rest/v1/yso/vocabularyStatistics?lang=fi')
       .then(data => {
         return data.json()
       })
@@ -20,7 +20,7 @@ const resourceCountsApp = Vue.createApp({
   },
   template: `
     <h3 class="fw-bold py-3">Resource counts by type</h3>
-    <table class="table" id="counts">
+    <table class="table" id="resource-stats">
       <tbody>
         <tr><th class="versal">Type</th><th class="versal">Count</th></tr>
         <resource-counts :concepts="concepts" :subTypes="subTypes" :conceptGroups="conceptGroups"></resource-counts>

--- a/src/view/base-template.twig
+++ b/src/view/base-template.twig
@@ -11,6 +11,7 @@
 <link href="node_modules/bootstrap/dist/css/bootstrap.min.css" media="screen, print" rel="stylesheet" type="text/css">
 <link href="resource/css/fonts.css" media="screen, print" rel="stylesheet" type="text/css">
 <link href="resource/css/skosmos.css" media="screen, print" rel="stylesheet" type="text/css">
+<script src="node_modules/vue/dist/vue.global.js"></script>
 {% if ServiceCustomCss %}
 <link href="{{ ServiceCustomCss }}" media="screen, print" rel="stylesheet" type="text/css">
 {% endif %}

--- a/src/view/vocab-info.inc
+++ b/src/view/vocab-info.inc
@@ -46,19 +46,8 @@
     {% endif %}
     {% if vocab.config.showStatistics %}
     <div class="vocab-statistics">
-      <h3 class="fw-bold py-3">Resource counts by type</h3>
-      <table class="table" id="counts">
-        <tr><th class="versal">Type</th><th class="versal">Count</th></tr>
-      </table>
-      <table class="table" id="statistics">
-      <h3 class="fw-bold py-3">Term counts by language</h3>
-      <tr>
-        <th class="main-table-label fw-bold">Concept language</th>
-        <th class="main-table-label fw-bold">Preferred terms</th>
-        <th class="main-table-label fw-bold">Alternate terms</th>
-        <th class="main-table-label fw-bold">Hidden terms</th>
-      </tr>
-      </table>
+      <div id="resource-counts"></div>
+      <div id="term-counts"></div>
     </div>
     {% endif %}
     {% if vocab.config.dataURLs %}
@@ -88,3 +77,5 @@
     {% endif %}
   </div>
 </div>
+<script src="resource/js/vocab-counts.js"></script>
+<script src="resource/js/term-counts.js"></script>


### PR DESCRIPTION
## Reasons for creating this PR

To add vue components for vocabulary statistics

## Link to relevant issue(s), if any

- Closes #

## Description of the changes in this PR

Added global vue script and vocab stats as two vue components in separate files

## Known problems or uncertainties in this PR

## Checklist

- [ ] phpUnit tests pass locally with my changes
- [ ] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [ ] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [ ] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
