### PR TITLE
Upgrade some GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
           ${{ runner.os }}-php${{ matrix.php_version}}-skosmos3-
 
     - name: Install Composer dependencies
-      uses: php-actions/composer@v5
+      uses: php-actions/composer@v6
       with:
         php_version: ${{ matrix.php_version }}
         php_extensions: gettext intl xsl pcov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         fetch-depth: 0
 
     - name: Cache Fuseki installation
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: tests/apache-jena-fuseki-*
         key: fuseki-${{ hashFiles('tests/init_fuseki.sh') }}
@@ -34,7 +34,7 @@ jobs:
       run: cd tests; sh ./init_fuseki.sh
     
     - name: Cache Composer dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           /tmp/composer-cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,4 +83,4 @@ jobs:
         prefix: /app
 
     - name: Publish code coverage to Codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
         configuration: phpunit.xml
 
     - name: Publish code coverage to Code Climate
-      uses: paambaati/codeclimate-action@v2.7.5
+      uses: paambaati/codeclimate-action@v4.0.0
       env:
         CC_TEST_REPORTER_ID: fb98170a5c7ea9cc2bbab19ff26268335e6a11a4f8267ca935e5e8ff4624886c
       with:


### PR DESCRIPTION
## Reasons for creating this PR

We are using old versions of some GitHub actions and there are deprecation messages on the GitHub workflow summary page.

## Link to relevant issue(s), if any

n/a

## Description of the changes in this PR

Upgrade the following actions:

- actions/cache@v3 (was v2)
- paambaati/codeclimate-action@v4.0.0 (was v2.7.5)
- codecov/codecov-action@v3 (was v1)
- php-actions/composer@v6 (was v5)

This gets rid of two kinds of deprecation warnings:

* [Node 12 deprecated](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/)
* [save-state and set-output deprecated](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

## Known problems or uncertainties in this PR

I wanted to also use setup-node action to install npm dependencies (instead of a separate step as currently done), but it doesn't work because we don't have `package.lock` committed to version control. Whether we want that is a separate discussion.

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
