### PR TITLE
expand Cypress tests to cover all current page types + set baseUrl

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -2,6 +2,7 @@ const { defineConfig } = require("cypress");
 
 module.exports = defineConfig({
   e2e: {
+    baseUrl: 'http://localhost/Skosmos',
     setupNodeEvents(on, config) {
       // implement node event listeners here
     },

--- a/cypress/e2e/about.cy.js
+++ b/cypress/e2e/about.cy.js
@@ -1,0 +1,3 @@
+describe('About page', () => {
+  it('no-op test', () => {})
+})

--- a/cypress/e2e/concept.cy.js
+++ b/cypress/e2e/concept.cy.js
@@ -1,0 +1,3 @@
+describe('Concept page', () => {
+  it('no-op test', () => {})
+})

--- a/cypress/e2e/feedback.cy.js
+++ b/cypress/e2e/feedback.cy.js
@@ -1,0 +1,3 @@
+describe('Feedback page', () => {
+  it('no-op test', () => {})
+})

--- a/cypress/e2e/global-search.cy.js
+++ b/cypress/e2e/global-search.cy.js
@@ -1,0 +1,3 @@
+describe('Global search page', () => {
+  it('no-op test', () => {})
+})

--- a/cypress/e2e/landing.cy.js
+++ b/cypress/e2e/landing.cy.js
@@ -1,11 +1,11 @@
-describe('template spec', () => {
-  it('passes', () => {
+describe('Landing page', () => {
+  it('links to vocabulary home', () => {
     // go to the Skosmos front page
-    cy.visit('http://localhost/Skosmos')
+    cy.visit('/')
     // click on the first vocabulary in the list
     cy.get('#vocabulary-list').find('a').first().click()
     // check that we are still within the Skosmos URL space
-    cy.url().should('include', 'http://localhost/Skosmos/')
+    cy.url().should('include', Cypress.config().baseUrl)
     // check that we are on the vocab home page
     cy.get('#vocab-info')
   })

--- a/cypress/e2e/vocab-home.cy.js
+++ b/cypress/e2e/vocab-home.cy.js
@@ -1,0 +1,11 @@
+describe('Vocabulary home page', () => {
+  it('contains vocabulary title', () => {
+    // go to the Skosmos front page
+    cy.visit('/')
+    // click on the first vocabulary in the list
+    cy.get('#vocabulary-list').find('a').first().click()
+
+    // check that the vocabulary title is not empty
+    cy.get('#vocab-title > a').invoke('text').should('match', /.+/)
+  })
+})

--- a/cypress/e2e/vocab-search.cy.js
+++ b/cypress/e2e/vocab-search.cy.js
@@ -1,0 +1,3 @@
+describe('Vocabulary search page', () => {
+  it('no-op test', () => {})
+})


### PR DESCRIPTION
## Reasons for creating this PR

Current Cypress setup is very limited, this expands it a little bit.

## Link to relevant issue(s), if any

- Follow-up to #1442 

## Description of the changes in this PR

* set baseUrl in Cypress config
* expand Cypress test suite, splitting them to files by page type

## Known problems or uncertainties in this PR

There are many placeholder no-op tests that need to be replaced with real tests later.

We still don't have a standardized Skosmos/Fuseki setup for Cypress so it's a bit hard to write substantial tests.

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
