### PR TITLE
Add twig template for error page

### DIFF
--- a/cypress/e2e/erorr.cy.js
+++ b/cypress/e2e/erorr.cy.js
@@ -1,0 +1,11 @@
+describe('Error page', () => {
+  it('Contains 404 error code', () => {
+    // check that HTTP code is 404 when accessing a non-existing page
+    cy.request({url: '/404', failOnStatusCode: false}).its('status').should('equal', 404)
+    // go to a non-existing page
+    cy.visit('/404', {failOnStatusCode: false})
+    // check that the page contains 404 error code
+    cy.get('.alert h3').invoke('text').should('contain', '404 Error') 
+  })
+})
+  

--- a/cypress/e2e/erorr.cy.js
+++ b/cypress/e2e/erorr.cy.js
@@ -8,4 +8,3 @@ describe('Error page', () => {
     cy.get('.alert h3').invoke('text').should('contain', '404 Error') 
   })
 })
-  

--- a/cypress/e2e/error.cy.js
+++ b/cypress/e2e/error.cy.js
@@ -8,3 +8,4 @@ describe('Error page', () => {
     cy.get('.alert h3').invoke('text').should('contain', '404 Error') 
   })
 })
+

--- a/cypress/e2e/error.cy.js
+++ b/cypress/e2e/error.cy.js
@@ -8,4 +8,3 @@ describe('Error page', () => {
     cy.get('.alert h3').invoke('text').should('contain', '404 Error') 
   })
 })
-

--- a/resource/css/skosmos.css
+++ b/resource/css/skosmos.css
@@ -5,6 +5,7 @@
   --medium-color: #dfe5ed;
   --secondary-medium-color: #b8c9db;
   --light-color: #f2f5f7;
+  --red-color: #a0270a;
   --white-color: #ffffff;
 
   /* Font definitions */
@@ -637,6 +638,14 @@ body {
 
   #feedback-form select:valid:focus {
     color: var(--feedback-form-text);
+  }
+
+  /* Error page
+   *****************************************/
+  .alert {
+    background-color: var(--red-color);
+    color: var(--white-color);
+    border-radius: 0;
   }
 
   /* Footer

--- a/resource/css/skosmos.css
+++ b/resource/css/skosmos.css
@@ -5,7 +5,7 @@
   --medium-color: #dfe5ed;
   --secondary-medium-color: #b8c9db;
   --light-color: #f2f5f7;
-  --red-color: #a0270a;
+  --alert-color: #a0270a;
   --white-color: #ffffff;
 
   /* Font definitions */
@@ -643,7 +643,7 @@ body {
   /* Error page
    *****************************************/
   .alert {
-    background-color: var(--red-color);
+    background-color: var(--alert-color);
     color: var(--white-color);
     border-radius: 0;
   }

--- a/src/view/error.twig
+++ b/src/view/error.twig
@@ -1,0 +1,13 @@
+{% extends "base-template.twig" %}
+{% block title %}: "Error"{% endblock %}
+{% block content %}
+{% set pageError = request.vocabid != '' and request.page == 'page' %}
+{% if pageError %}
+{% include "sidebar.inc" %}
+{% endif %}
+<div class="container{% if pageError %} col-md-8" id="main-content{% endif %}">
+  <div class="alert">
+    <h3>{% if not message%}404 Error: The page {{ requested_page }} cannot be found.{% else %}{{ message }}{% endif %}</h3>
+  </div>
+</div>
+{% endblock %}

--- a/src/view/error.twig
+++ b/src/view/error.twig
@@ -6,8 +6,8 @@
 {% include "sidebar.inc" %}
 {% endif %}
 <div class="container{% if pageError %} col-md-8" id="main-content{% endif %}">
-  <div class="alert">
-    <h3>{% if not message%}404 Error: The page {{ requested_page }} cannot be found.{% else %}{{ message }}{% endif %}</h3>
+  <div class="alert py-5 px-5">
+    <span class="fw-bold fs-5">{% if not message%}404 Error: The page {{ requested_page }} cannot be found.{% else %}{{ message }}{% endif %}</span>
   </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Reasons for creating this PR

Twig template for an error page

## Link to relevant issue(s), if any

- Linked to #1451

## Description of the changes in this PR

- Add twig template for error page
- Add cypress test for error page

## Known problems or uncertainties in this PR

## Checklist

- [ ] phpUnit tests pass locally with my changes
- [ ] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [ ] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [ ] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
