### PR TITLE
Add cypress tests for partial page load on vocab home page

### DIFF
--- a/cypress/e2e/vocab-home.cy.js
+++ b/cypress/e2e/vocab-home.cy.js
@@ -1,11 +1,34 @@
 describe('Vocabulary home page', () => {
-  it('contains vocabulary title', () => {
-    // go to the Skosmos front page
-    cy.visit('/')
-    // click on the first vocabulary in the list
-    cy.get('#vocabulary-list').find('a').first().click()
+  // using context because otherwise cypress would not clear the state and tests couldn't be run independently
+  context('Vocabulary home page', () => {
+    it('contains vocabulary title', () => {
+      // go to the Skosmos front page
+      cy.visit('/')
+      // click on the first vocabulary in the list
+      cy.get('#vocabulary-list').find('a').first().click()
+  
+      // check that the vocabulary title is not empty
+      cy.get('#vocab-title > a').invoke('text').should('match', /.+/)
+    })
+  })
 
-    // check that the vocabulary title is not empty
-    cy.get('#vocab-title > a').invoke('text').should('match', /.+/)
+  context('partial page load', () => {
+    it('does a partial page load', () => {
+      // go to the YSO home page (Allärs does not have an index in the backend for some reason)
+      cy.visit('/yso/en')
+      // click on the first concept in the alphabetical index
+      cy.get('#alpha-list').find('a').first().click()
+      // check that the term heading exists
+      cy.get('#term-heading')
+    })
+
+    it('updates mappings component after partial page load', () => {
+      // go to the YSO home page
+      cy.visit('/yso/en')
+      // click on the first concept in the alphabetical index
+      cy.get('#alpha-list').find('a').first().click()
+      // check that concept mappings is not empty
+      cy.get('#concept-mappings').should('not.be.empty')
+    })
   })
 })


### PR DESCRIPTION
## Reasons for creating this PR

Adding cypress tests for partial page load on vocab home page

## Link to relevant issue(s), if any

- Closes #

## Description of the changes in this PR

- Add cypress test for partial page load

## Known problems or uncertainties in this PR

## Checklist

- [ ] phpUnit tests pass locally with my changes
- [ ] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [ ] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [ ] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
