### PR TITLE
Skosmos 3: Use Apache Jena Fuseki docker image

### DIFF
--- a/dockerfiles/README.md
+++ b/dockerfiles/README.md
@@ -56,7 +56,7 @@ two files as necessary.
 
 **NOTE**: If you would like to start a Fuseki container to test with Docker only,
 without Docker Compose, you can try the following command before loading your
-vocabulary data. It starts a container in the same way our other example with
+vocabulary data. It starts a container in the same way as our other example with
 the `docker compose` command.
 
     export JENA_4_VERSION=4.8.0
@@ -66,7 +66,7 @@ the `docker compose` command.
         --no-cache dockerfiles/jena-fuseki2-docker
 
     docker run --name fuseki --rm -ti \
-        -v $(pwd)/config/skosmos.ttl:/fuseki/skosmos.ttl \
+        -v $(pwd)/dockerfiles/config/skosmos.ttl:/fuseki/skosmos.ttl \
         -e "JAVA_OPTIONS=-Xmx2g -Xms1g" \
         -p 3030:3030 \
         jena-fuseki:$JENA_4_VERSION \

--- a/dockerfiles/config/skosmos.ttl
+++ b/dockerfiles/config/skosmos.ttl
@@ -1,85 +1,73 @@
 @prefix :      <http://base/#> .
 @prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix tdb2:  <http://jena.apache.org/2016/tdb#> .
-@prefix ja:    <http://jena.hpl.hp.com/2005/11/Assembler#> .
 @prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix fuseki: <http://jena.apache.org/fuseki#> .
+@prefix tdb2:  <http://jena.apache.org/2016/tdb#> .
 @prefix text:  <http://jena.apache.org/text#> .
 @prefix skos:  <http://www.w3.org/2004/02/skos/core#> .
+@prefix fuseki: <http://jena.apache.org/fuseki#> .
 
-ja:DatasetTxnMem  rdfs:subClassOf  ja:RDFDataset .
-ja:MemoryDataset  rdfs:subClassOf  ja:RDFDataset .
-ja:RDFDatasetOne  rdfs:subClassOf  ja:RDFDataset .
-ja:RDFDatasetSink  rdfs:subClassOf  ja:RDFDataset .
-ja:RDFDatasetZero  rdfs:subClassOf  ja:RDFDataset .
+[] rdf:type fuseki:Server ;
+   fuseki:services (
+     :skosmos_service
+   )
+.
 
-tdb2:DatasetTDB  rdfs:subClassOf  ja:RDFDataset .
-tdb2:DatasetTDB2  rdfs:subClassOf  ja:RDFDataset .
-
-tdb2:GraphTDB  rdfs:subClassOf  ja:Model .
-tdb2:GraphTDB2  rdfs:subClassOf  ja:Model .
-
-<http://jena.hpl.hp.com/2008/tdb#DatasetTDB>
-    rdfs:subClassOf  ja:RDFDataset .
-
-<http://jena.hpl.hp.com/2008/tdb#GraphTDB>
-    rdfs:subClassOf  ja:Model .
-
-text:TextDataset
-    rdfs:subClassOf  ja:RDFDataset .
-
-:service_tdb_all  a               fuseki:Service ;
-    rdfs:label                    "TDB2+text skosmos" ;
-    fuseki:dataset                :text_dataset ;
-    fuseki:name                   "skosmos" ;
-    fuseki:serviceQuery           "query" , "" , "sparql" ;
-    fuseki:serviceReadGraphStore  "get" ;
-    fuseki:serviceReadQuads       "" ;
+:skosmos_service rdf:type fuseki:Service ;
+    rdfs:label                        "TDB2+text skosmos" ;
+    fuseki:name                       "skosmos" ;
+    fuseki:serviceQuery               "query" , "" , "sparql" ;
+    fuseki:serviceReadGraphStore      "get" ;
+    fuseki:serviceReadQuads           "" ;
     fuseki:serviceReadWriteGraphStore "data" ;
-    fuseki:serviceReadWriteQuads  "" ;
-    fuseki:serviceUpdate          "" , "update" ;
-    fuseki:serviceUpload          "upload" .
+    fuseki:serviceReadWriteQuads      "" ;
+    fuseki:serviceUpdate              "" , "update" ;
+    fuseki:serviceUpload              "upload" ;
+    fuseki:dataset                    :text_dataset
+.
 
-:text_dataset a text:TextDataset ;
-    text:dataset :tdb_dataset_readwrite ;
-    text:index :index_lucene .
+:text_dataset rdf:type text:TextDataset ;
+    text:dataset    :tdb_dataset_readwrite ;
+    text:index      <#indexLucene>
+.
 
-:tdb_dataset_readwrite
-    a tdb2:DatasetTDB2 ;
-    # tdb2:unionDefaultGraph true ;
-    tdb2:location  "/fuseki/databases/skosmos" .
+:tdb_dataset_readwrite rdf:type tdb2:DatasetTDB2 ;
+    tdb2:location               "/fuseki/databases/skosmos" ;
+    # tdb2:unionDefaultGraph    true ;
+.
 
-:index_lucene a text:TextIndexLucene ;
-    text:directory <file:/fuseki/databases/skosmos/text> ;
-    text:entityMap :entity_map ;
-    text:storeValues true .
+<#indexLucene> rdf:type text:TextIndexLucene ;
+    text:directory      <file:/fuseki/databases/skosmos/text> ;
+    text:entityMap      <#entMap> ;
+    text:storeValues    true
+.
 
 # Text index configuration for Skosmos
-:entity_map a text:EntityMap ;
-    text:entityField      "uri" ;
-    text:graphField       "graph" ;
+<#entMap> rdf:type text:EntityMap ;
     text:defaultField     "pref" ;
+    text:entityField      "uri" ;
     text:uidField         "uid" ;
     text:langField        "lang" ;
+    text:graphField       "graph" ;
     text:map (
          # skos:prefLabel
          [ text:field "pref" ;
            text:predicate skos:prefLabel ;
-           text:analyzer [ a text:LowerCaseKeywordAnalyzer ]
+           text:analyzer [ rdf:type text:LowerCaseKeywordAnalyzer ]
          ]
          # skos:altLabel
          [ text:field "alt" ;
            text:predicate skos:altLabel ;
-           text:analyzer [ a text:LowerCaseKeywordAnalyzer ]
+           text:analyzer [ rdf:type text:LowerCaseKeywordAnalyzer ]
          ]
          # skos:hiddenLabel
          [ text:field "hidden" ;
            text:predicate skos:hiddenLabel ;
-           text:analyzer [ a text:LowerCaseKeywordAnalyzer ]
+           text:analyzer [ rdf:type text:LowerCaseKeywordAnalyzer ]
          ]
          # skos:notation
          [ text:field "notation" ;
            text:predicate skos:notation ;
-           text:analyzer [ a text:LowerCaseKeywordAnalyzer ]
+           text:analyzer [ rdf:type text:LowerCaseKeywordAnalyzer ]
          ]
-     ) .
+     )
+.

--- a/dockerfiles/docker-compose.yml
+++ b/dockerfiles/docker-compose.yml
@@ -4,26 +4,31 @@ services:
   fuseki:
     container_name: skosmos-fuseki
     hostname: fuseki
-    image: stain/jena-fuseki
+    build:
+      context: ../dockerfiles/jena-fuseki2-docker
+      dockerfile: Dockerfile
+      args:
+        JENA_VERSION: 4.8.0
+    command: --config=/fuseki/skosmos.ttl
     environment:
-      - ADMIN_PASSWORD=admin
-      - JVM_ARGS=-Xmx2g
+      - JAVA_OPTIONS=-Xmx2g -Xms1g
     ports:
-      - 9030:3030
-  # You can uncomment the line below to have a local volume bound onto the container, or
-  # visit https://hub.docker.com/r/stain/jena-fuseki/ for other alternatives
-  # volumes:
-  #  - ${PWD}/fuseki:/fuseki
+      - '9030:3030'
     volumes:
-      - type: bind
-        source: ./config/skosmos.ttl
-        target: /fuseki/configuration/skosmos.ttl
+      # You can uncomment the lines below to persist data used in the
+      # container. For more complete documentation about it, please
+      # consult the official Apache Jena docs at
+      # https://github.com/apache/jena/tree/main/jena-fuseki2/jena-fuseki-docker
+      # - ./databases:/fuseki/databases
+      # - ./logs:/fuseki/logs
+      - ./config/skosmos.ttl:/fuseki/skosmos.ttl
+    user: 'fuseki:fuseki'
   fuseki-cache:
     container_name: skosmos-fuseki-cache
     hostname: fuseki-cache
     image: varnish
     ports:
-      - 9031:80
+      - '9031:80'
     volumes:
       - type: bind
         source: ./config/varnish-default.vcl
@@ -35,7 +40,7 @@ services:
       context: ..
       dockerfile: dockerfiles/Dockerfile.ubuntu
     ports:
-      - 9090:80
+      - '9090:80'
     depends_on:
       - fuseki
       - fuseki-cache

--- a/dockerfiles/jena-fuseki2-docker/Dockerfile
+++ b/dockerfiles/jena-fuseki2-docker/Dockerfile
@@ -1,0 +1,124 @@
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##     http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+
+## Apache Jena Fuseki server Dockerfile.
+
+## This Dockefile builds a reduced footprint container.
+
+ARG JAVA_VERSION=17
+
+ARG ALPINE_VERSION=3.17.1
+ARG JENA_VERSION=""
+
+# Internal, passed between stages.
+ARG FUSEKI_DIR=/fuseki
+ARG FUSEKI_JAR=jena-fuseki-server-${JENA_VERSION}.jar
+ARG JAVA_MINIMAL=/opt/java-minimal
+
+## ---- Stage: Download and build java.
+FROM eclipse-temurin:${JAVA_VERSION}-alpine AS base
+
+ARG JAVA_MINIMAL
+ARG JENA_VERSION
+ARG FUSEKI_DIR
+ARG FUSEKI_JAR
+ARG REPO=https://repo1.maven.org/maven2
+ARG JAR_URL=${REPO}/org/apache/jena/jena-fuseki-server/${JENA_VERSION}/${FUSEKI_JAR}
+
+RUN [ "${JENA_VERSION}" != "" ] || { echo -e '\n**** Set JENA_VERSION ****\n' ; exit 1 ; }
+RUN echo && echo "==== Docker build for Apache Jena Fuseki ${JENA_VERSION} ====" && echo
+
+# Alpine: For objcopy used in jlink
+RUN apk add --no-cache curl binutils
+
+## -- Fuseki installed and runs in /fuseki.
+WORKDIR $FUSEKI_DIR
+
+## -- Download the jar file.
+COPY download.sh .
+RUN chmod a+x download.sh
+
+# Download, with check of the SHA1 checksum.
+RUN ./download.sh --chksum sha1 "$JAR_URL"
+
+## -- Alternatives to download : copy already downloaded.
+## COPY ${FUSEKI_JAR} .
+
+## Use Docker ADD - does not retry, does not check checksum, and may run every build.
+## ADD "$JAR_URL"
+
+## -- Make reduced Java JDK
+
+ARG JDEPS_EXTRA="jdk.crypto.cryptoki,jdk.crypto.ec"
+RUN \
+  JDEPS="$(jdeps --multi-release base --print-module-deps --ignore-missing-deps ${FUSEKI_JAR})"  && \
+  jlink \
+        --compress 2 --strip-debug --no-header-files --no-man-pages \
+        --output "${JAVA_MINIMAL}" \
+        --add-modules "${JDEPS},${JDEPS_EXTRA}"
+
+ADD entrypoint.sh .
+ADD log4j2.properties .
+
+## ---- Stage: Build runtime
+FROM alpine:${ALPINE_VERSION}
+
+## Import ARGs
+ARG JENA_VERSION
+ARG JAVA_MINIMAL
+ARG FUSEKI_DIR
+ARG FUSEKI_JAR
+
+COPY --from=base /opt/java-minimal /opt/java-minimal
+COPY --from=base /fuseki /fuseki
+
+WORKDIR $FUSEKI_DIR
+
+ARG LOGS=${FUSEKI_DIR}/logs
+ARG DATA=${FUSEKI_DIR}/databases
+
+ARG JENA_USER=fuseki
+ARG JENA_GROUP=$JENA_USER
+ARG JENA_GID=1000
+ARG JENA_UID=1000
+
+# Run as this user
+# -H : no home directory
+# -D : no password
+RUN addgroup -g "${JENA_GID}" "${JENA_GROUP}" && \
+    adduser "${JENA_USER}" -G "${JENA_GROUP}" -s /bin/ash -u "${JENA_UID}" -H -D
+
+RUN mkdir --parents "${FUSEKI_DIR}" && \
+    chown -R $JENA_USER ${FUSEKI_DIR}
+
+USER $JENA_USER
+
+RUN \
+    mkdir -p $LOGS && \
+    mkdir -p $DATA && \
+    chmod a+x entrypoint.sh
+
+## Default environment variables.
+ENV \
+    JAVA_HOME=${JAVA_MINIMAL}           \
+    JAVA_OPTIONS="-Xmx2048m -Xms2048m"  \
+    JENA_VERSION=${JENA_VERSION}        \
+    FUSEKI_JAR="${FUSEKI_JAR}"          \
+    FUSEKI_DIR="${FUSEKI_DIR}"
+
+EXPOSE 3030
+
+ENTRYPOINT ["./entrypoint.sh" ]
+CMD []

--- a/dockerfiles/jena-fuseki2-docker/README.md
+++ b/dockerfiles/jena-fuseki2-docker/README.md
@@ -1,1 +1,12 @@
-Commit: 26153afe9a229bb7a609d5406d899eb240ab385e
+The files under this directory were copied from the Apache Jena
+project. There was a new comment about uploading it to DockerHub,
+but it was made on a closed issue.
+
+https://issues.apache.org/jira/browse/JENA-1949
+
+For the future it might be useful to open a GitHub discussion to
+ask about that again.
+
+The files were copied from the following commit.
+
+26153afe9a229bb7a609d5406d899eb240ab385e

--- a/dockerfiles/jena-fuseki2-docker/README.md
+++ b/dockerfiles/jena-fuseki2-docker/README.md
@@ -1,0 +1,1 @@
+Commit: 26153afe9a229bb7a609d5406d899eb240ab385e

--- a/dockerfiles/jena-fuseki2-docker/download.sh
+++ b/dockerfiles/jena-fuseki2-docker/download.sh
@@ -1,0 +1,147 @@
+#!/bin/sh
+
+## Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This is an ash/dash script (it uses "local"), not a bash script.
+# It can run in an Alpine image during a docker build.
+#
+# The advantage over using docker ADD is that it checks
+# whether download file is already present and does not
+# download each time.
+#
+# Shell script to download URL and check the checksum
+
+USAGE="Usage: $(basename "$0") --chksum [sha1|sha512] URL"
+
+if [ $# -eq 0 ]
+then
+    echo "$USAGE" 2>&1
+    exit 1
+fi
+
+CHKSUM_TYPE='unset'
+
+while [ $# -gt 0 ] ; do
+    case "$1" in
+    --chksum|-chksum|-sha|--sha)
+        if [ $# -lt 2 ]
+        then
+        echo "$USAGE" 1>&2
+        exit 1
+        fi
+        CHKSUM_TYPE=$2
+        shift
+        shift
+        ;;
+    -h|--help)
+        echo "$USAGE" 1>&2
+        exit 0
+        ;;
+    -*)
+        echo "$USAGE" 1>&2
+        exit 1
+        ;;
+    *)
+        if [ $# -ne 1 ]
+        then
+        echo "$USAGE" 1>&2
+        exit 1
+        fi
+        URL="$1"
+        shift
+        ;;
+    esac
+done
+
+case "${CHKSUM_TYPE}" in
+    unset)
+    echo "$USAGE" 1>&2
+    exit 1
+    ;;
+    sha*|md5) ;;
+    *)
+    echo "Bad checksum type: '$CHKSUM_TYPE' (must start 'sha' or be 'md5')" 2>&1
+    exit 1
+    ;;
+esac
+
+## ---- Script starts ----
+
+ARTIFACT_URL="${URL}"
+ARTIFACT_NAME="$(basename "$ARTIFACT_URL")"
+
+# -------- Checksum details
+
+CHKSUM_EXT=".${CHKSUM_TYPE}"
+CHKSUM_URL="${ARTIFACT_URL}${CHKSUM_EXT}"
+CHKSUM_FILE="${ARTIFACT_NAME}${CHKSUM_EXT}"
+CHKSUMPROG="${CHKSUM_TYPE}sum"
+# --------
+
+CURL_FETCH_OPTS="-s -S --fail --location --max-redirs 3"
+if false
+then
+    echo "ARTIFACT_URL=$ARTIFACT_URL"
+    echo "CHKSUM_URL=$CHKSUM_URL"
+fi
+
+download() { # URL
+    local URL="$1"
+    local FN="$(basename "$URL")"
+    if [ ! -e "$FN" ]
+    then
+    echo "Fetching $URL"
+    curl $CURL_FETCH_OPTS "$URL" --output "$FN" \
+        || { echo "Bad download of $FN" 2>&1 ; return 1 ; }
+    else
+    echo "$FN already present"
+    fi
+    return 0
+}
+
+checkChksum() { # Filename checksum
+    local FN="$1"
+    local CHKSUM="$2"
+    if [ ! -e "$FN" ]
+    then
+    echo "No such file: '$FN'" 2>&1
+    exit 1
+    fi
+    # NB Two spaces required for busybox
+    echo "$CHKSUM  $FN" | ${CHKSUMPROG} -c > /dev/null
+}
+
+download "$ARTIFACT_URL" || exit 1
+
+if [ -z "$CHKSUM" ]
+then
+    # Checksum not previously set.
+    # Extract from file, copes with variations in content (filename or not)
+    download "$CHKSUM_URL" || exit 1
+    CHKSUM="$(cut -d' ' -f1 "$CHKSUM_FILE")"
+fi
+
+checkChksum "${ARTIFACT_NAME}" "$CHKSUM"
+if [ $? = 0 ]
+then
+    echo "Good download: $ARTIFACT_NAME"
+else
+    echo "BAD download !!!! $ARTIFACT_NAME"
+    echo "To retry: delete downloaded files and try again"
+    exit 1
+fi

--- a/dockerfiles/jena-fuseki2-docker/entrypoint.sh
+++ b/dockerfiles/jena-fuseki2-docker/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+## Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
+
+## env | sort
+exec "$JAVA_HOME/bin/java" $JAVA_OPTIONS -jar "${FUSEKI_DIR}/${FUSEKI_JAR}" "$@"

--- a/dockerfiles/jena-fuseki2-docker/log4j2.properties
+++ b/dockerfiles/jena-fuseki2-docker/log4j2.properties
@@ -1,0 +1,73 @@
+## Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
+status = error
+name = PropertiesConfig
+
+## filters = threshold
+## filter.threshold.type = ThresholdFilter
+## filter.threshold.level = ALL
+
+appender.console.type = Console
+appender.console.name = OUT
+appender.console.target = SYSTEM_OUT
+appender.console.layout.type = PatternLayout
+## appender.console.layout.pattern = %d{HH:mm:ss} %-5p %-15c{1} :: %m%n
+## Include date.
+appender.console.layout.pattern = [%d{yyyy-MM-dd HH:mm:ss}] %-5p %-15c{1} :: %m%n
+
+## To a file.
+## appender.file.type = File
+## appender.file.name = FILE
+## appender.file.fileName=/fuseki/logs/log.fuseki
+## appender.file.layout.type=PatternLayout
+## appender.file.layout.pattern = [%d{yyyy-MM-dd HH:mm:ss}] %-5p %-15c{1} :: %m%n
+
+rootLogger.level                  = INFO
+rootLogger.appenderRef.stdout.ref = OUT
+
+logger.jena.name  = org.apache.jena
+logger.jena.level = INFO
+
+logger.arq-exec.name  = org.apache.jena.arq.exec
+logger.arq-exec.level = INFO
+
+logger.arq-info.name  = org.apache.jena.arq.info
+logger.arq-info.level = INFO
+
+logger.riot.name  = org.apache.jena.riot
+logger.riot.level = INFO
+
+logger.fuseki.name  = org.apache.jena.fuseki
+logger.fuseki.level = INFO
+
+logger.fuseki-fuseki.name  = org.apache.jena.fuseki.Fuseki
+logger.fuseki-fuseki.level = INFO
+
+logger.fuseki-server.name  = org.apache.jena.fuseki.Server
+logger.fuseki-server.level = INFO
+
+logger.fuseki-admin.name  = org.apache.jena.fuseki.Admin
+logger.fuseki-admin.level = INFO
+
+logger.jetty.name  = org.eclipse.jetty
+logger.jetty.level = WARN
+
+# May be useful to turn up to DEBUG if debugging HTTP communication issues
+logger.apache-http.name   = org.apache.http
+logger.apache-http.level  = WARN
+
+logger.shiro.name = org.apache.shiro
+logger.shiro.level = WARN
+# Hide bug in Shiro 1.5.x
+logger.shiro-realm.name = org.apache.shiro.realm.text.IniRealm
+logger.shiro-realm.level = ERROR
+
+# This goes out in NCSA format
+appender.plain.type = Console
+appender.plain.name = PLAIN
+appender.plain.layout.type = PatternLayout
+appender.plain.layout.pattern = %m%n
+
+logger.request-log.name                   = org.apache.jena.fuseki.Request
+logger.request-log.additivity             = false
+logger.request-log.level                  = OFF
+logger.request-log.appenderRef.plain.ref  = PLAIN


### PR DESCRIPTION
## Reasons for creating this PR

PR #1477 by @kinow switched to the official Apache Jena Fuseki image on the `master` branch. The same needs to be done on the `skosmos-3` branch. This PR makes the same changes for Skosmos 3.

## Link to relevant issue(s), if any

- Fixes #1415 for Skosmos 3 as well
- adapts PR #1477 for Skosmos 3 code

## Description of the changes in this PR

* cherry-picked all commits from PR #1477 i.e. changes to docker configuration and documentation

## Known problems or uncertainties in this PR

n/a

(I decided to remove the Ubuntu base image update from this PR as it wasn't really related to the fuseki image update)

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
