### PR TITLE
Use dockerized Fuseki for PHPUnit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         key: fuseki-${{ hashFiles('tests/init_fuseki.sh') }}
 
     - name: Start up Fuseki
-      run: cd tests; sh ./init_fuseki.sh
+      run: cd tests; ./init_fuseki.sh
     
     - name: Cache Composer dependencies
       uses: actions/cache@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,12 +24,6 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Cache Fuseki installation
-      uses: actions/cache@v3
-      with:
-        path: tests/apache-jena-fuseki-*
-        key: fuseki-${{ hashFiles('tests/init_fuseki.sh') }}
-
     - name: Start up Fuseki
       run: cd tests; ./init_fuseki.sh
     

--- a/dockerfiles/Dockerfile.ubuntu
+++ b/dockerfiles/Dockerfile.ubuntu
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 LABEL maintainer="National Library of Finland"
 LABEL version="0.1"
@@ -7,19 +7,18 @@ LABEL description="A Docker image for Skosmos with Apache httpd."
 ARG DEBIAN_FRONTEND=noninteractive
 
 # git is necessary for some composer packages e.g. davidstutz/bootstrap-multiselect
-# gettext is necessary as php-gettext was available in 18.04, but not in 20.04
 RUN apt-get update && apt-get install -y \
     apache2 \
     curl \
     gettext \
     git \
-    libapache2-mod-php7.4 \
+    libapache2-mod-php8.1 \
     locales \
-    php7.4 \
-    php7.4-curl \
-    php7.4-xsl \
-    php7.4-intl \
-    php7.4-mbstring \
+    php8.1 \
+    php8.1-curl \
+    php8.1-xsl \
+    php8.1-intl \
+    php8.1-mbstring \
     php-apcu \
     php-zip \
     unzip \
@@ -53,7 +52,7 @@ ENV LC_ALL=en_US.UTF-8
 ENV LANG=en_US.UTF-8  
 
 # timezone
-RUN sed -i 's/;date.timezone =/date.timezone = "UTC"/g' /etc/php/7.4/apache2/php.ini
+RUN sed -i 's/;date.timezone =/date.timezone = "UTC"/g' /etc/php/8.1/apache2/php.ini
 
 COPY dockerfiles/config/000-default.conf /etc/apache2/sites-available/000-default.conf
 

--- a/dockerfiles/config/skosmos.ttl
+++ b/dockerfiles/config/skosmos.ttl
@@ -32,7 +32,7 @@
 
 :tdb_dataset_readwrite rdf:type tdb2:DatasetTDB2 ;
     tdb2:location               "/fuseki/databases/skosmos" ;
-    # tdb2:unionDefaultGraph    true ;
+    tdb2:unionDefaultGraph    true ;
 .
 
 <#indexLucene> rdf:type text:TextIndexLucene ;

--- a/tests/JenaTextSparqlTest.php
+++ b/tests/JenaTextSparqlTest.php
@@ -371,6 +371,7 @@ class JenaTextSparqlTest extends PHPUnit\Framework\TestCase
      */
     public function testQueryConceptsAlphabeticalOrderBy()
     {
+        $this->markTestSkipped("disabled because ARQ collation doesn't work in dockerized Fuseki (Jena issue #1998)");
         $vocab = $this->model->getVocabulary('collation');
         $graph = $vocab->getGraph();
         $sparql = new JenaTextSparql($this->endpoint, $graph, $this->model);

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -117,7 +117,7 @@ class ModelTest extends PHPUnit\Framework\TestCase
     public function testGetVocabularyByInvalidGraphUri()
     {
         $this->expectException(ValueError::class);
-        $this->expectExceptionMessage("no vocabulary found for graph http://no/address and endpoint http://localhost:13030/skosmos-test/sparql");
+        $this->expectExceptionMessage("no vocabulary found for graph http://no/address and endpoint http://localhost:9030/skosmos/sparql");
         $vocab = $this->model->getVocabularyByGraph('http://no/address');
         $this->assertInstanceOf('Vocabulary', $vocab);
     }

--- a/tests/VocabularyTest.php
+++ b/tests/VocabularyTest.php
@@ -43,7 +43,7 @@ class VocabularyTest extends \PHPUnit\Framework\TestCase
     {
         $vocab = $this->model->getVocabulary('testdiff');
         $endpoint = $vocab->getEndpoint();
-        $this->assertEquals('http://localhost:13030/skosmos-test/sparql', $endpoint);
+        $this->assertEquals('http://localhost:9030/skosmos/sparql', $endpoint);
     }
 
     /**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -5,8 +5,8 @@ error_reporting(E_ALL);
 // make sure that a SPARQL endpoint is set by an environment variable
 $endpoint = getenv('SKOSMOS_SPARQL_ENDPOINT');
 if (!$endpoint) {
-    // default to Fuseki running on localhost:13030 as provided by init_fuseki.sh
-    putenv('SKOSMOS_SPARQL_ENDPOINT=http://localhost:13030/skosmos-test/sparql');
+    // default to Fuseki running on localhost:9030 as provided by init_fuseki.sh
+    putenv('SKOSMOS_SPARQL_ENDPOINT=http://localhost:9030/skosmos/sparql');
 }
 
 # Allow running git commands in the php-actions/phpunit container

--- a/tests/init_fuseki.sh
+++ b/tests/init_fuseki.sh
@@ -4,9 +4,16 @@
 cd ../dockerfiles
 docker compose up -d --build
 
-# FIXME: should check that it's up instead of blindly waiting 5 seconds
 echo "Waiting for Fuseki to get ready"
-sleep 5
+while true; do
+    if curl -fs http://localhost:9030/skosmos/ -o /dev/null; then
+        echo "Fuseki is up!"
+        break
+    else
+        echo "...waiting..."
+        sleep 1
+    fi
+done
 
 for fn in ../tests/test-vocab-data/*.ttl; do
     name=$(basename "${fn}" .ttl)

--- a/tests/testconfig.ttl
+++ b/tests/testconfig.ttl
@@ -22,7 +22,7 @@
 
 :config a skosmos:Configuration ;
     # SPARQL endpoint defaults to $SKOSMOS_SPARQL_ENDPOINT environment var
-    # skosmos:sparqlEndpoint <http://localhost:13030/skosmos-test/sparql> ;
+    # skosmos:sparqlEndpoint <http://localhost:9030/skosmos/sparql> ;
     # sparql-query extension, or "Generic" for plain SPARQL 1.1
     # set to "JenaText" instead if you use Fuseki with jena-text index
     # skosmos:sparqlDialect "JenaText" ;


### PR DESCRIPTION
## Reasons for creating this PR

Modernizing the test suite. See #1488

## Link to relevant issue(s), if any

- Closes #1488
- Includes commits from #1495 (those should be merged first)

## Description of the changes in this PR

See commit 817dd97476caeb144139b6e205d7c390d3ed1e65 for the changes that are specific to this PR (not just copied from #1495).

- rewritten init_fuseki.sh to use `docker compose` to start containers (instead of downloading, installing and starting up Fuseki from a tarball distribution) and regular `curl` commands for loading the vocabularies (instead of s-put that comes with the Fuseki tarball).
- changed the PHPUnit tests to use the dockerized Fuseki at `http://localhost:9030/skosmos/sparql` instead of `http://localhost:13030/skosmos-test/sparql` that was used in the previous configuration.
- Fuseki configuration (for the container) changed to enable `unionDefaultGraph`, because it is currently required by Skosmos for some functionality (see #678) and some tests will fail if it's not enabled.
- adjusted GitHub Actions CI configuration a little (no need to use `source` for running `init_fuseki.sh` anymore)

## Known problems or uncertainties in this PR

1. After starting up containers, the new `init_fuseki.sh` script sleeps for 5 seconds before trying to load vocabularies. I had to add this as a stopgap because Fuseki wasn't always immediately ready to handle the queries. But I think a more elegant mechanism would be needed here, for example waiting in a loop that checks if Fuseki is ready.
2. The `docker compose` command used here starts up three containers (skosmos, skosmos-cache, fuseki) but the PHPUnit tests only need the fuseki container. However, we will soon need the others as well for running Cypress tests (see e.g. #1479), so I think it's not too bad.
3. One of the tests is failing. This is `JenaTextSparql::testQueryConceptsAlphabeticalOrderBy` which checks for locale-aware collation in Jena SPARQL queries. It seems to me that collation is not currently working in the dockerized Fuseki - perhaps locale data is missing from the container?

I tested this also directly with the example query from the [Jena ARQ Collation](https://jena.apache.org/documentation/query/collation.html) documentation. Basically I put this in `collation.rq`:

```
PREFIX arq: <http://jena.apache.org/ARQ/function#>
SELECT ?label WHERE {
    VALUES ?label { "tsahurin kieli"@fi "tšekin kieli"@fi "tulun kieli"@fi "töyhtöhyyppä"@fi }
}
ORDER BY arq:collation("fi", ?label)
```

then ran it against the Fuseki Docker container using `rsparql` (from Jena) and the result was this:

```
$ rsparql --query collation.rq --service http://localhost:9030/skosmos/sparql
-----------------------
| label               |
=======================
| "töyhtöhyyppä"@fi   |
| "tsahurin kieli"@fi |
| "tšekin kieli"@fi   |
| "tulun kieli"@fi    |
-----------------------
```

This is not the correct, locale-aware order; `tsahurin kieli` should be first and `töyhtöhyyppä` last. So I think that the Fuseki container configuration should be modified to enable support for locale-aware collation. @kinow would you be able to help with this?

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
