### PR TITLE
Skosmos 3 docker: upgrade to Ubuntu 22.04 base image and PHP 8.1

### DIFF
--- a/dockerfiles/Dockerfile.ubuntu
+++ b/dockerfiles/Dockerfile.ubuntu
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 LABEL maintainer="National Library of Finland"
 LABEL version="0.1"
@@ -7,19 +7,17 @@ LABEL description="A Docker image for Skosmos with Apache httpd."
 ARG DEBIAN_FRONTEND=noninteractive
 
 # git is necessary for some composer packages e.g. davidstutz/bootstrap-multiselect
-# gettext is necessary as php-gettext was available in 18.04, but not in 20.04
 RUN apt-get update && apt-get install -y \
     apache2 \
     curl \
-    gettext \
     git \
-    libapache2-mod-php7.4 \
+    libapache2-mod-php8.1 \
     locales \
-    php7.4 \
-    php7.4-curl \
-    php7.4-xsl \
-    php7.4-intl \
-    php7.4-mbstring \
+    php8.1 \
+    php8.1-curl \
+    php8.1-xsl \
+    php8.1-intl \
+    php8.1-mbstring \
     php-apcu \
     php-zip \
     unzip \
@@ -53,7 +51,7 @@ ENV LC_ALL=en_US.UTF-8
 ENV LANG=en_US.UTF-8  
 
 # timezone
-RUN sed -i 's/;date.timezone =/date.timezone = "UTC"/g' /etc/php/7.4/apache2/php.ini
+RUN sed -i 's/;date.timezone =/date.timezone = "UTC"/g' /etc/php/8.1/apache2/php.ini
 
 COPY dockerfiles/config/000-default.conf /etc/apache2/sites-available/000-default.conf
 


### PR DESCRIPTION
## Reasons for creating this PR

Skosmos 3 needs a recent PHP version (currently 8.0 or 8.1) but the Dockerfile we are using for running Skosmos is based on Ubuntu 20.04 which has PHP 7.4. This PR upgrades to a more recent Ubuntu 22.04 base image which has PHP 8.1.

## Link to relevant issue(s), if any

- prerequisite for properly running Cypress tests using dockerized Skosmos, e.g. #1479

## Description of the changes in this PR

* upgrade to Ubuntu 22.04 base image
* adjust system and PHP packages (gettext shouldn't be needed anymore)

## Known problems or uncertainties in this PR

Not 100% sure if this is the right set of packages and PHP extensions, but we can fix that later if there are any problems.

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
