### PR TITLE
Checka11y function parameters with nulls and cypress folder tuning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,7 @@ tests/jena-fuseki*
 .DS_Store
 .phpunit.result.cache
 .php-cs-fixer.cache
-cypress/videos/
-cypress/screenshots/
+tests/cypress/videos/
+tests/cypress/screenshots/
 /.idea
 *.swp

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -22,6 +22,8 @@ module.exports = defineConfig({
       'tests/cypress/accessibility/**/*.cy.js',
       'tests/cypress/template/**/*.cy.js',
       'tests/cypress/e2e/**/*.cy.js'
-    ]
+    ],
+    screenshotsFolder: 'tests/cypress/screenshots',
+    videosFolder: 'tests/cypress/videos'
   }
 })

--- a/tests/cypress/support/accessibility.js
+++ b/tests/cypress/support/accessibility.js
@@ -39,12 +39,6 @@ function getConfigurationForCLITests () {
 }
 function getConfigurationForGUITests () {
   return it('Check for possible accessibility errors at all logging levels set below in accordance with WCAG AA requirements', () => {
-    checkA11y(null, null, {
-      includedImpacts: ['minor', 'moderate', 'serious', 'critical'],
-      runOnly: {
-        type: 'tag',
-        values: ['wcag2aa']
-      }
-    })
+    checkA11y(null)
   })
 }

--- a/tests/cypress/support/accessibility.js
+++ b/tests/cypress/support/accessibility.js
@@ -39,7 +39,7 @@ function getConfigurationForCLITests () {
 }
 function getConfigurationForGUITests () {
   return it('Check for possible accessibility errors at all logging levels set below in accordance with WCAG AA requirements', () => {
-    checkA11y({
+    checkA11y(null, null, {
       includedImpacts: ['minor', 'moderate', 'serious', 'critical'],
       runOnly: {
         type: 'tag',


### PR DESCRIPTION
## Reasons for creating this PR
A table that presents accessibility errors more effectively is necessary, even though SonarCloud reports the error. Additionally, the 'screenshots' and 'videos' directories should be in the correct test directory.

## Link to relevant issue(s), if any

- Closes #

## Description of the changes in this PR
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -22,6 +22,8 @@ module.exports = defineConfig({
       'tests/cypress/accessibility/**/*.cy.js',
       'tests/cypress/template/**/*.cy.js',
       'tests/cypress/e2e/**/*.cy.js'
-    ]
+    ],
+    screenshotsFolder: 'tests/cypress/screenshots',
+    videosFolder: 'tests/cypress/videos'
   }
 })

AND

--- a/tests/cypress/support/accessibility.js
+++ b/tests/cypress/support/accessibility.js
@@ -39,7 +39,7 @@ function getConfigurationForCLITests () {
 }
 function getConfigurationForGUITests () {
   return it('Check for possible accessibility errors at all logging levels set below in accordance with WCAG AA requirements', () => {
-    checkA11y({
+    checkA11y(null, null, {
       includedImpacts: ['minor', 'moderate', 'serious', 'critical'],
       runOnly: {
         type: 'tag',



## Known problems or uncertainties in this PR

## Checklist

- [ ] phpUnit tests pass locally with my changes
- [ ] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [ ] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [ ] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
