### PR TITLE
fix implementation of ConceptPropertyValue.getLang + add test

### DIFF
--- a/src/model/ConceptPropertyValue.php
+++ b/src/model/ConceptPropertyValue.php
@@ -38,7 +38,7 @@ class ConceptPropertyValue extends VocabularyDataObject
 
     public function getLang()
     {
-        return $this->getLang();
+        return $this->model->getLocale();
     }
 
     public function getLabel($lang = '', $fallbackToUri = 'uri')

--- a/tests/ConceptPropertyValueTest.php
+++ b/tests/ConceptPropertyValueTest.php
@@ -26,6 +26,16 @@ class ConceptPropertyValueTest extends PHPUnit\Framework\TestCase
     }
 
     /**
+     * @covers ConceptPropertyValue::getLang
+     */
+    public function testGetLang()
+    {
+        $props = $this->concept->getProperties();
+        $propvals = $props['skos:narrower']->getValues();
+        $this->assertEquals('en', $propvals['Crucian carp http://www.skosmos.skos/test/ta121']->getLang());
+    }
+
+    /**
      * @covers ConceptPropertyValue::getLabel
      */
     public function testGetLabel()


### PR DESCRIPTION
## Reasons for creating this PR

PR #1466 introduced a bug that causes infinite recursion in ConceptPropertyValue.getLang. This PR fixes the bug and adds a test that exercises the method.

## Link to relevant issue(s), if any

- follow-up fix to #1466

## Description of the changes in this PR

- implement getLang by calling the corresponding Model
- add unit test

## Known problems or uncertainties in this PR

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
