### PR TITLE
Top-level `docker-compose.yml`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,10 +2,9 @@ version: '3.7'
 
 services:
   fuseki:
-    container_name: skosmos-fuseki
     hostname: fuseki
     build:
-      context: ../dockerfiles/jena-fuseki2-docker
+      context: ./dockerfiles/jena-fuseki2-docker
       dockerfile: Dockerfile
       args:
         JENA_VERSION: 4.8.0
@@ -13,38 +12,36 @@ services:
     environment:
       - JAVA_OPTIONS=-Xmx2g -Xms1g
     ports:
-      - '9030:3030'
+      - ${FUSEKI_PORT:-9030}:3030
     volumes:
       # You can uncomment the lines below to persist data used in the
       # container. For more complete documentation about it, please
       # consult the official Apache Jena docs at
       # https://github.com/apache/jena/tree/main/jena-fuseki2/jena-fuseki-docker
-      # - ./databases:/fuseki/databases
-      # - ./logs:/fuseki/logs
-      - ./config/skosmos.ttl:/fuseki/skosmos.ttl
+      # - ./dockerfiles/databases:/fuseki/databases
+      # - ./dockerfiles/logs:/fuseki/logs
+      - ./dockerfiles/config/skosmos.ttl:/fuseki/skosmos.ttl
     user: 'fuseki:fuseki'
   fuseki-cache:
-    container_name: skosmos-fuseki-cache
     hostname: fuseki-cache
     image: varnish
     ports:
-      - '9031:80'
+      - ${CACHE_PORT:-9031}:80
     volumes:
       - type: bind
-        source: ./config/varnish-default.vcl
+        source: ./dockerfiles/config/varnish-default.vcl
         target: /etc/varnish/default.vcl
   skosmos:
-    container_name: skosmos-web
     hostname: skosmos
     build:
-      context: ..
+      context: .
       dockerfile: dockerfiles/Dockerfile.ubuntu
     ports:
-      - '9090:80'
+      - ${SKOSMOS_PORT:-9090}:80
     depends_on:
       - fuseki
       - fuseki-cache
     volumes:
       - type: bind
-        source: ./config/config-docker-compose.ttl
+        source: ./dockerfiles/config/config-docker-compose.ttl
         target: /var/www/html/config.ttl

--- a/dockerfiles/README.md
+++ b/dockerfiles/README.md
@@ -99,10 +99,13 @@ extension.
 
 **NOTE**: `fuseki:3030` and `fuseki-cache:80` are from the internal Docker network.
 To the host machine Docker Compose is exposing these values as `localhost:3030`
-and `localhost:9031` respectively.
+and `localhost:9031` respectively. The default host port numbers can be overriden
+by setting `SKOSMOS_PORT`, `FUSEKI_PORT`, and `CACHE_PORT` env variables in an
+`.env` file. This is useful when running multiple Skosmos Docker Compose instances
+on the same host but with different port numbers.
 
 To create the containers in this example setup, you can use this command
-from the `./dockerfiles/` directory:
+from the parent directory (where `docker-compose.yml` is located):
 
     docker compose up -d
 


### PR DESCRIPTION
## Reasons for creating this PR

`docker-compose` setup unsuitable for multiple Skosmos deployments

## Link to relevant issue(s), if any

- Closes #1511

## Description of the changes in this PR

* moved `docker-compose.yml` to the top-level dir
* fixed relative paths accordingly
* removed `container_name` properties
* replaced host port numbers with env variables with default values

## Known problems or uncertainties in this PR

Not tested directly :) But these changes work on our private fork and I was able to deploy 2 Skosmos instances on different ports on the same machine.

## Checklist

- [ ] phpUnit tests pass locally with my changes
- [ ] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
