### PR TITLE
fix: set correct SKOSMOS_SPARQL_ENDPOINT for Skosmos container

### DIFF
--- a/dockerfiles/docker-compose.yml
+++ b/dockerfiles/docker-compose.yml
@@ -27,6 +27,8 @@ services:
     container_name: skosmos-fuseki-cache
     hostname: fuseki-cache
     image: varnish
+    security_opt:
+      - seccomp:unconfined
     ports:
       - '9031:80'
     volumes:

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -17,3 +17,5 @@ services:
       - type: bind
         source: testconfig.ttl
         target: /var/www/html/config.ttl
+    environment:
+      SKOSMOS_SPARQL_ENDPOINT: http://fuseki-cache:80/skosmos/sparql


### PR DESCRIPTION
## Reasons for creating this PR

@joelit found out that when running Skosmos in a docker compose container for tests (e.g. cypress), the queries for vocabulary data were failing because Skosmos was using an incorrect SPARQL endpoint. This PR fixes the problem by setting the SKOSMOS_SPARQL_ENDPOINT environment variable for the `skosmos-web` container.

## Link to relevant issue(s), if any

- Follow-up fix to PR #1509 

## Description of the changes in this PR

- set SKOSMOS_SPARQL_ENDPOINT env var for the skosmos container used for tests

## Known problems or uncertainties in this PR

n/a

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
