### PR TITLE
Run Cypress under GitHub Actions & install Node dependencies in Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,7 +6,7 @@ components
 plugins/*
 composer.phar
 composer.lock
-tests/jena-fuseki*
+node_modules
 .vagrant
 .project
 .DS_Store

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,3 +78,25 @@ jobs:
 
     - name: Publish code coverage to Codecov
       uses: codecov/codecov-action@v3
+
+  cypress-test:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out repository code
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: Start up containers
+      run: cd tests; ./init_containers.sh
+
+    - name: Install Node
+      uses: actions/setup-node@v3
+      with:
+        node-version: 16.x
+
+    - name: Install JavaScript dependencies
+      run: npm install
+
+    - name: Run Cypress tests
+      run: npx cypress run

--- a/dockerfiles/Dockerfile.ubuntu
+++ b/dockerfiles/Dockerfile.ubuntu
@@ -5,7 +5,7 @@ WORKDIR /usr/src/app
 COPY package.json ./
 
 # install node.js dependencies e.g. Vue (but not the development dependencies)
-RUN npm install --omit=dev
+RUN npm install --omit=dev --ignore-scripts
 
 # Stage 1: runtime image
 FROM ubuntu:22.04

--- a/dockerfiles/Dockerfile.ubuntu
+++ b/dockerfiles/Dockerfile.ubuntu
@@ -1,3 +1,13 @@
+# Stage 0: install Node dependencies
+FROM node:18-alpine AS npm-installer
+
+WORKDIR /usr/src/app
+COPY package.json ./
+
+# install node.js dependencies e.g. Vue (but not the development dependencies)
+RUN npm install --omit=dev
+
+# Stage 1: runtime image
 FROM ubuntu:22.04
 
 LABEL maintainer="National Library of Finland"
@@ -6,7 +16,6 @@ LABEL description="A Docker image for Skosmos with Apache httpd."
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-# git is necessary for some composer packages e.g. davidstutz/bootstrap-multiselect
 RUN apt-get update && apt-get install -y \
     apache2 \
     curl \
@@ -76,6 +85,8 @@ RUN php composer.phar install --no-dev --no-autoloader
 COPY . /var/www/html
 RUN php composer.phar install --no-dev
 
+# install Node modules (from npm-installer stage)
+COPY --from=npm-installer /usr/src/app/node_modules /var/www/html/node_modules
 
 # Configure Skosmos
 COPY dockerfiles/config/config-docker.ttl /var/www/html/config.ttl


### PR DESCRIPTION
## Reasons for creating this PR

We want to have Cypress tests for the new frontend, and those tests should be automated as much as possible. PR #1509 changed the Cypress test to run against a standardized, dockerized Skosmos and Fuseki environment. This PR takes it a step further by also running the Cypress tests under GitHub Actions as a separate job.

In addition, while making this PR, I noticed that the Node dependencies of the frontend (e.g. Bootstrap and Vue.js) were not installed by the Dockerfile (they would only be included if they had been installed in the surrounding Skosmos codebase, and in that case often the development dependencies would be included as well). So I adjusted the Dockerfile to include a separate `npm-installer` stage that only installs those Node dependencies, then they are copied over to the next stage which is the Skosmos runtime image.

## Link to relevant issue(s), if any

- Closes #1189
- Supersedes PR #1479 by @kinow (this PR builds on the previously merged ones which didn't yet exist when 1479 was opened; I used that PR for inspiration, but wasn't able to copy the implementation)

## Description of the changes in this PR

- add GitHub Actions job that executes Cypress tests
- adjust Dockerfile.ubuntu (and .dockerignore) to make sure that the Node.js dependencies for production (Bootstrap and Vue) are included in the image, but not the development dependencies

## Known problems or uncertainties in this PR

n/a

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
