### PR TITLE
Added trans filter to templates

### DIFF
--- a/src/view/about.twig
+++ b/src/view/about.twig
@@ -5,7 +5,7 @@
 <div class="container">
   <div class="mx-5">
     <div class="px-3 pb-3 bg-light">
-      <h2 class="fs-3 mb-5">"About"</h2>
+      <h2 class="fs-3 mb-5">{{"About" | trans }}</h2>
       <p class="fs-6">
       {% include 'about-info.inc' %}
       </p>
@@ -13,7 +13,7 @@
 
     <div id="version">
       {% set version = request.version %}
-      <p>Skosmos version {{ version }}</p>
+      <p>{% trans %}Skosmos version %version%{% endtrans %}</p>
     </div>
   </div>
 </div>

--- a/src/view/concept-card.inc
+++ b/src/view/concept-card.inc
@@ -4,12 +4,12 @@
     <h2 class="visually-hidden">Concept information</h2>
     {% if concept.deprecated %}
     <div class="alert alert-danger">
-      <p class="deprecated-alert">deprecated</p>
+      <p class="deprecated-alert">{{ "deprecated" | trans }}</p>
     </div>
     {% endif %}
     {% if concept.label.lang != request.contentLang %}
     <div class="alert alert-lang">
-      <p class="language-alert">There is no term for this concept in this language</p>
+      <p class="language-alert">{{ "There is no term for this concept in this language" | trans }}</p>
     </div>
     {% endif %}
     <div class="container concept-info{% if concept.deprecated %} deprecated-concept{% endif %}">
@@ -130,7 +130,7 @@
       {% set foreignLabels = concept.foreignLabels %}
       {% if foreignLabels %}
       <tr class="prop-other-languages">
-        <td class="main-table-label">foreign prefLabels</td>
+        <td class="main-table-label">{{ "foreign prefLabels" | trans }}</td>
         <td class="align-middle">
             {% for language,labels in foreignLabels %}
               {% for value in labels.prefLabel|default([])|merge(labels.altLabel|default([])) %}
@@ -168,7 +168,7 @@
       </tbody>
     </table>
         <div class="row">
-            <div class="property-label"><h3 class="versal">Download this concept in SKOS format:</h3></div>
+            <div class="property-label"><h3 class="versal">{{ "Download this concept in SKOS format:" | trans }}</h3></div>
             <div class="property-value-column">
 <span class="versal concept-download-links"><a href="rest/v1/{% if concept.vocab %}{{ concept.vocab.id }}{% else %}{{ vocab.id }}{% endif %}/data?uri={{ concept.uri|url_encode }}&amp;format=application/rdf%2Bxml">RDF/XML</a>
           <a href="rest/v1/{% if concept.vocab %}{{ concept.vocab.id }}{% else %}{{ vocab.id }}{% endif %}/data?uri={{ concept.uri|url_encode }}&amp;format=text/turtle">
@@ -183,7 +183,7 @@
 
   {% else %}
   <div class="alert alert-danger">
-    <p>Error: Term "{{ term }}" not found in vocabulary!</p>
+    <p>{% trans %}Error: Term "{{ term }}" not found in vocabulary!{% endtrans %}</p>
   </div>
   {% endif %}
   <!-- appendix / concept mapping properties -->

--- a/src/view/concept-card.inc
+++ b/src/view/concept-card.inc
@@ -183,7 +183,7 @@
 
   {% else %}
   <div class="alert alert-danger">
-    <p>{% trans %}Error: Term "{{ term }}" not found in vocabulary!{% endtrans %}</p>
+    <p>{% trans %}Error: Term %term% not found in vocabulary!{% endtrans %}</p>
   </div>
   {% endif %}
   <!-- appendix / concept mapping properties -->

--- a/src/view/error.twig
+++ b/src/view/error.twig
@@ -7,7 +7,7 @@
 {% endif %}
 <div class="container{% if pageError %} col-md-8" id="main-content{% endif %}">
   <div class="alert py-5 px-5">
-    <span class="fw-bold fs-5">{% if not message%}404 Error: The page {{ requested_page }} cannot be found.{% else %}{{ message }}{% endif %}</span>
+    <span class="fw-bold fs-5">{% if not message%}{% trans %}404 Error: The page %requested_page% cannot be found.{% endtrans %}{% else %}{{ message }}{% endif %}</span>
   </div>
 </div>
 {% endblock %}

--- a/src/view/landing.twig
+++ b/src/view/landing.twig
@@ -4,12 +4,12 @@
 <div class="col-md-7">
   <div class="px-4 py-4 bg-medium" id="vocabulary-list">
     {% if request.vocabList|length == 0 %}
-    <h2 class="fs-2 fw-bold">No vocabularies on the server!</h2>
+    <h2 class="fs-2 fw-bold">{{ "No vocabularies on the server!" | trans }}</h2>
     {% else %}
       {% if category_label %}
       <h2 class="fs-2 fw-bold py-3">{{ category_label }}</h2>
       {% else %}
-      <h2 class="fs-2 fw-bold py-3">Available vocabularies and ontologies</h2>
+      <h2 class="fs-2 fw-bold py-3">{{ "Available vocabularies and ontologies" | trans }}</h2>
       {% endif %}
       {% for vocabClassName,vocabArray in request.vocabList %}
       <div class="vocab-category border-top border-dark-top">

--- a/src/view/vocab-info.inc
+++ b/src/view/vocab-info.inc
@@ -1,10 +1,10 @@
 <div class="col-md-8" id="main-content"> <!-- id for partial page load -->
   <div class="bg-light py-5 px-5" id="vocab-info">
-    <h2 class="fw-bold fs-3 py-4">Vocabulary information</h2>
+    <h2 class="fw-bold fs-3 py-4">{{ "Vocabulary information" | trans }}</h2>
     {% set vocabInfo = vocab.info(request.contentLang) %}
     {% if not vocabInfo %}
     <div class="alert alert-danger" role="alert">
-        Error: Failed to retrieve vocabulary information!
+        {{ "Error: Failed to retrieve vocabulary information!" | trans }}
     </div>
     {% else %}
     <table class="vocab-info-literals">
@@ -12,7 +12,7 @@
         {% for key, values in vocabInfo %}
         {% set keytrans = key %}
         <tr>
-          <td class="main-table-label fw-bold">{{ keytrans }}</td>
+          <td class="main-table-label fw-bold">{{ keytrans | trans }}</td>
           <td class="align-middle">
             {% for val in values %}
             <div class="property-value-wrapper">
@@ -53,7 +53,7 @@
     {% if vocab.config.dataURLs %}
     {% apply spaceless %}
     <div class="download-links">
-      <span class="versal">Download this vocabulary:</span>
+      <span class="versal">{{ "Download this vocabulary:" | trans }}</span>
         {% if 'application/rdf+xml' in vocab.config.dataURLs|keys %}
           <a href="rest/v1/{{ request.vocabid }}/data?format=application/rdf%2Bxml">RDF/XML</a>
         {% endif %}


### PR DESCRIPTION
## Reasons for creating this PR
New Symfony translation component added to skosmos-3 branch. Translation tags/filters notation has changed from previously used.

## Link to relevant issue(s), if any

- Closes #1503

## Description of the changes in this PR
trans filters added to Twig templates and inc files. Translation files containing variables in their identifiers are translated with notation `{% trans %} ... %variable% ... {% endtrans %}`

## Known problems or uncertainties in this PR
I could not find what causes and how to test this error message in file concept-card.inc:
`{% trans %}Error: Term "{{ term }}" not found in vocabulary!{% endtrans %}`

## Checklist

- [x] phpUnit tests pass locally with my changes
- [ ] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
