### PR TITLE
Show deprecated concepts without replacement in change list

### DIFF
--- a/model/sparql/GenericSparql.php
+++ b/model/sparql/GenericSparql.php
@@ -2262,13 +2262,17 @@ EOQ;
         $deprecatedVars = '';
         if ($showDeprecated) {
             $deprecatedVars = '?replacedBy ?deprecated ?replacingLabel';
-            $deprecatedOptions =
-            'UNION {'.
-                '?concept dc:isReplacedBy ?replacedBy ; dc:modified ?date2 .'.
-                'BIND(COALESCE(?date2, ?date) AS ?date)'.
-                'OPTIONAL { ?replacedBy skos:prefLabel ?replacingLabel .'.
-                    'FILTER (langMatches(lang(?replacingLabel), \''.$lang.'\')) }}'.
-                'OPTIONAL { ?concept owl:deprecated ?deprecated . }';
+            $deprecatedOptions = <<<EOQ
+UNION {
+    ?concept dc:isReplacedBy ?replacedBy ; dc:modified ?date2 .
+    BIND(COALESCE(?date2, ?date) AS ?date)
+    OPTIONAL {
+        ?replacedBy skos:prefLabel ?replacingLabel .
+        FILTER (langMatches(lang(?replacingLabel), '$lang'))
+    }
+}
+OPTIONAL { ?concept owl:deprecated ?deprecated . }
+EOQ;
         }
 
         $query = <<<EOQ

--- a/model/sparql/GenericSparql.php
+++ b/model/sparql/GenericSparql.php
@@ -2264,14 +2264,17 @@ EOQ;
             $deprecatedVars = '?replacedBy ?deprecated ?replacingLabel';
             $deprecatedOptions = <<<EOQ
 UNION {
-    ?concept dc:isReplacedBy ?replacedBy ; dc:modified ?date2 .
+    ?concept owl:deprecated True; dc:modified ?date2 .
+    BIND(True as ?deprecated)
     BIND(COALESCE(?date2, ?date) AS ?date)
     OPTIONAL {
-        ?replacedBy skos:prefLabel ?replacingLabel .
-        FILTER (langMatches(lang(?replacingLabel), '$lang'))
+        ?concept dc:isReplacedBy ?replacedBy .
+        OPTIONAL {
+            ?replacedBy skos:prefLabel ?replacingLabel .
+            FILTER (langMatches(lang(?replacingLabel), '$lang'))
+        }
     }
 }
-OPTIONAL { ?concept owl:deprecated ?deprecated . }
 EOQ;
         }
 
@@ -2316,6 +2319,11 @@ EOQ;
                 }
             }
 
+            if (isset($row->deprecated)) {
+                $concept['deprecated'] = $row->deprecated->getValue();
+            } else {
+                $concept['deprecated'] = false;
+            }
             if (isset($row->replacedBy)) {
                 $concept['replacedBy'] = $row->replacedBy->getURI();
             }

--- a/tests/GenericSparqlTest.php
+++ b/tests/GenericSparqlTest.php
@@ -1151,8 +1151,13 @@ class GenericSparqlTest extends PHPUnit\Framework\TestCase
     foreach($actual as $concept) {
         array_push($order, $concept['prefLabel']);
     }
-    $this->assertEquals(4, sizeof($actual));
-    $this->assertEquals(array('Fourth date', 'Hurr Durr', 'Second date', 'A date'), $order);
+    $this->assertEquals(5, sizeof($actual));
+    $this->assertEquals(array('No replacement', 'Fourth date', 'Hurr Durr', 'Second date', 'A date'), $order);
+
+    // check that deprecated status is correct
+    $this->assertTrue($actual[0]['deprecated']);  // 'No replacement'
+    $this->assertTrue($actual[1]['deprecated']);  // 'Fourth date'
+    $this->assertFalse($actual[2]['deprecated']); // 'Hurr Durr'
   }
 
 

--- a/tests/RestControllerTest.php
+++ b/tests/RestControllerTest.php
@@ -780,6 +780,11 @@ EOD;
      },
     "changeList": [
               { 
+                  "uri": "http://www.skosmos.skos/changes/d5",
+                  "prefLabel": "No replacement",
+                  "date": "2021-02-04T12:46:33+0000"
+              },
+              {
                   "uri": "http://www.skosmos.skos/changes/d4",
                   "prefLabel": "Fourth date",
                   "date": "2021-01-03T12:46:33+0000",
@@ -867,6 +872,7 @@ EOD;
         "date": { "@id":"http://purl.org/dc/terms/date","@type":"http://www.w3.org/2001/XMLSchema#dateTime" }
     },
     "changeList": [
+      { "date": "2021-02-04T12:46:33+0000", "prefLabel": "No replacement", "uri": "http://www.skosmos.skos/changes/d5" },
       { "date": "2021-01-03T12:46:30+0000", "prefLabel": "A date", "uri": "http://www.skosmos.skos/changes/d1" },
       { "date": "2021-01-03T12:46:33+0000", "prefLabel": "Fourth date", "replacedBy": "http://www.skosmos.skos/changes/d3", "replacingLabel": "Hurr Durr", "uri": "http://www.skosmos.skos/changes/d4" },
       { "date": "2021-01-03T12:46:32+0000", "prefLabel": "Hurr Durr", "uri": "http://www.skosmos.skos/changes/d3" },

--- a/tests/VocabularyTest.php
+++ b/tests/VocabularyTest.php
@@ -438,8 +438,8 @@ class VocabularyTest extends \PHPUnit\Framework\TestCase
   public function testGetChangeList() {
     $vocab = $this->model->getVocabulary('changes');
     $changeList = $vocab->getChangeList('dc:created','en', 0, 5);
-    $expected = array ('uri' => 'http://www.skosmos.skos/changes/d3', 'prefLabel' => 'Hurr Durr', 'date' => DateTime::__set_state(array('date' => '2010-02-12 10:26:39.000000', 'timezone_type' => 3, 'timezone' => 'UTC')));
-    $this->assertEquals($expected, $changeList[1]);
+    $expected = array ('uri' => 'http://www.skosmos.skos/changes/d3', 'prefLabel' => 'Hurr Durr', 'date' => DateTime::__set_state(array('date' => '2010-02-12 10:26:39.000000', 'timezone_type' => 3, 'timezone' => 'UTC')), 'deprecated' => false);
+    $this->assertEquals($expected, $changeList[2]);
   }
 
   /**

--- a/tests/WebControllerTest.php
+++ b/tests/WebControllerTest.php
@@ -223,7 +223,7 @@ class WebControllerTest extends TestCase
         $changeList = $this->webController->getChangeList($request, 'dc:created');
         $months =$this->webController->formatChangeList($changeList, 'en');
 
-        $expected = array ('hurr durr' => array ('uri' => 'http://www.skosmos.skos/changes/d3', 'prefLabel' => 'Hurr Durr', 'date' => DateTime::__set_state(array('date' => '2010-02-12 10:26:39.000000', 'timezone_type' => 3, 'timezone' => 'UTC')), 'datestring' => 'Feb 12, 2010'), 'second date' => array ('uri' => 'http://www.skosmos.skos/changes/d2', 'prefLabel' => 'Second date', 'date' => DateTime::__set_state(array('date' => '2010-02-12 15:26:39.000000', 'timezone_type' => 3, 'timezone' => 'UTC')), 'datestring' => 'Feb 12, 2010'));
+        $expected = array ('hurr durr' => array ('uri' => 'http://www.skosmos.skos/changes/d3', 'prefLabel' => 'Hurr Durr', 'date' => DateTime::__set_state(array('date' => '2010-02-12 10:26:39.000000', 'timezone_type' => 3, 'timezone' => 'UTC')), 'datestring' => 'Feb 12, 2010', 'deprecated' => false), 'second date' => array ('uri' => 'http://www.skosmos.skos/changes/d2', 'prefLabel' => 'Second date', 'date' => DateTime::__set_state(array('date' => '2010-02-12 15:26:39.000000', 'timezone_type' => 3, 'timezone' => 'UTC')), 'datestring' => 'Feb 12, 2010', 'deprecated' => false));
         $this->assertEquals($expected, $months['February 2010']);
     }
 

--- a/tests/test-vocab-data/changes.ttl
+++ b/tests/test-vocab-data/changes.ttl
@@ -30,3 +30,9 @@ changes:d4 a skos:Concept ;
     dc:created "2011-12-12T09:26:39"^^xsd:dateTime ;
     dc:modified "2021-01-03T12:46:33"^^xsd:dateTime ;
     skos:prefLabel "Fourth date"@en .
+
+changes:d5 a skos:Concept ;
+    owl:deprecated true ;
+    dc:created "2012-12-12T09:26:39"^^xsd:dateTime ;
+    dc:modified "2021-02-04T12:46:33"^^xsd:dateTime ;
+    skos:prefLabel "No replacement"@en .

--- a/view/changes.twig
+++ b/view/changes.twig
@@ -42,7 +42,7 @@
         <h5 class="versal versal-bold">{{day}}</h5>
         {% for concept in concepts %}
           <li><a href="{{ concept.uri | link_url(vocab,request.lang,'page', request.contentLang) }}">
-            {% if concept.replacedBy is defined %}
+            {% if concept.deprecated %}
               <s>{{ concept.prefLabel }}</s>
               {% else %}
               {{ concept.prefLabel }}


### PR DESCRIPTION
## Reasons for creating this PR

It was reported in #1513 that 

> concepts that have the owl:depracted true element/value only, BUT do not have the (optional) dct:replacedBy element seem to be missed completely/altogether and do not show up in the 'New and Deprecated' lists at all.

This PR fixes the problem by making sure that deprecated concepts which do not have an isReplacedBy relationship are shown. For example "elevated tracks" in this screenshot is a deprecated concept which doesn't have a replacement (I removed it manually from the YSO version I used for testing):

![image](https://github.com/NatLibFi/Skosmos/assets/1132830/6048e610-1870-4981-9a83-904afa726cec)

I verified that the performance of the "New and Deprecated" page is unchanged; possibly it is actually slightly better (1.4 seconds instead of 1.5 for the test case I used).

## Link to relevant issue(s), if any

- Closes #1513 (NB the issue mentions another problem about deprecated concepts shown in the hierarchy, but we need more clarification on that and a separate issue would be good)

## Description of the changes in this PR

* reformat the SPARQL query snippet in GenericSparql.generateChangeListQuery to make it more readable and easily editable
* change the querying and handling of deprecated concepts for the change list so that also concepts without isReplacedBy are included in the list; the deprecation status must be tracked separately from the possible replacement
* adjust the `changes` test vocabulary adding a deprecated concept without isReplacedBy and add tests to check that it is included as well (I had to adjust other unit tests that broke due to the changes in the test vocabulary)

## Known problems or uncertainties in this PR

The same or similar changes need to be repeated for Skosmos 3 as well.

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
