### PR TITLE
Show deprecated concepts without replacement in change list (skosmos 3)

### DIFF
--- a/src/model/sparql/GenericSparql.php
+++ b/src/model/sparql/GenericSparql.php
@@ -2333,14 +2333,17 @@ EOQ;
             $deprecatedVars = '?replacedBy ?deprecated ?replacingLabel';
             $deprecatedOptions = <<<EOQ
 UNION {
-    ?concept dc:isReplacedBy ?replacedBy ; dc:modified ?date2 .
+    ?concept owl:deprecated True; dc:modified ?date2 .
+    BIND(True as ?deprecated)
     BIND(COALESCE(?date2, ?date) AS ?date)
     OPTIONAL {
-        ?replacedBy skos:prefLabel ?replacingLabel .
-        FILTER (langMatches(lang(?replacingLabel), '$lang'))
+        ?concept dc:isReplacedBy ?replacedBy .
+        OPTIONAL {
+            ?replacedBy skos:prefLabel ?replacingLabel .
+            FILTER (langMatches(lang(?replacingLabel), '$lang'))
+        }
     }
 }
-OPTIONAL { ?concept owl:deprecated ?deprecated . }
 EOQ;
         }
 
@@ -2386,6 +2389,11 @@ EOQ;
                 }
             }
 
+            if (isset($row->deprecated)) {
+                $concept['deprecated'] = $row->deprecated->getValue();
+            } else {
+                $concept['deprecated'] = false;
+            }
             if (isset($row->replacedBy)) {
                 $concept['replacedBy'] = $row->replacedBy->getURI();
             }

--- a/src/model/sparql/GenericSparql.php
+++ b/src/model/sparql/GenericSparql.php
@@ -2331,13 +2331,17 @@ EOQ;
         $deprecatedVars = '';
         if ($showDeprecated) {
             $deprecatedVars = '?replacedBy ?deprecated ?replacingLabel';
-            $deprecatedOptions =
-            'UNION {'.
-                '?concept dc:isReplacedBy ?replacedBy ; dc:modified ?date2 .'.
-                'BIND(COALESCE(?date2, ?date) AS ?date)'.
-                'OPTIONAL { ?replacedBy skos:prefLabel ?replacingLabel .'.
-                    'FILTER (langMatches(lang(?replacingLabel), \''.$lang.'\')) }}'.
-                'OPTIONAL { ?concept owl:deprecated ?deprecated . }';
+            $deprecatedOptions = <<<EOQ
+UNION {
+    ?concept dc:isReplacedBy ?replacedBy ; dc:modified ?date2 .
+    BIND(COALESCE(?date2, ?date) AS ?date)
+    OPTIONAL {
+        ?replacedBy skos:prefLabel ?replacingLabel .
+        FILTER (langMatches(lang(?replacingLabel), '$lang'))
+    }
+}
+OPTIONAL { ?concept owl:deprecated ?deprecated . }
+EOQ;
         }
 
         $query = <<<EOQ

--- a/tests/GenericSparqlTest.php
+++ b/tests/GenericSparqlTest.php
@@ -1175,8 +1175,14 @@ class GenericSparqlTest extends PHPUnit\Framework\TestCase
         foreach($actual as $concept) {
             array_push($order, $concept['prefLabel']);
         }
-        $this->assertEquals(4, sizeof($actual));
-        $this->assertEquals(array('Fourth date', 'Hurr Durr', 'Second date', 'A date'), $order);
+
+        $this->assertEquals(5, sizeof($actual));
+        $this->assertEquals(array('No replacement', 'Fourth date', 'Hurr Durr', 'Second date', 'A date'), $order);
+
+        // check that deprecated status is correct
+        $this->assertTrue($actual[0]['deprecated']);  // 'No replacement'
+        $this->assertTrue($actual[1]['deprecated']);  // 'Fourth date'
+        $this->assertFalse($actual[2]['deprecated']); // 'Hurr Durr'
     }
 
 

--- a/tests/RestControllerTest.php
+++ b/tests/RestControllerTest.php
@@ -786,6 +786,11 @@ EOD;
      },
     "changeList": [
               { 
+                  "uri": "http://www.skosmos.skos/changes/d5",
+                  "prefLabel": "No replacement",
+                  "date": "2021-02-04T12:46:33+0000"
+              },
+              {
                   "uri": "http://www.skosmos.skos/changes/d4",
                   "prefLabel": "Fourth date",
                   "date": "2021-01-03T12:46:33+0000",
@@ -875,6 +880,7 @@ EOD;
         "date": { "@id":"http://purl.org/dc/terms/date","@type":"http://www.w3.org/2001/XMLSchema#dateTime" }
     },
     "changeList": [
+      { "date": "2021-02-04T12:46:33+0000", "prefLabel": "No replacement", "uri": "http://www.skosmos.skos/changes/d5" },
       { "date": "2021-01-03T12:46:30+0000", "prefLabel": "A date", "uri": "http://www.skosmos.skos/changes/d1" },
       { "date": "2021-01-03T12:46:33+0000", "prefLabel": "Fourth date", "replacedBy": "http://www.skosmos.skos/changes/d3", "replacingLabel": "Hurr Durr", "uri": "http://www.skosmos.skos/changes/d4" },
       { "date": "2021-01-03T12:46:32+0000", "prefLabel": "Hurr Durr", "uri": "http://www.skosmos.skos/changes/d3" },

--- a/tests/VocabularyTest.php
+++ b/tests/VocabularyTest.php
@@ -478,8 +478,8 @@ class VocabularyTest extends \PHPUnit\Framework\TestCase
     {
         $vocab = $this->model->getVocabulary('changes');
         $changeList = $vocab->getChangeList('dc:created', 'en', 0, 5);
-        $expected = array('uri' => 'http://www.skosmos.skos/changes/d3', 'prefLabel' => 'Hurr Durr', 'date' => DateTime::__set_state(array('date' => '2010-02-12 10:26:39.000000', 'timezone_type' => 3, 'timezone' => 'UTC')));
-        $this->assertEquals($expected, $changeList[1]);
+        $expected = array('uri' => 'http://www.skosmos.skos/changes/d3', 'prefLabel' => 'Hurr Durr', 'date' => DateTime::__set_state(array('date' => '2010-02-12 10:26:39.000000', 'timezone_type' => 3, 'timezone' => 'UTC')), 'deprecated' => false);
+        $this->assertEquals($expected, $changeList[2]);
     }
 
     /**

--- a/tests/WebControllerTest.php
+++ b/tests/WebControllerTest.php
@@ -225,7 +225,7 @@ class WebControllerTest extends TestCase
         $changeList = $this->webController->getChangeList($request, 'dc:created');
         $months =$this->webController->formatChangeList($changeList, 'en');
 
-        $expected = array('hurr durr' => array('uri' => 'http://www.skosmos.skos/changes/d3', 'prefLabel' => 'Hurr Durr', 'date' => DateTime::__set_state(array('date' => '2010-02-12 10:26:39.000000', 'timezone_type' => 3, 'timezone' => 'UTC')), 'datestring' => 'Feb 12, 2010'), 'second date' => array('uri' => 'http://www.skosmos.skos/changes/d2', 'prefLabel' => 'Second date', 'date' => DateTime::__set_state(array('date' => '2010-02-12 15:26:39.000000', 'timezone_type' => 3, 'timezone' => 'UTC')), 'datestring' => 'Feb 12, 2010'));
+        $expected = array('hurr durr' => array('uri' => 'http://www.skosmos.skos/changes/d3', 'prefLabel' => 'Hurr Durr', 'date' => DateTime::__set_state(array('date' => '2010-02-12 10:26:39.000000', 'timezone_type' => 3, 'timezone' => 'UTC')), 'datestring' => 'Feb 12, 2010', 'deprecated' => false), 'second date' => array('uri' => 'http://www.skosmos.skos/changes/d2', 'prefLabel' => 'Second date', 'date' => DateTime::__set_state(array('date' => '2010-02-12 15:26:39.000000', 'timezone_type' => 3, 'timezone' => 'UTC')), 'datestring' => 'Feb 12, 2010', 'deprecated' => false));
         $this->assertEquals($expected, $months['February 2010']);
     }
 

--- a/tests/test-vocab-data/changes.ttl
+++ b/tests/test-vocab-data/changes.ttl
@@ -30,3 +30,9 @@ changes:d4 a skos:Concept ;
     dc:created "2011-12-12T09:26:39"^^xsd:dateTime ;
     dc:modified "2021-01-03T12:46:33"^^xsd:dateTime ;
     skos:prefLabel "Fourth date"@en .
+
+changes:d5 a skos:Concept ;
+    owl:deprecated true ;
+    dc:created "2012-12-12T09:26:39"^^xsd:dateTime ;
+    dc:modified "2021-02-04T12:46:33"^^xsd:dateTime ;
+    skos:prefLabel "No replacement"@en .


### PR DESCRIPTION
## Reasons for creating this PR

PR #1529 fixed issue #1513  for skosmos 2 - the problem of deprecated concepts without an isReplacedBy relationship not being shown in the change list. This PR performs the same fixes for Skosmos 3.

## Link to relevant issue(s), if any

- Fixes #1513 for Skosmos 3 (the backend parts; frontend doesn't yet exist)

## Description of the changes in this PR

See #1529

## Known problems or uncertainties in this PR

Doesn't contain the front-end parts of the fix.

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
