### PR TITLE
Show only mainConceptScheme in hierarchy

### DIFF
--- a/controller/RestController.php
+++ b/controller/RestController.php
@@ -225,6 +225,10 @@ class RestController extends Controller
                 'uri' => '@id',
                 'type' => '@type',
                 'conceptschemes' => 'onki:hasConceptScheme',
+                'mainConceptScheme' => array(
+                    '@id' => 'onki:mainConceptScheme',
+                    '@type' => '@id'
+                ),
                 'id' => 'onki:vocabularyIdentifier',
                 'defaultLanguage' => 'onki:defaultLanguage',
                 'languages' => 'onki:language',
@@ -241,6 +245,7 @@ class RestController extends Controller
             'defaultLanguage' => $vocab->getConfig()->getDefaultLanguage(),
             'languages' => array_values($vocab->getConfig()->getLanguages()),
             'conceptschemes' => $conceptschemes,
+            'mainConceptScheme' => $vocab->getConfig()->getMainConceptSchemeURI()
         );
 
         if ($vocab->getConfig()->getTypes($request->getLang())) {

--- a/resource/js/hierarchy.js
+++ b/resource/js/hierarchy.js
@@ -442,11 +442,12 @@ function getTreeConfiguration() {
             req_kind: $.ajaxQ.requestKind.SIDEBAR_PRIVILEGED,
             success: function (response) {
               schemeObjects = schemeRoot(response.conceptschemes);
-              // if there are multiple concept schemes display those at the top level
-              if (schemeObjects.length > 1 && node.id === '#' && $('#vocab-info').length) {
+              // if there are multiple concept schemes and none of them is the main concept scheme,
+              // display them all at the top level
+              if (schemeObjects.length > 1 && node.id === '#' && $('#vocab-info').length && response.mainConceptScheme === null) {
                 return cb(schemeObjects);
-              } 
-              // if there was only one concept scheme display it's top concepts at the top level 
+              }
+              // if there was only one concept scheme (possibly main) display its top concepts at the top level 
               else if(node.id === '#' && $('#vocab-info').length) { 
                 $.ajax({
                   data: $.param({'lang': clang}),

--- a/swagger.json
+++ b/swagger.json
@@ -1551,6 +1551,9 @@
             "$ref": "#/definitions/ConceptScheme"
           }
         },
+        "mainConceptScheme": {
+          "type": "string"
+        },
         "type": {
           "description": "Optional vocabulary classification e.g. 'http://publications.europa.eu/resource/authority/dataset-type/ONTOLOGY'",
           "type": "array",


### PR DESCRIPTION
## Reasons for creating this PR

Attempt to fix #1396 i.e. make it possible to limit the hierarchy display to a single ConceptScheme by setting `skosmos:mainConceptScheme` in the vocabulary configuration.

I tried loading the INRAE Thesaurus (version without dc:subject triples for microthesauri from @saubin78's comment https://github.com/NatLibFi/Skosmos/issues/1396#issuecomment-1545695301) into a local Fuseki and configured it like this in `config.ttl`:

```
:inrae a skosmos:Vocabulary, void:Dataset ;
    skosmos:shortName "INRAE" ;
    dc:title "INRAE Thesaurus"@fi ;
    dc:subject :cat_general ;
    void:uriSpace "http://opendata.inrae.fr/thesaurusINRAE/";
    skosmos:language "en", "fr";
    skosmos:defaultLanguage "fr";
    skosmos:showTopConcepts true ;
    skosmos:mainConceptScheme <http://opendata.inrae.fr/thesaurusINRAE/thesaurusINRAE> ;
    void:sparqlEndpoint <http://localhost:3030/ds/sparql> ;
    skosmos:sparqlGraph <http://opendata.inrae.fr/thesaurusINRAE/> ;
    skosmos:sparqlDialect "Generic" .
```

This is how the hierarchy looks like when I go to http://localhost/Skosmos2/inrae/en/?clang=fr and open the Hierarchy tab:

![image](https://github.com/NatLibFi/Skosmos/assets/1132830/798bac88-eeb4-4c5a-a06c-3db07f1219d7)

I must say I'm a little confused by the structure in the INRAE Thesaurus. It seems to me that you have two kinds of top concepts under the main concept scheme ("INRAE Thesaurus"): the numbered ones that seem to be topical divisions (e.g. "01. ENVIRONNEMENT") as well as what look like regular concepts intended for subject indexing (e.g. "abattage de bétail"). So Skosmos will display them both. Is this what you intended @dipso-num4sci @saubin78?

## Link to relevant issue(s), if any

- Closes #1396

## Description of the changes in this PR

* make the REST API vocabulary URL return the value of the skosmos:mainConceptScheme setting
* in the frontend JS code for the hierarchy display, check if mainConceptScheme is set, and if it is, display only the top concepts of that ConceptScheme at the top level of the hierarchy, instead of showing all concept schemes

## Known problems or uncertainties in this PR

Not sure that I handled all cases. For instance, is the hierarchy correct when opening a concept page directly via URL?

This may affect other vocabularies with more than one ConceptScheme. For example IPTC and all the YSO based domain ontologies in Finto. Careful testing has to be done before merging so that we don't break existing usage of these.

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
