### PR TITLE
Added url encoding to getLangUrl function

### DIFF
--- a/model/Request.php
+++ b/model/Request.php
@@ -208,6 +208,11 @@ class Request
         if ($newlang !== null) {
             $langurl = preg_replace("#^(.*/)?{$this->lang}/#", "$1{$newlang}/", $langurl);
         }
+        if (str_contains($langurl, '?')) {
+            $urlparts = explode('?', $langurl);
+            $langurl = $urlparts[0] . '?' . urlencode($urlparts[1]);
+            $langurl = str_replace("%3D", "=", $langurl);
+        }
         // make sure that the resulting URL isn't interpreted as an absolute URL
         $langurl = str_replace(":", "", $langurl);
         return $langurl;

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -240,4 +240,15 @@ class RequestTest extends PHPUnit\Framework\TestCase
     $this->assertEquals("http//example.com", $langurl);
   }
 
+  /**
+   * @covers Request::getLangUrl
+   */
+  public function testGetEncodedUrld() {
+    $this->request->setServerConstant('SCRIPT_NAME', '/Skosmos/index.php');
+    $this->request->setServerConstant('REQUEST_URI', '/Skosmos/afo/fi/page/?uri=http://www.yso.fi/onto/yso/p1669');
+    $this->request->setLang('en');
+    $langurl = $this->request->getLangUrl();
+    $this->assertEquals("afo/fi/page/?uri=http%3A%2F%2Fwww.yso.fi%2Fonto%2Fyso%2Fp1669", $langurl);
+  }
+
 }


### PR DESCRIPTION
## Reasons for creating this PR
Fixes made in PR #1307 caused that changing UI language broke URLs containing colons from language change links in top bar.

## Link to relevant issue(s), if any
- Closes #1537 

## Description of the changes in this PR
Now URLs in top bar are URL encoded (except equal sign and ampersand) and should contain only encoded colons that are not omitted.

## Known problems or uncertainties in this PR
If URL contains equal signs and ampersands as values that should be escaped they are not URL encoded as should be.

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
