### PR TITLE
Top-level docker-compose.yml for Skosmos 3

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,10 +2,9 @@ version: '3.7'
 
 services:
   fuseki:
-    container_name: skosmos-fuseki
     hostname: fuseki
     build:
-      context: ../dockerfiles/jena-fuseki2-docker
+      context: ./dockerfiles/jena-fuseki2-docker
       dockerfile: Dockerfile
       args:
         JENA_VERSION: 4.8.0
@@ -13,40 +12,38 @@ services:
     environment:
       - JAVA_OPTIONS=-Xmx2g -Xms1g
     ports:
-      - '9030:3030'
+      - ${FUSEKI_PORT:-9030}:3030
     volumes:
       # You can uncomment the lines below to persist data used in the
       # container. For more complete documentation about it, please
       # consult the official Apache Jena docs at
       # https://github.com/apache/jena/tree/main/jena-fuseki2/jena-fuseki-docker
-      # - ./databases:/fuseki/databases
-      # - ./logs:/fuseki/logs
-      - ./config/skosmos.ttl:/fuseki/skosmos.ttl
+      # - ./dockerfiles/databases:/fuseki/databases
+      # - ./dockerfiles/logs:/fuseki/logs
+      - ./dockerfiles/config/skosmos.ttl:/fuseki/skosmos.ttl
     user: 'fuseki:fuseki'
   fuseki-cache:
-    container_name: skosmos-fuseki-cache
     hostname: fuseki-cache
     image: varnish
     security_opt:
       - seccomp:unconfined
     ports:
-      - '9031:80'
+      - ${CACHE_PORT:-9031}:80
     volumes:
       - type: bind
-        source: ./config/varnish-default.vcl
+        source: ./dockerfiles/config/varnish-default.vcl
         target: /etc/varnish/default.vcl
   skosmos:
-    container_name: skosmos-web
     hostname: skosmos
     build:
-      context: ..
+      context: .
       dockerfile: dockerfiles/Dockerfile.ubuntu
     ports:
-      - '9090:80'
+      - ${SKOSMOS_PORT:-9090}:80
     depends_on:
       - fuseki
       - fuseki-cache
     volumes:
       - type: bind
-        source: ./config/config-docker-compose.ttl
+        source: ./dockerfiles/config/config-docker-compose.ttl
         target: /var/www/html/config.ttl

--- a/dockerfiles/README.md
+++ b/dockerfiles/README.md
@@ -99,10 +99,13 @@ extension.
 
 **NOTE**: `fuseki:3030` and `fuseki-cache:80` are from the internal Docker network.
 To the host machine Docker Compose is exposing these values as `localhost:3030`
-and `localhost:9031` respectively.
+and `localhost:9031` respectively. The default host port numbers can be overriden
+by setting `SKOSMOS_PORT`, `FUSEKI_PORT`, and `CACHE_PORT` env variables in an
+`.env` file. This is useful when running multiple Skosmos Docker Compose instances
+on the same host but with different port numbers.
 
 To create the containers in this example setup, you can use this command
-from the `./dockerfiles/` directory:
+from the parent directory (where `docker-compose.yml` is located):
 
     docker compose up -d
 

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -3,15 +3,15 @@ version: '3.7'
 services:
   fuseki:
     extends:
-      file: ../dockerfiles/docker-compose.yml
+      file: ../docker-compose.yml
       service: fuseki
   fuseki-cache:
     extends:
-      file: ../dockerfiles/docker-compose.yml
+      file: ../docker-compose.yml
       service: fuseki-cache
   skosmos:
     extends:
-      file: ../dockerfiles/docker-compose.yml
+      file: ../docker-compose.yml
       service: skosmos
     volumes:
       - type: bind


### PR DESCRIPTION
## Reasons for creating this PR

docker-compose.yml was moved to the top level in PR 1512, already merged to the master branch. The same should be done for the skosmos-3 branch. This PR does just that.

## Link to relevant issue(s), if any

- Closes #1541

## Description of the changes in this PR

- cherry-picked commits from PR #1512 originally by @namedgraph 
- adjust paths in `tests/docker-compose.yml` after `docker-compose.yml` was moved to the top level

## Known problems or uncertainties in this PR

n/a

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
