### PR TITLE
PHP 8.2 support for Skosmos 3 (avoid dynamic properties)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php_version: ["8.0", "8.1"]
+        php_version: ["8.0", "8.1", "8.2"]
         experimental: [false]
-        include:
-          - php_version: "8.2"
-            experimental: true
 
     steps:
     - name: Check out repository code

--- a/src/model/ConceptProperty.php
+++ b/src/model/ConceptProperty.php
@@ -5,6 +5,8 @@
  */
 class ConceptProperty
 {
+    /** stores the Model object (used for translations) */
+    private $model;
     /** stores the property type */
     private $prop;
     /** stores the property supertype */

--- a/src/model/PluginRegister.php
+++ b/src/model/PluginRegister.php
@@ -3,6 +3,7 @@
 class PluginRegister
 {
     private $requestedPlugins;
+    private $pluginOrder;
 
     public function __construct($requestedPlugins=array())
     {

--- a/src/model/VocabularyConfig.php
+++ b/src/model/VocabularyConfig.php
@@ -5,6 +5,7 @@
  */
 class VocabularyConfig extends BaseConfig
 {
+    private $globalPlugins;
     private $pluginRegister;
     private $pluginParameters = array();
     private $languageOrderCache = array();

--- a/tests/ConceptSearchParametersTest.php
+++ b/tests/ConceptSearchParametersTest.php
@@ -14,11 +14,6 @@ class ConceptSearchParametersTest extends PHPUnit\Framework\TestCase
         $this->model = new Model(new GlobalConfig('/../../tests/testconfig.ttl'));
     }
 
-    protected function tearDown(): void
-    {
-        $this->params = null;
-    }
-
     /**
      * @covers ConceptSearchParameters::__construct
      * @covers ConceptSearchParameters::getSearchLimit

--- a/tests/ConceptTest.php
+++ b/tests/ConceptTest.php
@@ -6,6 +6,7 @@ class ConceptTest extends PHPUnit\Framework\TestCase
      * @var Model
      */
     private $model;
+    private $vocab;
     private $concept;
     private $cbdVocab;
     private $cbdGraph;

--- a/tests/FeedbackTest.php
+++ b/tests/FeedbackTest.php
@@ -6,6 +6,7 @@ class FeedbackTest extends PHPUnit\Framework\TestCase
 {
     private $model;
     private $request;
+    private $controller;
 
     protected function setUp(): void
     {

--- a/tests/GenericSparqlTest.php
+++ b/tests/GenericSparqlTest.php
@@ -7,6 +7,7 @@ class GenericSparqlTest extends PHPUnit\Framework\TestCase
     private $sparql;
     private $vocab;
     private $params;
+    private $endpoint;
 
     protected function setUp(): void
     {

--- a/tests/JenaTextSparqlTest.php
+++ b/tests/JenaTextSparqlTest.php
@@ -7,6 +7,7 @@ class JenaTextSparqlTest extends PHPUnit\Framework\TestCase
     private $sparql;
     private $vocab;
     private $params;
+    private $endpoint;
 
     protected function setUp(): void
     {

--- a/tests/PluginRegisterTest.php
+++ b/tests/PluginRegisterTest.php
@@ -5,6 +5,8 @@ class PluginRegisterTest extends PHPUnit\Framework\TestCase
     private $model;
     private $concept;
     private $mockpr;
+    private $stubplugs;
+    private $vocab;
 
     protected function setUp(): void
     {

--- a/tests/VocabularyTest.php
+++ b/tests/VocabularyTest.php
@@ -6,6 +6,7 @@ class VocabularyTest extends \PHPUnit\Framework\TestCase
      * @var Model
      */
     private $model;
+    private $jenamodel;
 
     protected function setUp(): void
     {


### PR DESCRIPTION
## Reasons for creating this PR

Make Skosmos 3 work properly (without deprecation warnings) on PHP 8.2.

## Link to relevant issue(s), if any

- Closes #1413

## Description of the changes in this PR

- make sure to declare all properties to avoid dynamic properties deprecation warnings
- remove useless tearDown method from ConceptSearchParametersTest class
- PHP 8.2 unit tests are no longer marked as experimental (allowed to fail) on PHP 8.2

## Known problems or uncertainties in this PR

I thought about fixing Skosmos 2 (master branch) as well, but it would probably be difficult to make everything work on PHP 8.2 due to all the legacy libraries, so decided to do this only for Skosmos 3.

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
