### PR TITLE
Fix the layout for vocab home and concept page

### DIFF
--- a/resource/css/skosmos.css
+++ b/resource/css/skosmos.css
@@ -376,11 +376,6 @@ body {
     font-weight: bold;
   }
 
-  #sidebar, #main-content {
-    background-color: var(--vocab-bg);
-    margin-left: 1rem;
-  }
-
   /*** Sidebar termpage & vocabpage ***/
   #main-container.vocabpage #sidebar .nav-item, #main-container.termpage #sidebar .nav-item {
     background-color: var(--sidebar-tab-inactive-bg);

--- a/resource/css/skosmos.css
+++ b/resource/css/skosmos.css
@@ -548,6 +548,9 @@ body {
   }
 
   /***** Main content searchpage & searchpage multi vocab *****/
+  #search-results {
+    background-color: var(--vocab-bg);
+  }
   .search-result {
     border-top: 1px solid var(--vocab-table-border);
     margin-top: 2.5rem;

--- a/src/view/vocab-search.twig
+++ b/src/view/vocab-search.twig
@@ -7,7 +7,7 @@
       {% include "search-results-filter.inc" %}
       
       <div class="col-md-7 ps-3" id="main-content">
-        <div class="p-4 pt-4">
+        <div class="p-4 pt-4" id="search-results">
           <div class="search-count">
             <p class="py-2">
               <span class="fw-bold">{{ "%search_count% results for '%term%'" | trans({'%search_count%': search_count, '%term%' : term}) }}</span>


### PR DESCRIPTION
## Reasons for creating this PR

During the previous sprint, combining css code meant the layout on vocabulary and concept page got messed up.

## Description of the changes in this PR

 * Removed css margin styles for sidebar and main-content responsible for the layout mess
 * Moved css colour definitions for main-content and search results to appropriate level that matches the [layout diagram](https://github.com/NatLibFi/Skosmos/wiki/Skosmos-3.0-Roadmap) for vocab-search
