### PR TITLE
Concept page template and Cypress tests

### DIFF
--- a/resource/css/skosmos.css
+++ b/resource/css/skosmos.css
@@ -553,7 +553,7 @@ body {
     margin-bottom: 0;
   }
 
-  .term-other-languages a {
+  .term-other-languages .label {
     display: inline-block;
     width: 50%;
   }

--- a/resource/css/skosmos.css
+++ b/resource/css/skosmos.css
@@ -276,7 +276,7 @@ body {
     font-size: 16px;
   }
 
-  #main-container h1, #main-container h2 {
+  #main-container h1 {
     font-family: var(--font-family-heading);
     font-weight: bold;
   }
@@ -506,9 +506,10 @@ body {
     padding: .5rem 0;
   }
 
-  .property-label {
+  .property-label h2 {
     font-weight: bold;
     font-size: 20px !important;
+    margin-bottom: 0;
   }
 
   .property-value {
@@ -537,7 +538,7 @@ body {
     padding-top: 1.25rem;
   }
 
-  #concept-label h2 {
+  #concept-label h1 {
     float: left;
   }
 
@@ -560,6 +561,10 @@ body {
   #concept-other-languages .label {
     display: inline-block;
     width: 50%;
+  }
+
+  #download-links li {
+    display: inline-block;
   }
 
   /***** Main content searchpage & searchpage multi vocab *****/

--- a/resource/css/skosmos.css
+++ b/resource/css/skosmos.css
@@ -558,6 +558,10 @@ body {
     margin-bottom: 0;
   }
 
+  .prop-skos_altLabel .property-value li, .altlabel {
+    font-style: italic;
+  }
+
   .prop-foreignlabels h3 {
     font-size: 1rem;
     margin-bottom: 0;

--- a/resource/css/skosmos.css
+++ b/resource/css/skosmos.css
@@ -534,7 +534,8 @@ body {
   /*** Main content termpage ***/
   #term-heading span {
     width: 30%;
-    align-self: end;
+    align-self: start;
+    padding-top: 1.2rem;
   }
 
   .copy-clipboard {

--- a/resource/css/skosmos.css
+++ b/resource/css/skosmos.css
@@ -376,6 +376,10 @@ body {
     font-weight: bold;
   }
 
+  #sidebar, #main-content {
+    background-color: var(--vocab-bg);
+  }
+
   /*** Sidebar termpage & vocabpage ***/
   #main-container.vocabpage #sidebar .nav-item, #main-container.termpage #sidebar .nav-item {
     background-color: var(--sidebar-tab-inactive-bg);
@@ -540,6 +544,13 @@ body {
 
   .copy-clipboard:active, .copy-clipboard:focus, .copy-clipboard:active:focus {
     border: none;
+  }
+
+  .property ul, .property li {
+    list-style-type: none;
+    margin-left: 0;
+    padding-left: 0;
+    margin-bottom: 0;
   }
 
   .term-other-languages a {

--- a/resource/css/skosmos.css
+++ b/resource/css/skosmos.css
@@ -497,32 +497,32 @@ body {
     border-bottom: 2px solid var(--main-bg-2);
   }
 
-  #main-table {
-    margin-top: 4rem;
+  #pref-label {
+    padding-bottom: 4rem;
   }
 
-  #main-table tr {
+  .property {
     border-top: 1px solid var(--vocab-table-border);
+    padding: .5rem 0;
   }
 
-  #main-table td {
-    color: var(--vocab-text);
-    border: none;
-  }
-
-  .main-table-label {
-    width: 30%;
+  .property-label {
     font-weight: bold;
     font-size: 20px !important;
   }
 
-  #resource-table th, #term-table th {
+  .property-value {
+    color: var(--vocab-text);
+    border: none;
+  }
+
+  #resource-table th {
     color: var(--vocab-text);
     font-weight: bold;
     border-bottom: 1px solid var(--vocab-text);
   }
 
-  #resource-table td, #term-table td {
+  #resource-table td {
     color: var(--vocab-text);
     border: none;
   }
@@ -532,10 +532,13 @@ body {
   }
 
   /*** Main content termpage ***/
-  #term-heading span {
-    width: 30%;
+  #concept-heading {
     align-self: start;
-    padding-top: 1.2rem;
+    padding-top: 1.25rem;
+  }
+
+  #concept-label h2 {
+    float: left;
   }
 
   .copy-clipboard {
@@ -554,7 +557,7 @@ body {
     margin-bottom: 0;
   }
 
-  .term-other-languages .label {
+  #concept-other-languages .label {
     display: inline-block;
     width: 50%;
   }
@@ -769,7 +772,7 @@ body {
     text-decoration: none !important;
     font-weight: 700 !important;
   }
-  td.main-table-label, .vocab-statistics > h3 {
+  .vocab-statistics > h3 {
     font-size: 20px !important;
   }
   td.align-middle {

--- a/resource/css/skosmos.css
+++ b/resource/css/skosmos.css
@@ -497,7 +497,7 @@ body {
     border-bottom: 2px solid var(--main-bg-2);
   }
 
-  #pref-label {
+  #concept-heading {
     padding-bottom: 4rem;
   }
 
@@ -532,7 +532,7 @@ body {
   }
 
   /*** Main content termpage ***/
-  #concept-heading {
+  #concept-property-label {
     align-self: start;
     padding-top: 1.25rem;
   }

--- a/resource/css/skosmos.css
+++ b/resource/css/skosmos.css
@@ -376,7 +376,7 @@ body {
     font-weight: bold;
   }
 
-  #sidebar, #main-content {
+  #sidebar {
     background-color: var(--vocab-bg);
   }
 
@@ -494,6 +494,7 @@ body {
   }
 
   .main-content-section {
+    background-color: var(--vocab-bg);
     border-bottom: 2px solid var(--main-bg-2);
   }
 

--- a/resource/css/skosmos.css
+++ b/resource/css/skosmos.css
@@ -558,9 +558,9 @@ body {
     margin-bottom: 0;
   }
 
-  #concept-other-languages .label {
-    display: inline-block;
-    width: 50%;
+  .prop-foreignlabels h3 {
+    font-size: 1rem;
+    margin-bottom: 0;
   }
 
   #download-links li {

--- a/src/controller/RestController.php
+++ b/src/controller/RestController.php
@@ -700,12 +700,10 @@ class RestController extends Controller
 
         $queryExVocabs = $request->getQueryParamBoolean('external', true);
 
-        $results = $vocab->getConceptInfo($uri, $request->getContentLang());
-        if (empty($results)) {
+        $concept = $vocab->getConceptInfo($uri, $request->getContentLang());
+        if (empty($concept)) {
             return $this->returnError(404, 'Bad Request', "no concept found with given uri");
         }
-
-        $concept = $results[0];
 
         $mappings = [];
         foreach ($concept->getMappingProperties() as $mappingProperty) {

--- a/src/controller/WebController.php
+++ b/src/controller/WebController.php
@@ -178,12 +178,12 @@ class WebController extends Controller
         $langcodes = $vocab->getConfig()->getShowLangCodes();
         $uri = $vocab->getConceptURI($request->getUri()); // make sure it's a full URI
 
-        $results = $vocab->getConceptInfo($uri, $request->getContentLang());
-        if (!$results) {
+        $concept = $vocab->getConceptInfo($uri, $request->getContentLang());
+        if (empty($concept)) {
             $this->invokeGenericErrorPage($request);
             return;
         }
-        if ($this->notModified($results[0])) {
+        if ($this->notModified($concept)) {
             return;
         }
         $customLabels = $vocab->getConfig()->getPropertyLabelOverrides();
@@ -194,7 +194,7 @@ class WebController extends Controller
         $crumbs = $vocab->getBreadCrumbs($request->getContentLang(), $uri);
         echo $template->render(
             array(
-            'search_results' => $results,
+            'concept' => $concept,
             'vocab' => $vocab,
             'concept_uri' => $uri,
             'languages' => $this->languages,

--- a/src/model/Vocabulary.php
+++ b/src/model/Vocabulary.php
@@ -444,22 +444,23 @@ class Vocabulary extends DataObject implements Modifiable
     }
 
     /**
-     * Makes a query into the sparql endpoint for a concept.
-     * @param string $uri the full URI of the concept
-     * @return Concept[]
+     * Get all information about a single concept.
+     * @param string $uri full URI of the concept
+     * @param string $clang content language
+     * @return Concept
      */
-    public function getConceptInfo($uri, $clang)
+    public function getConceptInfo(string $uri, string $clang): Concept
     {
         $sparql = $this->getSparql();
         $conceptInfo = null;
         try {
-            $conceptInfo = $sparql->queryConceptInfo($uri, $this->config->getArrayClassURI(), array($this), $clang);
+            $conceptInfo = $sparql->queryConceptInfo([$uri], $this->config->getArrayClassURI(), array($this), $clang);
         } catch (EasyRdf\Http\Exception | EasyRdf\Exception | Throwable $e) {
             if ($this->model->getConfig()->getLogCaughtExceptions()) {
                 error_log('Caught exception: ' . $e->getMessage());
             }
         }
-        return $conceptInfo;
+        return $conceptInfo[0];
     }
 
     /**

--- a/src/view/about.twig
+++ b/src/view/about.twig
@@ -5,7 +5,7 @@
 <div class="container">
   <div class="mx-5">
     <div class="px-3 pb-3 bg-light">
-      <h2 class="fs-3 mb-5">{{"About" | trans }}</h2>
+      <h1 class="fs-3 mb-5">{{"About" | trans }}</h1>
       <p class="fs-6">
       {% include 'about-info.inc' %}
       </p>

--- a/src/view/concept-card.inc
+++ b/src/view/concept-card.inc
@@ -1,184 +1,51 @@
-<div class="col-md-8" id="main-content"> <!-- id for partial page load -->
-    <h2 class="visually-hidden">Concept information</h2>
-    {% if concept.deprecated %}
-    <div class="alert alert-danger">
-      <p class="deprecated-alert">{{ "deprecated" | trans }}</p>
-    </div>
-    {% endif %}
-    {% if concept.label.lang != request.contentLang %}
-    <div class="alert alert-lang">
-      <p class="language-alert">{{ "There is no term for this concept in this language" | trans }}</p>
-    </div>
-    {% endif %}
-    <div class="container concept-info{% if concept.deprecated %} deprecated-concept{% endif %}">
-      <div class="bg-light py-5 px-5 concept-main">
-      {% spaceless %}
-      <div id="term-heading" class="d-flex">
-          <span>
-            {% set subPrefLabelTranslation = concept.preferredSubpropertyLabelTranslation(request.lang) %}
-            {% if subPrefLabelTranslation %}
-              {{ subPrefLabelTranslation }}
-            {% elseif custom_labels['skos:prefLabel']['label'][request.lang] %}
-              {{ custom_labels['skos:prefLabel']['label'][request.lang] }}
-            {% else %}
-              skos:prefLabel
-            {% endif %}
-          </span>
-        {% if concept.foundBy %} {# hit has been found through an alternative label #}
-        <span class="versal">{{ concept.foundBy }} ></span>
-        {% if concept.ExVocab is defined %}
-        <span class="prefLabel conceptlabel redirected-vocab-id"> @{{ concept.ExVocab }}</span>
-        {% endif %}
-      {% else %}
-        {% apply spaceless %}
-        {% if concept.notation %}<span class="notation" id="notation">{{ concept.notation }}</span>{% endif %}
-        {% if concept.hasXlLabel %}
-        <span class="reified-property-value xl-pref-label tooltip-html">
-          <img src="resource/pics/about.png">
-            <div class="reified-tooltip tooltip-html-content">
-              {% for key, val in concept.xlLabel.properties %}
-              <p><span class="tooltip-prop">{{ key }}</span>:
-                <span class="versal">{{ val }}</span>
-              </p>
-              {% endfor %}
-            </div>
-        </span>
-        <h1 id="pref-label">{{ concept.xlLabel }}</h1>
-        {% else %}
-        <h1 id="pref-label">{{ concept.label }}</h1>
-        {% if concept.label.lang != request.contentLang and concept.label.lang != '' %}
-        <span class="prefLabelLang"> ({{ concept.label.lang }})</span>
-        {% endif %}
-        {% endif %}
-        &nbsp;
-        <button type="button" data-bs-toggle="tooltip" data-bs-placement="button" title="Copy to clipboard" class="btn btn-default btn-xs copy-clipboard" for="#{% if concept.notation %}notation{% else %}pref-label{% endif %}">
-          <span class="fa-regular fa-copy"></span>
+<div class="col-md-8 ps-3">
+  <div class="pt-3" id="main-content">
+
+    <div class="main-content-section p-5">
+
+      <div class="d-flex" id="term-heading">
+        <span>Käytettävä termi</span>
+        <h2 class="mb-0" id="pref-label">A Allgemeinwörter</h2>
+        <button class="btn btn-default copy-clipboard" type="button" data-bs-toggle="tooltip" data-bs-placement="button" title="Copy to clipboard" for="#pref-label">
+          <i class="fa-regular fa-copy"></i>
         </button>
-        {% endapply %}
-      {% endif %}
       </div>
-      {% endspaceless %}
-      <table id="main-table" class="table">
+
+      <table class="table" id="main-table">
         <tbody>
-        {% for property in concept.properties %} {# loop through ConceptProperty objects #}
-          {% if property.getSubPropertyOf != 'skos:hiddenLabel' %}
-          <tr class="{% if property.type == 'dc:isReplacedBy' %}replaced-by {% endif%}property prop-{{property.ID}}">
-            <td class="main-table-label">
-                {%- if custom_labels[property.type]['label'][request.lang] -%}
-                  {{ custom_labels[property.type]['label'][request.lang] }}
-                {%- else -%}
-                  {{ property.label }}
-                {%- endif -%}
+          <tr>
+            <td class="main-table-label px-0">Tyyppi</td>
+            <td class="align-middle px-0">Thsys</td>
+          </tr>
+          <tr>
+            <td class="main-table-label px-0">Alakäsitteet</td>
+            <td class="align-middle px-0">
+              <a href="#">A.00 Allgemeinwörter</a><br>
+              <a href="#">A.01 Regionaladjektive und Sprache</a>
             </td>
-          {% for propval in property.values %} {# loop through ConceptPropertyValue objects #}
-          {% if not loop.first %}</tr><tr><td class="main-table-label"></td>{% endif %}
-          <td class="align-middle">
-            {% if propval.uri and propval.type != 'rdf:type' %} {# resources with URI #}
-              {% if propval.label %}
-                {% if propval.isExternal %}
-                <a href="{{ propval.uri | link_url(propval.exvocab, request.lang, 'page', request.contentLang) }}">{{ propval.label }}</a>{% if propval.exvocab %} ({{ propval.vocabname }}){% endif %}
-                  {% else %}
-                  {% if propval.isReified %} {# e.g. skos:definition's with resource values #}
-                  <span class="versal reified-property-value tooltip-html">
-                    <img alt="Information" src="resource/pics/about.png">{% if propval.notation %}<span class="versal">{{ propval.notation }} </span>{% endif %} {{ propval.label(request.contentLang) }}
-                    <div class="reified-tooltip tooltip-html-content">{% for key, val in propval.reifiedPropertyValues %}<p><span class="tooltip-prop">{{ key }}</span>: <a href="{{ val.uri | link_url(val.exvocab, request.lang, 'page', request.contentLang) }}">{{ val.label(request.contentLang) }}</a></p>{% endfor %}</div>
-                  </span>
-                  {% else %}
-                      <a href="{{ propval.uri | link_url(propval.vocab, request.lang, 'page', request.contentLang) }}">{% if propval.notation %}<span class="versal">{{ propval.notation }} </span>{% endif %}{{ propval.label(request.contentLang) }}</a>
-                  {% endif %}
-                  {% endif %}
-                  {% if propval.label.lang and (propval.label.lang != request.contentLang or explicit_langcodes) %}<span class="versal"> ({{ propval.label(request.contentLang).lang }})</span>{% endif %}
-                  {% if propval.SubMembers %}<div class="subvalue"> {# if property is a group concept that has sub properties #}
-                    {% for sub_member in propval.SubMembers %}
-                      <a class="propertyvalue" href="{{ sub_member.uri | link_url(propval.vocab,request.lang) }}">{{ sub_member.label(request.contentLang) }}</a>
-                      {% if sub_member.lang and (sub_member.lang != request.lang or explicit_langcodes) %}<span class="propertyvalue"> ({{ sub_member.lang }})</span>{% endif %}
-                      <br />
-                    {% endfor %}
-                    </div>
-                  {% endif %}
-                {% endif %}
-              {% elseif property.type == 'rdf:type' %}<p>{{ propval.label }}</p>
-              {% else %} {# Literals (no URI), eg. alternative labels as properties #}
-                  {% if propval.lang == request.contentLang or propval.lang == null or not request.contentLang and propval.lang == request.lang %}
-                    {% if propval.hasXlProperties %}
-                    <span class="reified-property-value xl-label tooltip-html">
-                      <img alt="Information" src="resource/pics/about.png">
-                      <div class="reified-tooltip tooltip-html-content">
-                      {% for key, val in propval.xlLabel.properties %}
-                        <p><span class="tooltip-prop">{{ key }}</span>:
-                          <span class="versal">{{ val }}</span>
-                        </p>
-                      {% endfor %}
-                      </div>
-                    </span>
-                    {% endif %}
-                    <span{% if property.type == 'skos:altLabel' %} class="replaced"{% endif %}>
-                      {%- if propval.containsHtml %}{{ propval.label|raw }}{% else %}{{ propval.label }}{% endif %}
-                      {%- if propval.lang and (request.contentLang and propval.lang != request.contentLang or explicit_langcodes) %} ({{ propval.lang }}){% endif %}
-                      {%- if propval.datatype %} ({{ propval.datatype }}){% endif -%}
-                    </span>
-                {% endif %}
-              {% endif %}
-              </td>
-            </tr>
-          {% endfor %}
-          {% endif %}
-        {% endfor %}
-        </tr>
-      {% set foreignLabels = concept.foreignLabels %}
-      {% if foreignLabels %}
-      <tr class="prop-other-languages">
-        <td class="main-table-label">{{ "foreign prefLabels" | trans }}</td>
-        <td class="align-middle">
-            {% for language,labels in foreignLabels %}
-              {% for value in labels.prefLabel|default([])|merge(labels.altLabel|default([])) %}
-                <div class="col-6 versal{% if value.type == "skos:altLabel" %} replaced{%else %} versal-pref{% endif %}">
-                  {% if value.hasXlProperties %}
-                  <span class="reified-property-value xl-label tooltip-html">
-                    <img alt="Information" src="resource/pics/about.png">
-                    <div class="reified-tooltip tooltip-html-content">
-                    {% for key, val in value.xlLabel.properties %}
-                    {% if key != 'rdf:type' and key != 'skosxl:literalForm' %}
-                      <p><span class="tooltip-prop">{{ key }}</span>:
-                        <span class="versal">{{ val }}</span>
-                      </p>
-                    {% endif %}
-                    {% endfor %}
-                    </div>
-                  </span>
-                  {% endif %}
-                  {% if value.type == "skos:prefLabel" and value.lang in request.vocab.config.languages %}
-                  <a href='{{ concept.uri|link_url(request.vocabid,request.lang, 'page', value.lang) }}' hreflang='{{ value.lang }}'>{{ value.label }}</a>
-                  {% else %}{{ value.label }}
-                  {% endif %}
-                </div>
-                <div class="col-6 versal">{% if loop.first %}<p>{{ language }}</p>{% endif %}</div>
-              {% endfor %}
-            {% endfor %}
-          </div>
-        </td>
-      </tr>
-      {% endif %}
-      <tr class="prop-uri">
-        <td class="main-table-label">URI</td>
-        <td class="align-middle">{{ concept.uri }}</td>
-      </tr>
-      </tbody>
-    </table>
-        <div class="row">
-            <div class="property-label"><h3 class="versal">{{ "Download this concept in SKOS format:" | trans }}</h3></div>
-            <div class="property-value-column">
-<span class="versal concept-download-links"><a href="rest/v1/{% if concept.vocab %}{{ concept.vocab.id }}{% else %}{{ vocab.id }}{% endif %}/data?uri={{ concept.uri|url_encode }}&amp;format=application/rdf%2Bxml">RDF/XML</a>
-          <a href="rest/v1/{% if concept.vocab %}{{ concept.vocab.id }}{% else %}{{ vocab.id }}{% endif %}/data?uri={{ concept.uri|url_encode }}&amp;format=text/turtle">
-            TURTLE</a>
-          <a href="rest/v1/{% if concept.vocab %}{{ concept.vocab.id }}{% else %}{{ vocab.id }}{% endif %}/data?uri={{ concept.uri|url_encode }}&amp;format=application/ld%2Bjson">JSON-LD</a>
-        </span>{% if concept.date %}<span class="versal date-info">{{ concept.date }}</span>{% endif %}
-            </div>
-        </div>
-      </div>
+          </tr>
+          <tr>
+            <td class="main-table-label px-0">Notaatio</td>
+            <td class="align-middle px-0">A</td>
+          </tr>
+          <tr>
+            <td class="main-table-label px-0">Muunkieliset termit</td>
+            <td class="term-other-languages align-middle px-0">
+              <a href="#">A General descriptors</a>
+              <span>englanti</span>
+            </td>
+          </tr>
+          <tr>
+            <td class="main-table-label px-0">URI</td>
+            <td class="align-middle px-0"><a href="#">http://zbw.eu/stw/thsys/a</a></td>
+          </tr>
+          <tr>
+            <td class="main-table-label px-0"><i class="fa-solid fa-download"></i> Lataa tämä käsite</td>
+            <td class="align-middle px-0"><a class="me-3" href="#">RDF/XML</a> <a class="me-3" href="#">TURTLE</a> <a href="#">JSON-LD</a></td>
+          </tr>
+        </tbody>
+      </table>
     </div>
 
-  <!-- appendix / concept mapping properties -->
-  <div id="concept-mappings">
   </div>
 </div>

--- a/src/view/concept-card.inc
+++ b/src/view/concept-card.inc
@@ -29,13 +29,24 @@
             </td>
           </tr>
           {% endfor %}
+          {% set foreignLabels = concept.foreignLabels %}
+          {% if foreignLabels %}
           <tr>
-            <td class="main-table-label px-0">Muunkieliset termit</td>
+            <td class="main-table-label px-0">{{ 'foreign prefLabels'|trans }}</td>
             <td class="term-other-languages align-middle px-0">
-              <a href="#">A General descriptors</a>
-              <span>englanti</span>
+                {% for language,labels in foreignLabels %}
+                {% for value in labels.prefLabel|default([])|merge(labels.altLabel|default([])) %}
+                {% if value.type == "skos:prefLabel" and value.lang in request.vocab.config.languages %}
+                <a class="label" href='{{ concept.uri|link_url(request.vocabid,request.lang, 'page', value.lang) }}' hreflang='{{ value.lang }}'>{{ value.label }}</a>
+                {% else %}
+                <span class="label">{{ value.label }}</span>
+                {% endif %}
+                {% if loop.first %}<span>{{ language }}</span>{% endif %}
+                {% endfor %}
+                {% endfor %}
             </td>
           </tr>
+          {% endif %}
           <tr>
             <td class="main-table-label px-0">URI</td>
             <td class="align-middle px-0"><a href="#">{{ concept.uri }}</a></td>

--- a/src/view/concept-card.inc
+++ b/src/view/concept-card.inc
@@ -7,7 +7,7 @@
         <div class="col-sm-4 px-0" id="concept-property-label">{{ "skos:prefLabel" | trans }}</div>
         <div class="col-sm-8" id="concept-label">
           <h1 class="mb-0">{{ concept.label }}</h1>
-          <button class="btn btn-default copy-clipboard" type="button" data-bs-toggle="tooltip" data-bs-placement="button" title="{{ "Copy to clipboard" | trans }}" for="#pref-label">
+          <button class="btn btn-default copy-clipboard" type="button" data-bs-toggle="tooltip" data-bs-placement="button" title="{{ "Copy to clipboard" | trans }}">
           <i class="fa-regular fa-copy"></i>
           </button>
         </div>
@@ -25,7 +25,7 @@
             <li>{{ propval.label }}</li>
             {% endif %}
           {% endfor %}
-          </li>
+          </ul>
         </div>
       </div>
       {% endfor %}
@@ -34,16 +34,22 @@
       <div class="row property prop-foreignlabels">
         <div class="col-sm-4 px-0 property-label"><h2>{{ 'foreign prefLabels'|trans }}</h2></div>
         <div class="col-sm-8" id="concept-other-languages">
-            {% for language,labels in foreignLabels %}
-            {% for value in labels.prefLabel|default([])|merge(labels.altLabel|default([])) %}
-            {% if value.type == "skos:prefLabel" and value.lang in request.vocab.config.languages %}
-            <a class="label" href='{{ concept.uri|link_url(request.vocabid,request.lang, 'page', value.lang) }}' hreflang='{{ value.lang }}'>{{ value.label }}</a>
-            {% else %}
-            <span class="label">{{ value.label }}</span>
-            {% endif %}
-            {% if loop.first %}<span>{{ language }}</span>{% endif %}
-            {% endfor %}
-            {% endfor %}
+          {% for language,labels in foreignLabels %}
+          <div class="row">
+            <div class="col-sm-6 order-last"><h3>{{ language }}</h3></div>
+            <div class="col-sm-6">
+              <ul>
+                {% for value in labels.prefLabel|default([])|merge(labels.altLabel|default([])) %}
+                {% if value.type == "skos:prefLabel" and value.lang in request.vocab.config.languages %}
+                <li><a href='{{ concept.uri|link_url(request.vocabid,request.lang, 'page', value.lang) }}' hreflang='{{ value.lang }}'>{{ value.label }}</a></li>
+                {% else %}
+                <li>{{ value.label }}</li>
+                {% endif %}
+                {% endfor %}
+              </ul>
+            </div>
+          </div>
+          {% endfor %}
         </div>
       </div>
       {% endif %}
@@ -64,5 +70,8 @@
 
     </div>
 
+  </div>
+  <!-- appendix / concept mapping properties -->
+  <div id="concept-mappings">
   </div>
 </div>

--- a/src/view/concept-card.inc
+++ b/src/view/concept-card.inc
@@ -19,7 +19,7 @@
         <div class="col-sm-8 align-self-center property-value">
           <ul class="align-bottom">
           {% for propval in property.values %}
-            {% if propval.uri %} {# resources with URI #}
+            {% if propval.uri and property.type != 'rdf:type' %} {# resources with URI #}
             <li><a href="{{ propval.uri | link_url(propval.vocab, request.lang, 'page', request.contentLang) }}">{% if propval.notation %}<span class="versal">{{ propval.notation }}</span> {% endif %}{{ propval.label(request.contentLang) }}</a></li>
             {% else %} {# literals, e.g. altLabels #}
             <li>{{ propval.label }}</li>

--- a/src/view/concept-card.inc
+++ b/src/view/concept-card.inc
@@ -6,7 +6,7 @@
       <div class="row" id="concept-heading">
         <div class="col-sm-4 px-0" id="concept-property-label">{{ "skos:prefLabel" | trans }}</div>
         <div class="col-sm-8" id="concept-label">
-          <h2 class="mb-0">{{ concept.label }}</h2>
+          <h1 class="mb-0">{{ concept.label }}</h1>
           <button class="btn btn-default copy-clipboard" type="button" data-bs-toggle="tooltip" data-bs-placement="button" title="{{ "Copy to clipboard" | trans }}" for="#pref-label">
           <i class="fa-regular fa-copy"></i>
           </button>
@@ -15,7 +15,7 @@
 
       {% for property in concept.properties %}
       <div class="row property prop-{{property.ID}}">
-        <div class="col-sm-4 px-0 property-label">{{ property.label }}</div>
+        <div class="col-sm-4 px-0 property-label"><h2>{{ property.label}}</h2></div>
         <div class="col-sm-8 align-self-center property-value">
           <ul class="align-bottom">
           {% for propval in property.values %}
@@ -32,7 +32,7 @@
       {% set foreignLabels = concept.foreignLabels %}
       {% if foreignLabels %}
       <div class="row property prop-foreignlabels">
-        <div class="col-sm-4 px-0 property-label">{{ 'foreign prefLabels'|trans }}</div>
+        <div class="col-sm-4 px-0 property-label"><h2>{{ 'foreign prefLabels'|trans }}</h2></div>
         <div class="col-sm-8" id="concept-other-languages">
             {% for language,labels in foreignLabels %}
             {% for value in labels.prefLabel|default([])|merge(labels.altLabel|default([])) %}
@@ -48,15 +48,17 @@
       </div>
       {% endif %}
       <div class="row property prop-uri">
-        <div class="col-sm-4 px-0 property-label">URI</div>
+        <div class="col-sm-4 px-0 property-label"><h2>URI</h2></div>
         <div class="col-sm-8" id="concept-uri"><a href="#">{{ concept.uri }}</a></div>
       </div>
       <div class="row property prop-download">
-        <div class="col-sm-4 px-0 property-label"><i class="fa-solid fa-download"></i> {{ "Download this concept" | trans }}</div>
+        <div class="col-sm-4 px-0 property-label"><h2><i class="fa-solid fa-download"></i> {{ "Download this concept" | trans }}</h2></div>
         <div class="col-sm-8" id="download-links">
-          <a class="me-3" href="rest/v1/{% if concept.vocab %}{{ concept.vocab.id }}{% else %}{{ vocab.id }}{% endif %}/data?uri={{ concept.uri|url_encode }}&amp;format=application/rdf%2Bxml">RDF/XML</a>
-          <a class="me-3" href="rest/v1/{% if concept.vocab %}{{ concept.vocab.id }}{% else %}{{ vocab.id }}{% endif %}/data?uri={{ concept.uri|url_encode }}&amp;format=text/turtle">TURTLE</a>
-          <a href="rest/v1/{% if concept.vocab %}{{ concept.vocab.id }}{% else %}{{ vocab.id }}{% endif %}/data?uri={{ concept.uri|url_encode }}&amp;format=application/ld%2Bjson">JSON-LD</a>
+          <ul>
+            <li><a class="me-3" href="rest/v1/{% if concept.vocab %}{{ concept.vocab.id }}{% else %}{{ vocab.id }}{% endif %}/data?uri={{ concept.uri|url_encode }}&amp;format=application/rdf%2Bxml">RDF/XML</a></li>
+            <li><a class="me-3" href="rest/v1/{% if concept.vocab %}{{ concept.vocab.id }}{% else %}{{ vocab.id }}{% endif %}/data?uri={{ concept.uri|url_encode }}&amp;format=text/turtle">TURTLE</a></li>
+            <li><a href="rest/v1/{% if concept.vocab %}{{ concept.vocab.id }}{% else %}{{ vocab.id }}{% endif %}/data?uri={{ concept.uri|url_encode }}&amp;format=application/ld%2Bjson">JSON-LD</a></li>
+          </ul>
         </div>
       </div>
 

--- a/src/view/concept-card.inc
+++ b/src/view/concept-card.inc
@@ -66,11 +66,11 @@
           {% if property.getSubPropertyOf != 'skos:hiddenLabel' %}
           <tr class="{% if property.type == 'dc:isReplacedBy' %}replaced-by {% endif%}property prop-{{property.ID}}">
             <td class="main-table-label">
-                {% if custom_labels[property.type]['label'][request.lang] %}
+                {%- if custom_labels[property.type]['label'][request.lang] -%}
                   {{ custom_labels[property.type]['label'][request.lang] }}
-                {% else %}
+                {%- else -%}
                   {{ property.label }}
-                {% endif %}
+                {%- endif -%}
             </td>
           {% for propval in property.values %} {# loop through ConceptPropertyValue objects #}
           {% if not loop.first %}</tr><tr><td class="main-table-label"></td>{% endif %}
@@ -86,7 +86,7 @@
                     <div class="reified-tooltip tooltip-html-content">{% for key, val in propval.reifiedPropertyValues %}<p><span class="tooltip-prop">{{ key }}</span>: <a href="{{ val.uri | link_url(val.exvocab, request.lang, 'page', request.contentLang) }}">{{ val.label(request.contentLang) }}</a></p>{% endfor %}</div>
                   </span>
                   {% else %}
-                      <a href="{{ propval.uri | link_url(propval.vocab, request.lang, 'page', request.contentLang) }}">{% if propval.notation %}<span class="versal">{{ propval.notation }} </span>{% endif %} {{ propval.label(request.contentLang) }}</a>
+                      <a href="{{ propval.uri | link_url(propval.vocab, request.lang, 'page', request.contentLang) }}">{% if propval.notation %}<span class="versal">{{ propval.notation }} </span>{% endif %}{{ propval.label(request.contentLang) }}</a>
                   {% endif %}
                   {% endif %}
                   {% if propval.label.lang and (propval.label.lang != request.contentLang or explicit_langcodes) %}<span class="versal"> ({{ propval.label(request.contentLang).lang }})</span>{% endif %}
@@ -161,8 +161,8 @@
         </td>
       </tr>
       {% endif %}
-      <tr>
-        <td class="main-table-label"><h3>URI</h3></td>
+      <tr class="prop-uri">
+        <td class="main-table-label">URI</td>
         <td class="align-middle">{{ concept.uri }}</td>
       </tr>
       </tbody>

--- a/src/view/concept-card.inc
+++ b/src/view/concept-card.inc
@@ -13,21 +13,22 @@
 
       <table class="table" id="main-table">
         <tbody>
-          <tr>
-            <td class="main-table-label px-0">Tyyppi</td>
-            <td class="align-middle px-0">Thsys</td>
-          </tr>
-          <tr>
-            <td class="main-table-label px-0">Alakäsitteet</td>
+          {% for property in concept.properties %}
+          <tr class="property prop-{{property.ID}}">
+            <td class="main-table-label px-0">{{ property.label }}</td>
             <td class="align-middle px-0">
-              <a href="#">A.00 Allgemeinwörter</a><br>
-              <a href="#">A.01 Regionaladjektive und Sprache</a>
+              <ul>
+              {% for propval in property.values %}
+                {% if propval.uri %} {# resources with URI #}
+                <li><a href="{{ propval.uri | link_url(propval.vocab, request.lang, 'page', request.contentLang) }}">{% if propval.notation %}<span class="versal">{{ propval.notation }} </span>{% endif %} {{ propval.label(request.contentLang) }}</a></li>
+                {% else %} {# literals, e.g. altLabels #}
+                <li>{{ propval.label }}</li>
+                {% endif %}
+              {% endfor %}
+              </li>
             </td>
           </tr>
-          <tr>
-            <td class="main-table-label px-0">Notaatio</td>
-            <td class="align-middle px-0">A</td>
-          </tr>
+          {% endfor %}
           <tr>
             <td class="main-table-label px-0">Muunkieliset termit</td>
             <td class="term-other-languages align-middle px-0">

--- a/src/view/concept-card.inc
+++ b/src/view/concept-card.inc
@@ -7,7 +7,8 @@
         <div class="col-sm-4 px-0" id="concept-property-label">{{ "skos:prefLabel" | trans }}</div>
         <div class="col-sm-8" id="concept-label">
           <h1 class="mb-0">{{ concept.label }}</h1>
-          <button class="btn btn-default copy-clipboard" type="button" data-bs-toggle="tooltip" data-bs-placement="button" title="{{ "Copy to clipboard" | trans }}">
+          <button class="btn btn-default copy-clipboard" type="button"
+                  data-bs-toggle="tooltip" data-bs-placement="button" title="{{ 'Copy to clipboard' | trans }}">
           <i class="fa-regular fa-copy"></i>
           </button>
         </div>
@@ -20,7 +21,11 @@
           <ul class="align-bottom">
           {% for propval in property.values %}
             {% if propval.uri and property.type != 'rdf:type' %} {# resources with URI #}
-            <li><a href="{{ propval.uri | link_url(propval.vocab, request.lang, 'page', request.contentLang) }}">{% if propval.notation %}<span class="versal">{{ propval.notation }}</span> {% endif %}{{ propval.label(request.contentLang) }}</a></li>
+            <li>
+              <a href="{{ propval.uri | link_url(propval.vocab, request.lang, 'page', request.contentLang) }}">
+                {{ propval.label(request.contentLang) }}
+              </a>
+            </li>
             {% else %} {# literals, e.g. altLabels #}
             <li>{{ propval.label }}</li>
             {% endif %}
@@ -41,7 +46,10 @@
               <ul>
                 {% for value in labels.prefLabel|default([])|merge(labels.altLabel|default([])) %}
                 {% if value.type == "skos:prefLabel" and value.lang in request.vocab.config.languages %}
-                <li><a href='{{ concept.uri|link_url(request.vocabid,request.lang, 'page', value.lang) }}' hreflang='{{ value.lang }}'>{{ value.label }}</a></li>
+                <li>
+                  <a href="{{ concept.uri|link_url(request.vocabid,request.lang, 'page', value.lang) }}"
+                     hreflang="{{ value.lang }}">{{ value.label }}</a>
+                </li>
                 {% else %}
                 <li class="altlabel">{{ value.label }}</li>
                 {% endif %}
@@ -58,12 +66,20 @@
         <div class="col-sm-8" id="concept-uri"><a href="#">{{ concept.uri }}</a></div>
       </div>
       <div class="row property prop-download">
-        <div class="col-sm-4 px-0 property-label"><h2><i class="fa-solid fa-download"></i> {{ "Download this concept" | trans }}</h2></div>
+        <div class="col-sm-4 px-0 property-label">
+          <h2><i class="fa-solid fa-download"></i> {{ "Download this concept" | trans }}</h2>
+        </div>
         <div class="col-sm-8" id="download-links">
           <ul>
-            <li><a class="me-3" href="rest/v1/{% if concept.vocab %}{{ concept.vocab.id }}{% else %}{{ vocab.id }}{% endif %}/data?uri={{ concept.uri|url_encode }}&amp;format=application/rdf%2Bxml">RDF/XML</a></li>
-            <li><a class="me-3" href="rest/v1/{% if concept.vocab %}{{ concept.vocab.id }}{% else %}{{ vocab.id }}{% endif %}/data?uri={{ concept.uri|url_encode }}&amp;format=text/turtle">TURTLE</a></li>
-            <li><a href="rest/v1/{% if concept.vocab %}{{ concept.vocab.id }}{% else %}{{ vocab.id }}{% endif %}/data?uri={{ concept.uri|url_encode }}&amp;format=application/ld%2Bjson">JSON-LD</a></li>
+            <li>
+              <a class="me-3" href="rest/v1/{{ vocab.id }}/data?uri={{ concept.uri|url_encode }}&amp;format=application/rdf%2Bxml">RDF/XML</a>
+            </li>
+            <li>
+              <a class="me-3"href="rest/v1/{{ vocab.id }}/data?uri={{ concept.uri|url_encode }}&amp;format=text/turtle">TURTLE</a>
+            </li>
+            <li>
+              <a href="rest/v1/{{ vocab.id }}/data?uri={{ concept.uri|url_encode }}&amp;format=application/ld%2Bjson">JSON-LD</a>
+            </li>
           </ul>
         </div>
       </div>

--- a/src/view/concept-card.inc
+++ b/src/view/concept-card.inc
@@ -1,6 +1,4 @@
 <div class="col-md-8" id="main-content"> <!-- id for partial page load -->
-  {% if search_results %}
-    {% for concept in search_results %} {# loop through the hits #}
     <h2 class="visually-hidden">Concept information</h2>
     {% if concept.deprecated %}
     <div class="alert alert-danger">
@@ -179,13 +177,7 @@
         </div>
       </div>
     </div>
-    {% endfor %}
 
-  {% else %}
-  <div class="alert alert-danger">
-    <p>{% trans %}Error: Term %term% not found in vocabulary!{% endtrans %}</p>
-  </div>
-  {% endif %}
   <!-- appendix / concept mapping properties -->
   <div id="concept-mappings">
   </div>

--- a/src/view/concept-card.inc
+++ b/src/view/concept-card.inc
@@ -43,7 +43,7 @@
                 {% if value.type == "skos:prefLabel" and value.lang in request.vocab.config.languages %}
                 <li><a href='{{ concept.uri|link_url(request.vocabid,request.lang, 'page', value.lang) }}' hreflang='{{ value.lang }}'>{{ value.label }}</a></li>
                 {% else %}
-                <li>{{ value.label }}</li>
+                <li class="altlabel">{{ value.label }}</li>
                 {% endif %}
                 {% endfor %}
               </ul>

--- a/src/view/concept-card.inc
+++ b/src/view/concept-card.inc
@@ -3,10 +3,10 @@
 
     <div class="main-content-section p-5">
 
-      <div class="row">
-        <div class="col-sm-4 px-0" id="concept-heading">{{ "skos:prefLabel" | trans }}</div>
+      <div class="row" id="concept-heading">
+        <div class="col-sm-4 px-0" id="concept-property-label">{{ "skos:prefLabel" | trans }}</div>
         <div class="col-sm-8" id="concept-label">
-          <h2 class="mb-0" id="pref-label">{{ concept.label }}</h2>
+          <h2 class="mb-0">{{ concept.label }}</h2>
           <button class="btn btn-default copy-clipboard" type="button" data-bs-toggle="tooltip" data-bs-placement="button" title="{{ "Copy to clipboard" | trans }}" for="#pref-label">
           <i class="fa-regular fa-copy"></i>
           </button>
@@ -20,7 +20,7 @@
           <ul class="align-bottom">
           {% for propval in property.values %}
             {% if propval.uri %} {# resources with URI #}
-            <li><a href="{{ propval.uri | link_url(propval.vocab, request.lang, 'page', request.contentLang) }}">{% if propval.notation %}<span class="versal">{{ propval.notation }} </span>{% endif %} {{ propval.label(request.contentLang) }}</a></li>
+            <li><a href="{{ propval.uri | link_url(propval.vocab, request.lang, 'page', request.contentLang) }}">{% if propval.notation %}<span class="versal">{{ propval.notation }}</span> {% endif %}{{ propval.label(request.contentLang) }}</a></li>
             {% else %} {# literals, e.g. altLabels #}
             <li>{{ propval.label }}</li>
             {% endif %}

--- a/src/view/concept-card.inc
+++ b/src/view/concept-card.inc
@@ -3,64 +3,63 @@
 
     <div class="main-content-section p-5">
 
-      <div class="d-flex" id="term-heading">
-        <span>{{ "skos:prefLabel" | trans }}</span>
-        <h2 class="mb-0" id="pref-label">{{ concept.label }}</h2>
-        <button class="btn btn-default copy-clipboard" type="button" data-bs-toggle="tooltip" data-bs-placement="button" title="{{ "Copy to clipboard" | trans }}" for="#pref-label">
+      <div class="row">
+        <div class="col-sm-4 px-0" id="concept-heading">{{ "skos:prefLabel" | trans }}</div>
+        <div class="col-sm-8" id="concept-label">
+          <h2 class="mb-0" id="pref-label">{{ concept.label }}</h2>
+          <button class="btn btn-default copy-clipboard" type="button" data-bs-toggle="tooltip" data-bs-placement="button" title="{{ "Copy to clipboard" | trans }}" for="#pref-label">
           <i class="fa-regular fa-copy"></i>
-        </button>
+          </button>
+        </div>
       </div>
 
-      <table class="table" id="main-table">
-        <tbody>
-          {% for property in concept.properties %}
-          <tr class="property prop-{{property.ID}}">
-            <td class="main-table-label px-0">{{ property.label }}</td>
-            <td class="align-middle px-0">
-              <ul>
-              {% for propval in property.values %}
-                {% if propval.uri %} {# resources with URI #}
-                <li><a href="{{ propval.uri | link_url(propval.vocab, request.lang, 'page', request.contentLang) }}">{% if propval.notation %}<span class="versal">{{ propval.notation }} </span>{% endif %} {{ propval.label(request.contentLang) }}</a></li>
-                {% else %} {# literals, e.g. altLabels #}
-                <li>{{ propval.label }}</li>
-                {% endif %}
-              {% endfor %}
-              </li>
-            </td>
-          </tr>
+      {% for property in concept.properties %}
+      <div class="row property prop-{{property.ID}}">
+        <div class="col-sm-4 px-0 property-label">{{ property.label }}</div>
+        <div class="col-sm-8 align-self-center property-value">
+          <ul class="align-bottom">
+          {% for propval in property.values %}
+            {% if propval.uri %} {# resources with URI #}
+            <li><a href="{{ propval.uri | link_url(propval.vocab, request.lang, 'page', request.contentLang) }}">{% if propval.notation %}<span class="versal">{{ propval.notation }} </span>{% endif %} {{ propval.label(request.contentLang) }}</a></li>
+            {% else %} {# literals, e.g. altLabels #}
+            <li>{{ propval.label }}</li>
+            {% endif %}
           {% endfor %}
-          {% set foreignLabels = concept.foreignLabels %}
-          {% if foreignLabels %}
-          <tr>
-            <td class="main-table-label px-0">{{ 'foreign prefLabels'|trans }}</td>
-            <td class="term-other-languages align-middle px-0">
-                {% for language,labels in foreignLabels %}
-                {% for value in labels.prefLabel|default([])|merge(labels.altLabel|default([])) %}
-                {% if value.type == "skos:prefLabel" and value.lang in request.vocab.config.languages %}
-                <a class="label" href='{{ concept.uri|link_url(request.vocabid,request.lang, 'page', value.lang) }}' hreflang='{{ value.lang }}'>{{ value.label }}</a>
-                {% else %}
-                <span class="label">{{ value.label }}</span>
-                {% endif %}
-                {% if loop.first %}<span>{{ language }}</span>{% endif %}
-                {% endfor %}
-                {% endfor %}
-            </td>
-          </tr>
-          {% endif %}
-          <tr>
-            <td class="main-table-label px-0">URI</td>
-            <td class="align-middle px-0"><a href="#">{{ concept.uri }}</a></td>
-          </tr>
-          <tr>
-            <td class="main-table-label px-0"><i class="fa-solid fa-download"></i> {{ "Download this concept" | trans }}</td>
-            <td class="align-middle px-0">
-              <a class="me-3" href="rest/v1/{% if concept.vocab %}{{ concept.vocab.id }}{% else %}{{ vocab.id }}{% endif %}/data?uri={{ concept.uri|url_encode }}&amp;format=application/rdf%2Bxml">RDF/XML</a>
-              <a class="me-3" href="rest/v1/{% if concept.vocab %}{{ concept.vocab.id }}{% else %}{{ vocab.id }}{% endif %}/data?uri={{ concept.uri|url_encode }}&amp;format=text/turtle">TURTLE</a>
-              <a href="rest/v1/{% if concept.vocab %}{{ concept.vocab.id }}{% else %}{{ vocab.id }}{% endif %}/data?uri={{ concept.uri|url_encode }}&amp;format=application/ld%2Bjson">JSON-LD</a>
-            </td>
-          </tr>
-        </tbody>
-      </table>
+          </li>
+        </div>
+      </div>
+      {% endfor %}
+      {% set foreignLabels = concept.foreignLabels %}
+      {% if foreignLabels %}
+      <div class="row property prop-foreignlabels">
+        <div class="col-sm-4 px-0 property-label">{{ 'foreign prefLabels'|trans }}</div>
+        <div class="col-sm-8" id="concept-other-languages">
+            {% for language,labels in foreignLabels %}
+            {% for value in labels.prefLabel|default([])|merge(labels.altLabel|default([])) %}
+            {% if value.type == "skos:prefLabel" and value.lang in request.vocab.config.languages %}
+            <a class="label" href='{{ concept.uri|link_url(request.vocabid,request.lang, 'page', value.lang) }}' hreflang='{{ value.lang }}'>{{ value.label }}</a>
+            {% else %}
+            <span class="label">{{ value.label }}</span>
+            {% endif %}
+            {% if loop.first %}<span>{{ language }}</span>{% endif %}
+            {% endfor %}
+            {% endfor %}
+        </div>
+      </div>
+      {% endif %}
+      <div class="row property prop-uri">
+        <div class="col-sm-4 px-0 property-label">URI</div>
+        <div class="col-sm-8" id="concept-uri"><a href="#">{{ concept.uri }}</a></div>
+      </div>
+      <div class="row property prop-download">
+        <div class="col-sm-4 px-0 property-label"><i class="fa-solid fa-download"></i> {{ "Download this concept" | trans }}</div>
+        <div class="col-sm-8" id="download-links">
+          <a class="me-3" href="rest/v1/{% if concept.vocab %}{{ concept.vocab.id }}{% else %}{{ vocab.id }}{% endif %}/data?uri={{ concept.uri|url_encode }}&amp;format=application/rdf%2Bxml">RDF/XML</a>
+          <a class="me-3" href="rest/v1/{% if concept.vocab %}{{ concept.vocab.id }}{% else %}{{ vocab.id }}{% endif %}/data?uri={{ concept.uri|url_encode }}&amp;format=text/turtle">TURTLE</a>
+          <a href="rest/v1/{% if concept.vocab %}{{ concept.vocab.id }}{% else %}{{ vocab.id }}{% endif %}/data?uri={{ concept.uri|url_encode }}&amp;format=application/ld%2Bjson">JSON-LD</a>
+        </div>
+      </div>
+
     </div>
 
   </div>

--- a/src/view/concept-card.inc
+++ b/src/view/concept-card.inc
@@ -4,9 +4,9 @@
     <div class="main-content-section p-5">
 
       <div class="d-flex" id="term-heading">
-        <span>Käytettävä termi</span>
-        <h2 class="mb-0" id="pref-label">A Allgemeinwörter</h2>
-        <button class="btn btn-default copy-clipboard" type="button" data-bs-toggle="tooltip" data-bs-placement="button" title="Copy to clipboard" for="#pref-label">
+        <span>{{ "skos:prefLabel" | trans }}</span>
+        <h2 class="mb-0" id="pref-label">{{ concept.label }}</h2>
+        <button class="btn btn-default copy-clipboard" type="button" data-bs-toggle="tooltip" data-bs-placement="button" title="{{ "Copy to clipboard" | trans }}" for="#pref-label">
           <i class="fa-regular fa-copy"></i>
         </button>
       </div>
@@ -37,11 +37,15 @@
           </tr>
           <tr>
             <td class="main-table-label px-0">URI</td>
-            <td class="align-middle px-0"><a href="#">http://zbw.eu/stw/thsys/a</a></td>
+            <td class="align-middle px-0"><a href="#">{{ concept.uri }}</a></td>
           </tr>
           <tr>
-            <td class="main-table-label px-0"><i class="fa-solid fa-download"></i> Lataa tämä käsite</td>
-            <td class="align-middle px-0"><a class="me-3" href="#">RDF/XML</a> <a class="me-3" href="#">TURTLE</a> <a href="#">JSON-LD</a></td>
+            <td class="main-table-label px-0"><i class="fa-solid fa-download"></i> {{ "Download this concept" | trans }}</td>
+            <td class="align-middle px-0">
+              <a class="me-3" href="rest/v1/{% if concept.vocab %}{{ concept.vocab.id }}{% else %}{{ vocab.id }}{% endif %}/data?uri={{ concept.uri|url_encode }}&amp;format=application/rdf%2Bxml">RDF/XML</a>
+              <a class="me-3" href="rest/v1/{% if concept.vocab %}{{ concept.vocab.id }}{% else %}{{ vocab.id }}{% endif %}/data?uri={{ concept.uri|url_encode }}&amp;format=text/turtle">TURTLE</a>
+              <a href="rest/v1/{% if concept.vocab %}{{ concept.vocab.id }}{% else %}{{ vocab.id }}{% endif %}/data?uri={{ concept.uri|url_encode }}&amp;format=application/ld%2Bjson">JSON-LD</a>
+            </td>
           </tr>
         </tbody>
       </table>

--- a/src/view/concept-card.inc
+++ b/src/view/concept-card.inc
@@ -23,7 +23,7 @@
             {% if propval.uri and property.type != 'rdf:type' %} {# resources with URI #}
             <li>
               <a href="{{ propval.uri | link_url(propval.vocab, request.lang, 'page', request.contentLang) }}">
-                {{ propval.label(request.contentLang) }}
+                {{- propval.label(request.contentLang) -}}
               </a>
             </li>
             {% else %} {# literals, e.g. altLabels #}

--- a/src/view/concept.twig
+++ b/src/view/concept.twig
@@ -1,5 +1,5 @@
 {% extends "base-template.twig" %}
-{% block title %}: {{ vocab.shortName }}{% if search_results|length == 1 %}: {{ concept_label }}{% endif %}{% endblock %}
+{% block title %}: {{ vocab.shortName }}: {{ concept_label }}{% endblock %}
 
 {% block content %}
   {% include "sidebar.inc" %}

--- a/src/view/feedback.twig
+++ b/src/view/feedback.twig
@@ -4,11 +4,11 @@
 {% block content %}
 
   {% if feedback_sent %}
-    <h2>{{ 'Feedback has been sent!' | trans }}</h2>
+    <h1>{{ 'Feedback has been sent!' | trans }}</h1>
     <p id="feedback-thanks">{{ 'Thank you for your feedback' | trans }}</p>
   {% else %}
 
-    <h2 class="fs-3 mb-5">{{ 'Contact us!' | trans}}</h2>
+    <h1 class="fs-3 mb-5">{{ 'Contact us!' | trans}}</h1>
     <p class="fs-5 mb-5">{{ 'feedback_enter_name_email' | trans }}</p>
     
     <form id="feedback-form" method="post" action="{% if request.vocab %}{{request.vocab.id}}/{% endif %}{{ request.lang }}/feedback">

--- a/src/view/scripts.inc
+++ b/src/view/scripts.inc
@@ -6,9 +6,9 @@ const SKOSMOS = {
   "lang": "{{ request.lang }}",
   "vocab": "{{ request.vocabid }}",
   "waypoint_results": {{ parameters ? parameters.searchLimit : "null" }},
-  {%- if request.page == "page" and search_results and search_results|length == 1 %}
-  "prefLabels": [{"lang": "{{ search_results|first.label.lang }}","label": "{{ search_results|first.label }}"}{% for lang in search_results|first.foreignLabels %}{% for literal in lang %}{% if literal.type == "skos:prefLabel" %},{"lang": "{{literal.lang}}", "label": "{{literal.label}}"}{% endif %}{% endfor %}{% endfor %}],
-  "uri": "{{ search_results|first.uri }}",
+  {%- if request.page == "page" and concept %}
+  "prefLabels": [{"lang": "{{ concept.label.lang }}","label": "{{ concept.label }}"}{% for lang in concept.foreignLabels %}{% for literal in lang %}{% if literal.type == "skos:prefLabel" %},{"lang": "{{literal.lang}}", "label": "{{literal.label}}"}{% endif %}{% endfor %}{% endfor %}],
+  "uri": "{{ concept.uri }}",
   {% endif %}
   {%- if request.vocab ~%}
   "languageOrder": [{% for lang in request.vocab.config.languageOrder(request.contentLang) %}"{{ lang }}"{% if not loop.last %}, {% endif %}{% endfor %}],
@@ -28,8 +28,8 @@ const SKOSMOS = {
 
 <!-- Search result data -->
 <script type="application/ld+json">
-  {%- if search_results and search_results|length == 1 -%}
-    {{ search_results|first.dumpJsonLd|raw }}
+  {%- if concept -%}
+    {{ concept.dumpJsonLd|raw }}
   {%- else -%}
     {}
   {%- endif -%}

--- a/src/view/vocab-info.inc
+++ b/src/view/vocab-info.inc
@@ -1,5 +1,5 @@
 <div class="col-md-8" id="main-content"> <!-- id for partial page load -->
-  <div class="bg-light py-5 px-5" id="vocab-info">
+  <div class="main-content-section py-5 px-5" id="vocab-info">
     <h2 class="fw-bold fs-3 py-4">{{ "Vocabulary information" | trans }}</h2>
     {% set vocabInfo = vocab.info(request.contentLang) %}
     {% if not vocabInfo %}

--- a/tests/ConceptMappingPropertyValueTest.php
+++ b/tests/ConceptMappingPropertyValueTest.php
@@ -11,8 +11,7 @@ class ConceptMappingPropertyValueTest extends PHPUnit\Framework\TestCase
     {
         $this->model = new Model(new GlobalConfig('/../../tests/testconfig.ttl'));
         $this->vocab = $this->model->getVocabulary('mapping');
-        $concepts = $this->vocab->getConceptInfo('http://www.skosmos.skos/mapping/m1', 'en');
-        $this->concept = $concepts[0];
+        $this->concept = $this->vocab->getConceptInfo('http://www.skosmos.skos/mapping/m1', 'en');
         $this->props = $this->concept->getMappingProperties();
     }
 

--- a/tests/ConceptPropertyTest.php
+++ b/tests/ConceptPropertyTest.php
@@ -28,8 +28,7 @@ class ConceptPropertyTest extends PHPUnit\Framework\TestCase
     public function testGetDescriptionAndLabel()
     {
         $vocab = $this->model->getVocabulary('test');
-        $concepts = $vocab->getConceptInfo('http://www.skosmos.skos/test/ta122', 'en');
-        $concept = $concepts[0];
+        $concept = $vocab->getConceptInfo('http://www.skosmos.skos/test/ta122', 'en');
         $props = $concept->getProperties();
         $propvals = $props['skos:definition']->getValues();
         $this->assertEquals('Definition', $props['skos:definition']->getLabel());
@@ -42,8 +41,7 @@ class ConceptPropertyTest extends PHPUnit\Framework\TestCase
     public function testGetLabel()
     {
         $vocab = $this->model->getVocabulary('dates');
-        $concepts = $vocab->getConceptInfo('http://www.skosmos.skos/date/d1', 'en');
-        $concept = $concepts[0];
+        $concept = $vocab->getConceptInfo('http://www.skosmos.skos/date/d1', 'en');
         $props = $concept->getProperties();
         $proplabel = $props['http://www.skosmos.skos/date/ownDate']->getLabel();
         $this->assertEquals('This is also a dateTime', $proplabel->getValue());
@@ -65,8 +63,7 @@ class ConceptPropertyTest extends PHPUnit\Framework\TestCase
     public function testGetDescriptionAndLabelForCustomProperty()
     {
         $vocab = $this->model->getVocabulary('test');
-        $concepts = $vocab->getConceptInfo('http://www.skosmos.skos/test/ta112', 'en');
-        $concept = $concepts[0];
+        $concept = $vocab->getConceptInfo('http://www.skosmos.skos/test/ta112', 'en');
         $props = $concept->getProperties();
         $prop = $props["http://www.skosmos.skos/testprop"];
         $this->assertEquals('Skosmos test property', $prop->getLabel());
@@ -80,8 +77,7 @@ class ConceptPropertyTest extends PHPUnit\Framework\TestCase
     public function testGetDescriptionAndLabelForCustomPropertyMissingDesc()
     {
         $vocab = $this->model->getVocabulary('test-notation-sort');
-        $concepts = $vocab->getConceptInfo('http://www.skosmos.skos/test/ta0112', 'en');
-        $concept = $concepts[0];
+        $concept = $vocab->getConceptInfo('http://www.skosmos.skos/test/ta0112', 'en');
         $props = $concept->getProperties();
         $prop = $props["http://www.skosmos.skos/testprop"];
         $this->assertEquals('Skosmos test property', $prop->getLabel());
@@ -95,8 +91,7 @@ class ConceptPropertyTest extends PHPUnit\Framework\TestCase
     public function testGetType()
     {
         $vocab = $this->model->getVocabulary('test');
-        $concepts = $vocab->getConceptInfo('http://www.skosmos.skos/test/ta122', 'en');
-        $concept = $concepts[0];
+        $concept = $vocab->getConceptInfo('http://www.skosmos.skos/test/ta122', 'en');
         $props = $concept->getProperties();
         $this->assertEquals('skos:definition', $props['skos:definition']->getType());
     }
@@ -108,8 +103,7 @@ class ConceptPropertyTest extends PHPUnit\Framework\TestCase
     public function testAddValue()
     {
         $vocab = $this->model->getVocabulary('test');
-        $concepts = $vocab->getConceptInfo('http://www.skosmos.skos/test/ta1', 'en');
-        $concept = $concepts[0];
+        $concept = $vocab->getConceptInfo('http://www.skosmos.skos/test/ta1', 'en');
         $props = $concept->getProperties();
         $prevlabel = null;
         foreach($props['skos:narrower']->getValues() as $val) {
@@ -129,8 +123,7 @@ class ConceptPropertyTest extends PHPUnit\Framework\TestCase
     {
         # the vocabulary is configured to use lexical sorting
         $vocab = $this->model->getVocabulary('test-notation-sort');
-        $concepts = $vocab->getConceptInfo('http://www.skosmos.skos/test/ta01', 'en');
-        $concept = $concepts[0];
+        $concept = $vocab->getConceptInfo('http://www.skosmos.skos/test/ta01', 'en');
         $props = $concept->getProperties();
         $expected = array(
           "test:ta0111", # 33.01
@@ -159,8 +152,7 @@ class ConceptPropertyTest extends PHPUnit\Framework\TestCase
     {
         # the vocabulary is configured to use natural sorting
         $vocab = $this->model->getVocabulary('testNotation');
-        $concepts = $vocab->getConceptInfo('http://www.skosmos.skos/test/ta01', 'en');
-        $concept = $concepts[0];
+        $concept = $vocab->getConceptInfo('http://www.skosmos.skos/test/ta01', 'en');
         $props = $concept->getProperties();
         $expected = array(
           "test:ta0111", # 33.01
@@ -187,8 +179,7 @@ class ConceptPropertyTest extends PHPUnit\Framework\TestCase
     public function testGetPropertiesSubClassOfHiddenLabel()
     {
         $vocab = $this->model->getVocabulary('subclass');
-        $results = $vocab->getConceptInfo('http://www.skosmos.skos/sub/d1', 'en');
-        $concept = reset($results);
+        $concept = $vocab->getConceptInfo('http://www.skosmos.skos/sub/d1', 'en');
         $props = $concept->getProperties();
         $this->assertEquals('skos:hiddenLabel', $props['subclass:prop1']->getSubPropertyOf());
     }

--- a/tests/ConceptPropertyValueLiteralTest.php
+++ b/tests/ConceptPropertyValueLiteralTest.php
@@ -10,8 +10,7 @@ class ConceptPropertyValueLiteralTest extends PHPUnit\Framework\TestCase
     {
         $this->model = new Model(new GlobalConfig('/../../tests/testconfig.ttl'));
         $this->vocab = $this->model->getVocabulary('test');
-        $results = $this->vocab->getConceptInfo('http://www.skosmos.skos/test/ta112', 'en');
-        $this->concept = reset($results);
+        $this->concept = $this->vocab->getConceptInfo('http://www.skosmos.skos/test/ta112', 'en');
     }
 
     /**
@@ -41,8 +40,8 @@ class ConceptPropertyValueLiteralTest extends PHPUnit\Framework\TestCase
     public function testGetLabelThatIsADate()
     {
         $vocab = $this->model->getVocabulary('dates');
-        $concepts = $vocab->getConceptInfo("http://www.skosmos.skos/date/d1", "en");
-        $props = $concepts[0]->getProperties();
+        $concept = $vocab->getConceptInfo("http://www.skosmos.skos/date/d1", "en");
+        $props = $concept->getProperties();
         $propvals = $props['http://www.skosmos.skos/date/ownDate']->getValues();
         $this->assertStringContainsString('8/8/15', $propvals['8/8/15']->getLabel());
     }
@@ -54,8 +53,8 @@ class ConceptPropertyValueLiteralTest extends PHPUnit\Framework\TestCase
     {
         $this->expectWarning();
         $vocab = $this->model->getVocabulary('dates');
-        $concepts = $vocab->getConceptInfo("http://www.skosmos.skos/date/d2", "en");
-        $props = $concepts[0]->getProperties();
+        $concept = $vocab->getConceptInfo("http://www.skosmos.skos/date/d2", "en");
+        $props = $concept->getProperties();
         $propvals = $props['http://www.skosmos.skos/date/ownDate']->getValues();
     }
 
@@ -65,8 +64,8 @@ class ConceptPropertyValueLiteralTest extends PHPUnit\Framework\TestCase
     public function testGetLabelForDatatype()
     {
         $vocab = $this->model->getVocabulary('test');
-        $concepts = $vocab->getConceptInfo('http://www.skosmos.skos/test/ta112', 'en');
-        $props = $concepts[0]->getProperties();
+        $concept = $vocab->getConceptInfo('http://www.skosmos.skos/test/ta112', 'en');
+        $props = $concept->getProperties();
         $propvals = $props['skos:notation']->getValues();
         $this->assertEquals('NameOfTheDatatype', $propvals['665']->getDatatype());
     }
@@ -77,8 +76,8 @@ class ConceptPropertyValueLiteralTest extends PHPUnit\Framework\TestCase
     public function testGetNotationDatatypeWithoutLabel()
     {
         $vocab = $this->model->getVocabulary('test');
-        $concepts = $vocab->getConceptInfo('http://www.skosmos.skos/test/ta128', 'en');
-        $props = $concepts[0]->getProperties();
+        $concept = $vocab->getConceptInfo('http://www.skosmos.skos/test/ta128', 'en');
+        $props = $concept->getProperties();
         $propvals = $props['skos:notation']->getValues();
         $this->assertNull($propvals['testnotation']->getDatatype());
     }
@@ -89,8 +88,8 @@ class ConceptPropertyValueLiteralTest extends PHPUnit\Framework\TestCase
     public function testGetLabelForDatatypeIfNull()
     {
         $vocab = $this->model->getVocabulary('test');
-        $concepts = $vocab->getConceptInfo('http://www.skosmos.skos/test/ta126', 'en');
-        $props = $concepts[0]->getProperties();
+        $concept = $vocab->getConceptInfo('http://www.skosmos.skos/test/ta126', 'en');
+        $props = $concept->getProperties();
         $propvals = $props['skos:notation']->getValues();
         $this->assertNull($propvals['12.34']->getDatatype());
     }
@@ -212,7 +211,7 @@ class ConceptPropertyValueLiteralTest extends PHPUnit\Framework\TestCase
     public function testGetXlLabel()
     {
         $voc = $this->model->getVocabulary('xl');
-        $conc = $voc->getConceptInfo('http://www.skosmos.skos/xl/c1', 'en')[0];
+        $conc = $voc->getConceptInfo('http://www.skosmos.skos/xl/c1', 'en');
         $props = $conc->getProperties();
         $vals = $props['skos:altLabel']->getValues();
         $val = reset($vals);

--- a/tests/ConceptPropertyValueTest.php
+++ b/tests/ConceptPropertyValueTest.php
@@ -10,8 +10,7 @@ class ConceptPropertyValueTest extends PHPUnit\Framework\TestCase
     {
         $this->model = new Model(new GlobalConfig('/../../tests/testconfig.ttl'));
         $this->vocab = $this->model->getVocabulary('test');
-        $results = $this->vocab->getConceptInfo('http://www.skosmos.skos/test/ta112', 'en');
-        $this->concept = reset($results);
+        $this->concept = $this->vocab->getConceptInfo('http://www.skosmos.skos/test/ta112', 'en');
     }
 
     /**
@@ -113,8 +112,7 @@ class ConceptPropertyValueTest extends PHPUnit\Framework\TestCase
      */
     public function testGetNotation()
     {
-        $results = $this->vocab->getConceptInfo('http://www.skosmos.skos/test/ta121', 'en');
-        $concept = reset($results);
+        $concept = $this->vocab->getConceptInfo('http://www.skosmos.skos/test/ta121', 'en');
         $props = $concept->getProperties();
         $propvals = $props['skos:broader']->getValues();
         $this->assertEquals(665, $propvals['665 Carp http://www.skosmos.skos/test/ta112']->getNotation());
@@ -136,8 +134,7 @@ class ConceptPropertyValueTest extends PHPUnit\Framework\TestCase
      */
     public function testToStringWhenSortByNotationNotSet()
     {
-        $results = $this->vocab->getConceptInfo('http://www.skosmos.skos/test/ta121', 'en');
-        $concept = reset($results);
+        $concept = $this->vocab->getConceptInfo('http://www.skosmos.skos/test/ta121', 'en');
         $props = $concept->getProperties();
         $propvals = $props['skos:broader']->getValues();
         $this->assertEquals('Carp', (string)$propvals['665 Carp http://www.skosmos.skos/test/ta112']);
@@ -150,8 +147,7 @@ class ConceptPropertyValueTest extends PHPUnit\Framework\TestCase
      */
     public function testSubmemberSorting()
     {
-        $results = $this->vocab->getConceptInfo('http://www.skosmos.skos/test/ta121', 'en');
-        $concept = reset($results);
+        $concept = $this->vocab->getConceptInfo('http://www.skosmos.skos/test/ta121', 'en');
         $props = $concept->getProperties();
         $propvals = $props['skos:broader']->getValues();
         $prop = reset($propvals);
@@ -187,7 +183,7 @@ class ConceptPropertyValueTest extends PHPUnit\Framework\TestCase
     public function testGetReifiedPropertyValues()
     {
         $vocab = $this->model->getVocabulary('xl');
-        $concept = $vocab->getConceptInfo('http://www.skosmos.skos/xl/c1', 'en')[0];
+        $concept = $vocab->getConceptInfo('http://www.skosmos.skos/xl/c1', 'en');
         $props = $concept->getProperties();
         $vals = $props['skos:definition']->getValues();
         $val = reset($vals);

--- a/tests/ConceptTest.php
+++ b/tests/ConceptTest.php
@@ -15,8 +15,7 @@ class ConceptTest extends PHPUnit\Framework\TestCase
     {
         $this->model = new Model(new GlobalConfig('/../../tests/testconfig.ttl'));
         $this->vocab = $this->model->getVocabulary('test');
-        $results = $this->vocab->getConceptInfo('http://www.skosmos.skos/test/ta112', 'en');
-        $this->concept = reset($results);
+        $this->concept = $this->vocab->getConceptInfo('http://www.skosmos.skos/test/ta112', 'en');
 
         $this->cbdVocab = $this->model->getVocabulary('cbd');
         $this->cbdGraph =  new EasyRdf\Graph();
@@ -120,12 +119,10 @@ class ConceptTest extends PHPUnit\Framework\TestCase
         $this->assertArrayNotHasKey('altLabel', $labels['Finnish']);
         $this->assertArrayNotHasKey('English', $labels);
 
-        $results = $this->vocab->getConceptInfo('http://www.skosmos.skos/test/ta115', 'en');
-        $concept = reset($results);
+        $concept = $this->vocab->getConceptInfo('http://www.skosmos.skos/test/ta115', 'en');
         $this->assertEmpty($concept->getForeignLabels());
 
-        $results = $this->vocab->getConceptInfo('http://www.skosmos.skos/test/ta127', 'en');
-        $concept = reset($results);
+        $concept = $this->vocab->getConceptInfo('http://www.skosmos.skos/test/ta127', 'en');
         $labels = $concept->getForeignLabels();
         $this->assertEquals(['', 'Finnish', 'Swedish'], array_keys($labels));
 
@@ -143,8 +140,7 @@ class ConceptTest extends PHPUnit\Framework\TestCase
      */
     public function testGetAllLabels()
     {
-        $results = $this->vocab->getConceptInfo('http://www.skosmos.skos/test/ta115', 'en');
-        $concept = reset($results);
+        $concept = $this->vocab->getConceptInfo('http://www.skosmos.skos/test/ta115', 'en');
         $labels = $concept->getAllLabels('skos:definition');
         $this->assertEquals('Iljettävä limanuljaska', $labels['Finnish'][0]->getLabel());
         $this->assertEquals('any fish belonging to the order Anguilliformes', $labels['English'][0]->getLabel());
@@ -200,8 +196,7 @@ class ConceptTest extends PHPUnit\Framework\TestCase
      */
     public function testGetPropertiesAlphabeticalSortingOfPropertyValues()
     {
-        $results = $this->vocab->getConceptInfo('http://www.skosmos.skos/test/ta1', 'en');
-        $concept = reset($results);
+        $concept = $this->vocab->getConceptInfo('http://www.skosmos.skos/test/ta1', 'en');
         $props = $concept->getProperties();
         $prevlabel = null;
         foreach($props['skos:narrower']->getValues() as $val) {
@@ -220,8 +215,7 @@ class ConceptTest extends PHPUnit\Framework\TestCase
     public function testGetMappingPropertiesWithIdenticalLabels()
     {
         $vocab = $this->model->getVocabulary('duplicates');
-        $concepts = $vocab->getConceptInfo("http://www.skosmos.skos/dup/d3", "en");
-        $concept = $concepts[0];
+        $concept = $vocab->getConceptInfo("http://www.skosmos.skos/dup/d3", "en");
         $props = $concept->getMappingProperties();
         $values = $props['skos:closeMatch']->getValues();
         $this->assertCount(2, $values);
@@ -234,8 +228,7 @@ class ConceptTest extends PHPUnit\Framework\TestCase
     public function testRemoveDuplicatePropertyValues()
     {
         $vocab = $this->model->getVocabulary('duplicates');
-        $concepts = $vocab->getConceptInfo("http://www.skosmos.skos/dup/d4", "en");
-        $concept = $concepts[0];
+        $concept = $vocab->getConceptInfo("http://www.skosmos.skos/dup/d4", "en");
         $props = $concept->getProperties();
         $this->assertCount(1, $props);
     }
@@ -247,8 +240,7 @@ class ConceptTest extends PHPUnit\Framework\TestCase
     public function testgetPreferredSubpropertyLabelTranslation()
     {
         $vocab = $this->model->getVocabulary('duplicates');
-        $concepts = $vocab->getConceptInfo("http://www.skosmos.skos/dup/d6", "en");
-        $concept = $concepts[0];
+        $concept = $vocab->getConceptInfo("http://www.skosmos.skos/dup/d6", "en");
         $this->assertEquals($concept->getPreferredSubpropertyLabelTranslation('en'), "Subproperty of skos:prefLabel");
         $this->assertEquals($concept->getPreferredSubpropertyLabelTranslation('fi'), null);
     }
@@ -260,8 +252,7 @@ class ConceptTest extends PHPUnit\Framework\TestCase
     public function testRemoveDuplicateValuesForPreflabel()
     {
         $vocab = $this->model->getVocabulary('duplicates');
-        $concepts = $vocab->getConceptInfo("http://www.skosmos.skos/dup/d7", "en");
-        $concept = $concepts[0];
+        $concept = $vocab->getConceptInfo("http://www.skosmos.skos/dup/d7", "en");
         $props = $concept->getProperties();
         $this->assertCount(0, $props);
     }
@@ -273,8 +264,7 @@ class ConceptTest extends PHPUnit\Framework\TestCase
     public function testRemoveDuplicatePropertyValuesOtherThanSubpropertyof()
     {
         $vocab = $this->model->getVocabulary('duplicates');
-        $concepts = $vocab->getConceptInfo("http://www.skosmos.skos/dup/d5", "en");
-        $concept = $concepts[0];
+        $concept = $vocab->getConceptInfo("http://www.skosmos.skos/dup/d5", "en");
         $props = $concept->getProperties();
         $this->assertCount(2, $props);
     }
@@ -287,8 +277,7 @@ class ConceptTest extends PHPUnit\Framework\TestCase
     public function testGetTimestamp()
     {
         $vocab = $this->model->getVocabulary('test');
-        $concepts = $vocab->getConceptInfo("http://www.skosmos.skos/test/ta123", "en");
-        $concept = $concepts[0];
+        $concept = $vocab->getConceptInfo("http://www.skosmos.skos/test/ta123", "en");
         $date = $concept->getDate();
         $this->assertStringContainsString('10/1/14', $date);
     }
@@ -299,8 +288,7 @@ class ConceptTest extends PHPUnit\Framework\TestCase
     public function testGetDateWithCreatedAndModified()
     {
         $vocab = $this->model->getVocabulary('dates');
-        $concepts = $vocab->getConceptInfo("http://www.skosmos.skos/date/d1", "en");
-        $concept = $concepts[0];
+        $concept = $vocab->getConceptInfo("http://www.skosmos.skos/date/d1", "en");
         $date = $concept->getDate();
         $this->assertStringContainsString('1/3/00', $date);
         $this->assertStringContainsString('6/6/12', $date);
@@ -315,8 +303,7 @@ class ConceptTest extends PHPUnit\Framework\TestCase
     {
         $this->expectError();
         $vocab = $this->model->getVocabulary('test');
-        $concepts = $vocab->getConceptInfo("http://www.skosmos.skos/test/ta114", "en");
-        $concept = $concepts[0];
+        $concept = $vocab->getConceptInfo("http://www.skosmos.skos/test/ta114", "en");
         $props = $concept->getDate(); # this should throw a E_USER_WARNING exception
     }
 
@@ -329,8 +316,7 @@ class ConceptTest extends PHPUnit\Framework\TestCase
     public function testGetTimestampInvalidResult()
     {
         $vocab = $this->model->getVocabulary('test');
-        $concepts = $vocab->getConceptInfo("http://www.skosmos.skos/test/ta114", "en");
-        $concept = $concepts[0];
+        $concept = $vocab->getConceptInfo("http://www.skosmos.skos/test/ta114", "en");
         # we use @ to suppress the exceptions in order to be able to check the result
         $date = @$concept->getDate();
         $this->assertStringContainsString('1986-21-00', $date);
@@ -354,8 +340,7 @@ class ConceptTest extends PHPUnit\Framework\TestCase
     public function testGetNotationWhenNull()
     {
         $vocab = $this->model->getVocabulary('test');
-        $concepts = $vocab->getConceptInfo("http://www.skosmos.skos/test/ta114", "en");
-        $concept = $concepts[0];
+        $concept = $vocab->getConceptInfo("http://www.skosmos.skos/test/ta114", "en");
         $this->assertEquals(null, $concept->getNotation());
     }
 
@@ -383,7 +368,7 @@ class ConceptTest extends PHPUnit\Framework\TestCase
         $model = new Model(new GlobalConfig('/../../tests/testconfig.ttl'));
         $vocab = $model->getVocabulary('test');
         $concept = $vocab->getConceptInfo("http://www.skosmos.skos/test/ta120", "en");
-        $this->assertEquals(null, $concept[0]->getLabel());
+        $this->assertEquals(null, $concept->getLabel());
     }
 
     /**
@@ -408,10 +393,10 @@ class ConceptTest extends PHPUnit\Framework\TestCase
         $model = new Model(new GlobalConfig('/../../tests/testconfig.ttl'));
         $vocab = $model->getVocabulary('groups');
         $concept = $vocab->getConceptInfo("http://www.skosmos.skos/groups/ta111", "en");
-        $arrays = $concept[0]->getArrayProperties();
+        $arrays = $concept->getArrayProperties();
         $this->assertArrayHasKey("Saltwater fish", $arrays);
         $this->assertArrayHasKey("Submarine-like fish", $arrays);
-        $groups = $concept[0]->getGroupProperties();
+        $groups = $concept->getGroupProperties();
         $this->assertEmpty($groups);
     }
 
@@ -424,7 +409,7 @@ class ConceptTest extends PHPUnit\Framework\TestCase
         $model = new Model(new GlobalConfig('/../../tests/testconfig.ttl'));
         $vocab = $model->getVocabulary('dupgroup');
         $concept = $vocab->getConceptInfo("http://www.skosmos.skos/dupgroup/c1", "en");
-        $groups = $concept[0]->getGroupProperties();
+        $groups = $concept->getGroupProperties();
         $this->assertEquals(0, sizeof($groups));
     }
 
@@ -437,7 +422,7 @@ class ConceptTest extends PHPUnit\Framework\TestCase
         $model = new Model(new GlobalConfig('/../../tests/testconfig.ttl'));
         $vocab = $model->getVocabulary('dupgroup');
         $concept = $vocab->getConceptInfo("http://www.skosmos.skos/dupgroup/ta111", "en");
-        $groups = $concept[0]->getGroupProperties();
+        $groups = $concept->getGroupProperties();
         $this->assertEquals(2, sizeof($groups));
         $this->assertArrayHasKey("Animalia", $groups);
         $this->assertArrayHasKey("Biology", $groups);
@@ -455,7 +440,7 @@ class ConceptTest extends PHPUnit\Framework\TestCase
         $model = new Model(new GlobalConfig('/../../tests/testconfig.ttl'));
         $vocab = $model->getVocabulary('groups');
         $concept = $vocab->getConceptInfo("http://www.skosmos.skos/groups/ta1", "en");
-        $props = $concept[0]->getProperties();
+        $props = $concept->getProperties();
         $narrowers = $props['skos:narrower']->getValues();
         $this->assertCount(3, $narrowers);
         foreach ($narrowers as $coll) {
@@ -477,8 +462,7 @@ class ConceptTest extends PHPUnit\Framework\TestCase
     public function testMultilingualPropertiesOnWithLangHit()
     {
         $vocab = $this->model->getVocabulary('test');
-        $concepts = $vocab->getConceptInfo('http://www.skosmos.skos/test/ta112', 'en');
-        $concept = $concepts[0];
+        $concept = $vocab->getConceptInfo('http://www.skosmos.skos/test/ta112', 'en');
         $props = $concept->getProperties();
         $propvals = $props['http://www.skosmos.skos/multiLingOn']->getValues();
         $runner = array();
@@ -495,8 +479,7 @@ class ConceptTest extends PHPUnit\Framework\TestCase
     public function testMultilingualPropertiesOnWithoutLangHit()
     {
         $vocab = $this->model->getVocabulary('test');
-        $concepts = $vocab->getConceptInfo('http://www.skosmos.skos/test/ta112', 'ru');
-        $concept = $concepts[0];
+        $concept = $vocab->getConceptInfo('http://www.skosmos.skos/test/ta112', 'ru');
         $props = $concept->getProperties();
         $propvals = $props['http://www.skosmos.skos/multiLingOn']->getValues();
         $runner = array();
@@ -513,8 +496,7 @@ class ConceptTest extends PHPUnit\Framework\TestCase
     public function testMultilingualPropertiesOffWithLangHit()
     {
         $vocab = $this->model->getVocabulary('test');
-        $concepts = $vocab->getConceptInfo('http://www.skosmos.skos/test/ta112', 'en');
-        $concept = $concepts[0];
+        $concept = $vocab->getConceptInfo('http://www.skosmos.skos/test/ta112', 'en');
         $props = $concept->getProperties();
         $propvals = $props['http://www.skosmos.skos/multiLingOff']->getValues();
         $runner = array();
@@ -531,8 +513,7 @@ class ConceptTest extends PHPUnit\Framework\TestCase
     public function testMultilingualPropertiesOffWithoutLangHit()
     {
         $vocab = $this->model->getVocabulary('test');
-        $concepts = $vocab->getConceptInfo('http://www.skosmos.skos/test/ta112', 'ru');
-        $concept = $concepts[0];
+        $concept = $vocab->getConceptInfo('http://www.skosmos.skos/test/ta112', 'ru');
         $props = $concept->getProperties();
         $propvals = $props['http://www.skosmos.skos/multiLingOff']->getValues();
         $runner = array();
@@ -549,8 +530,7 @@ class ConceptTest extends PHPUnit\Framework\TestCase
     public function testGetPropertiesDefinitionLiteral()
     {
         $vocab = $this->model->getVocabulary('test');
-        $concepts = $vocab->getConceptInfo('http://www.skosmos.skos/test/ta115', 'en');
-        $concept = $concepts[0];
+        $concept = $vocab->getConceptInfo('http://www.skosmos.skos/test/ta115', 'en');
         $props = $concept->getProperties();
         $propvals = $props['skos:definition']->getValues();
         $this->assertEquals('any fish belonging to the order Anguilliformes', $propvals['any fish belonging to the order Anguilliformes']->getLabel());
@@ -563,8 +543,7 @@ class ConceptTest extends PHPUnit\Framework\TestCase
     public function testGetPropertiesDefinitionResource()
     {
         $vocab = $this->model->getVocabulary('test');
-        $concepts = $vocab->getConceptInfo('http://www.skosmos.skos/test/ta122', 'en');
-        $concept = $concepts[0];
+        $concept = $vocab->getConceptInfo('http://www.skosmos.skos/test/ta122', 'en');
         $props = $concept->getProperties();
         $propvals = $props['skos:definition']->getValues();
         $this->assertEquals('The black sea bass (Centropristis striata) is an exclusively marine fish.', $propvals['The black sea bass (Centropristis striata) is an exclusively marine fish. http://www.skosmos.skos/test/black_sea_bass_def']->getLabel());
@@ -576,8 +555,7 @@ class ConceptTest extends PHPUnit\Framework\TestCase
      */
     public function testExternalResourceReifications()
     {
-        $concepts = $this->cbdVocab->getConceptInfo('http://www.skosmos.skos/cbd/test2', 'en');
-        $concept = $concepts[0];
+        $concept = $this->cbdVocab->getConceptInfo('http://www.skosmos.skos/cbd/test2', 'en');
 
         $res = $this->cbdGraph->resource('http://www.skosmos.skos/cbd/test1');
 
@@ -594,8 +572,7 @@ class ConceptTest extends PHPUnit\Framework\TestCase
      */
     public function testProcessExternalResource()
     {
-        $concepts = $this->cbdVocab->getConceptInfo('http://www.skosmos.skos/cbd/test2', 'en');
-        $concept = $concepts[0];
+        $concept = $this->cbdVocab->getConceptInfo('http://www.skosmos.skos/cbd/test2', 'en');
 
         $res = $this->cbdGraph->resource('http://www.skosmos.skos/cbd/test1');
 
@@ -632,8 +609,7 @@ class ConceptTest extends PHPUnit\Framework\TestCase
     public function testGetModifiedDate($animal, $expected_time, $expected_timezone)
     {
         $vocab = $this->model->getVocabulary('http304');
-        $results = $vocab->getConceptInfo('http://www.skosmos.skos/test/' . $animal, 'en');
-        $concept = reset($results);
+        $concept = $vocab->getConceptInfo('http://www.skosmos.skos/test/' . $animal, 'en');
         if (is_null($expected_time)) {
             $modifiedDate = $concept->getModifiedDate();
             $this->assertNull($modifiedDate);
@@ -649,8 +625,7 @@ class ConceptTest extends PHPUnit\Framework\TestCase
     public function testGetModifiedDateFallbackToVocabularyModified()
     {
         $vocab = $this->model->getVocabulary('test');
-        $results = $vocab->getConceptInfo('http://www.skosmos.skos/test/ta111', 'en');
-        $concept = reset($results);
+        $concept = $vocab->getConceptInfo('http://www.skosmos.skos/test/ta111', 'en');
         $modifiedDate = $concept->getModifiedDate();
         $this->assertEquals(new DateTime("2014-10-01T16:29:03+00:00"), $modifiedDate);
     }
@@ -661,7 +636,7 @@ class ConceptTest extends PHPUnit\Framework\TestCase
     public function testHasXlLabelTrue()
     {
         $vocab = $this->model->getVocabulary('xl');
-        $concept = $vocab->getConceptInfo('http://www.skosmos.skos/xl/c1', 'en')[0];
+        $concept = $vocab->getConceptInfo('http://www.skosmos.skos/xl/c1', 'en');
         $this->assertTrue($concept->hasXlLabel());
     }
 
@@ -671,7 +646,7 @@ class ConceptTest extends PHPUnit\Framework\TestCase
     public function testHasXlLabelFalse()
     {
         $vocab = $this->model->getVocabulary('test');
-        $concept = $vocab->getConceptInfo('http://www.skosmos.skos/test/ta111', 'en')[0];
+        $concept = $vocab->getConceptInfo('http://www.skosmos.skos/test/ta111', 'en');
         $this->assertFalse($concept->hasXlLabel());
     }
 
@@ -682,7 +657,7 @@ class ConceptTest extends PHPUnit\Framework\TestCase
     public function testGetXlLabel()
     {
         $vocab = $this->model->getVocabulary('xl');
-        $concept = $vocab->getConceptInfo('http://www.skosmos.skos/xl/c1', 'en')[0];
+        $concept = $vocab->getConceptInfo('http://www.skosmos.skos/xl/c1', 'en');
         $label = $concept->getXlLabel();
         $props = $label->getProperties();
         $this->assertArrayHasKey('skosxl:labelRelation', $props);
@@ -697,7 +672,7 @@ class ConceptTest extends PHPUnit\Framework\TestCase
     public function testGetXlLabelNull()
     {
         $vocab = $this->model->getVocabulary('test');
-        $concept = $vocab->getConceptInfo('http://www.skosmos.skos/test/ta111', 'en')[0];
+        $concept = $vocab->getConceptInfo('http://www.skosmos.skos/test/ta111', 'en');
         $this->assertNull($concept->getXlLabel());
     }
 

--- a/tests/Http304Test.php
+++ b/tests/Http304Test.php
@@ -73,17 +73,15 @@ class Http304Test extends TestCase
             ->shouldReceive("getConceptURI")
             ->andReturn("");
 
-        $concepts = [];
         $concept = Mockery::mock("Concept")->makePartial();
         $concept->allows([
             "getType" => ["skos:Concept"]
         ]);
         $concept->shouldReceive("getVocab")
             ->andReturn($this->vocab);
-        $concepts[] = $concept;
         $this->vocab
             ->shouldReceive("getConceptInfo")
-            ->andReturn($concepts);
+            ->andReturn($concept);
         $this->vocab
             ->shouldReceive("getBreadCrumbs")
             ->andReturn([
@@ -119,17 +117,15 @@ class Http304Test extends TestCase
             ->shouldReceive("getConceptURI")
             ->andReturn("");
 
-        $concepts = [];
         $concept = Mockery::mock("Concept")->makePartial();
         $concept->allows([
             "getType" => ["skos:Concept"]
         ]);
         $concept->shouldReceive("getVocab")
             ->andReturn($this->vocab);
-        $concepts[] = $concept;
         $this->vocab
             ->shouldReceive("getConceptInfo")
-            ->andReturn($concepts);
+            ->andReturn($concept);
         $this->vocab
             ->shouldReceive("getBreadCrumbs")
             ->andReturn([
@@ -175,17 +171,15 @@ class Http304Test extends TestCase
             ->shouldReceive("getConceptURI")
             ->andReturn("");
 
-        $concepts = [];
         $concept = Mockery::mock("Concept")->makePartial();
         $concept->allows([
             "getType" => ["skos:Concept"]
         ]);
         $concept->shouldReceive("getVocab")
             ->andReturn($this->vocab);
-        $concepts[] = $concept;
         $this->vocab
             ->shouldReceive("getConceptInfo")
-            ->andReturn($concepts);
+            ->andReturn($concept);
         $this->vocab
             ->shouldReceive("getBreadCrumbs")
             ->andReturn([

--- a/tests/VocabularyTest.php
+++ b/tests/VocabularyTest.php
@@ -572,8 +572,7 @@ class VocabularyTest extends \PHPUnit\Framework\TestCase
     {
         $vocab = $this->model->getVocabulary('test');
         $concept = $vocab->getConceptInfo('http://www.skosmos.skos/test/ta112', 'en');
-        $this->assertInstanceOf('Concept', $concept[0]);
-        $this->assertEquals(1, sizeof($concept));
+        $this->assertInstanceOf('Concept', $concept);
     }
 
     /**

--- a/tests/cypress/template/concept.cy.js
+++ b/tests/cypress/template/concept.cy.js
@@ -1,47 +1,63 @@
 describe('Concept page', () => {
   it('contains concept preflabel', () => {
-    cy.visit('/test/en/page/ta122') // go to "Black sea bass" concept page
+    cy.visit('/yso/en/page/p21685') // go to "music research" concept page
 
     // check that the vocabulary title is correct
-    cy.get('#vocab-title > a').invoke('text').should('equal', 'Test ontology')
+    cy.get('#vocab-title > a').invoke('text').should('equal', 'YSO - General Finnish ontology (archaeology)')
 
     // check the concept prefLabel
-    cy.get('#pref-label').invoke('text').should('equal', 'Black sea bass')
+    cy.get('#concept-heading h2').invoke('text').should('equal', 'music research')
   })
   it('contains concept type', () => {
-    cy.visit('/test/en/page/ta122') // go to "Black sea bass" concept page
+    cy.visit('/yso/en/page/p21685') // go to "music research" concept page
 
     // check the property name
-    cy.get('.prop-rdf_type .main-table-label').invoke('text').should('equal', 'Type')
+    cy.get('.prop-rdf_type .property-label').invoke('text').should('equal', 'Type')
 
     // check the concept type
-    cy.get('.prop-rdf_type .align-middle > p').invoke('text').should('equal', 'Test class')
+    cy.get('.prop-rdf_type .property-value a').invoke('text').should('equal', 'General concept')
   })
-  it('contains definition', () => {
+  it('contains definition in Finnish', () => {
+    cy.visit('/yso/en/page/p21685?clang=fi') // go to "music research" concept page (Finnish content language)
+
+    // check the property name
+    cy.get('.prop-skos_definition .property-label').invoke('text').should('equal', 'Definition')
+
+    // check the definition text
+    cy.get('.prop-skos_definition .property-value li').invoke('text').should('contain', 'Musiikin ja musiikin harjoittamisen systemaattinen tutkiminen niiden kaikissa ilmenemismuodoissa.')
+  })
+  it("doesn't contain definition in English", () => {
+    cy.visit('/yso/en/page/p21685') // go to "music research" concept page (English content language)
+
+    // check that there is no definition on the page
+    cy.get('.prop-skos_definition').should('not.exist')
+  })
+  it.skip('contains reified definition', () => {
     cy.visit('/test/en/page/ta122') // go to "Black sea bass" concept page
 
     // check the property name
-    cy.get('.prop-skos_definition .main-table-label').invoke('text').should('equal', 'Definition')
+    cy.get('.prop-skos_definition .property-label').invoke('text').should('equal', 'Definition')
 
     // check the definition text
     cy.get('.prop-skos_definition .reified-property-value').invoke('text').should('contain', 'The black sea bass')
   })
+
   it('contains broader concept', () => {
-    cy.visit('/test/en/page/ta122') // go to "Black sea bass" concept page
+    cy.visit('/yso/en/page/p21685') // go to "music research" concept page
 
     // check the property name
-    cy.get('.prop-skos_broader .main-table-label').invoke('text').should('equal', 'Broader concept')
+    cy.get('.prop-skos_broader .property-label').invoke('text').should('equal', 'Broader concept')
 
     // check the broader concept
-    cy.get('.prop-skos_broader .align-middle a').invoke('text').should('equal', 'Bass')
+    cy.get('.prop-skos_broader .property-value a').invoke('text').should('equal', 'research')
   })
   it('contains concept URI', () => {
-    cy.visit('/test/en/page/ta122') // go to "Black sea bass" concept page
+    cy.visit('/yso/en/page/p21685') // go to "music research" concept page
 
     // check the property name
-    cy.get('.prop-uri .main-table-label').invoke('text').should('equal', 'URI')
+    cy.get('.prop-uri .property-label').invoke('text').should('equal', 'URI')
 
     // check the broader concept
-    cy.get('.prop-uri .align-middle').invoke('text').should('equal', 'http://www.skosmos.skos/test/ta122')
+    cy.get('#concept-uri').invoke('text').should('equal', 'http://www.yso.fi/onto/yso/p21685')
   })
 })

--- a/tests/cypress/template/concept.cy.js
+++ b/tests/cypress/template/concept.cy.js
@@ -110,4 +110,11 @@ describe('Concept page', () => {
     // check the broader concept
     cy.get('#concept-uri').invoke('text').should('equal', 'http://www.yso.fi/onto/yso/p21685')
   })
+  it('contains mappings', () => {
+    cy.visit('/yso/en/page/p21685') // go to "music research" concept page
+
+    // check that we have some mappings
+    cy.get('#concept-mappings').should('not.be.empty')
+
+  })
 })

--- a/tests/cypress/template/concept.cy.js
+++ b/tests/cypress/template/concept.cy.js
@@ -6,7 +6,7 @@ describe('Concept page', () => {
     cy.get('#vocab-title > a').invoke('text').should('equal', 'YSO - General Finnish ontology (archaeology)')
 
     // check the concept prefLabel
-    cy.get('#concept-heading h2').invoke('text').should('equal', 'music research')
+    cy.get('#concept-heading h1').invoke('text').should('equal', 'music research')
   })
   it('contains concept type', () => {
     cy.visit('/yso/en/page/p21685') // go to "music research" concept page

--- a/tests/cypress/template/concept.cy.js
+++ b/tests/cypress/template/concept.cy.js
@@ -41,7 +41,6 @@ describe('Concept page', () => {
     // check the definition text
     cy.get('.prop-skos_definition .reified-property-value').invoke('text').should('contain', 'The black sea bass')
   })
-
   it('contains broader concept', () => {
     cy.visit('/yso/en/page/p21685') // go to "music research" concept page
 
@@ -50,6 +49,57 @@ describe('Concept page', () => {
 
     // check the broader concept
     cy.get('.prop-skos_broader .property-value a').invoke('text').should('equal', 'research')
+  })
+  it('contains narrower concepts', () => {
+    cy.visit('/yso/en/page/p21685') // go to "music research" concept page
+
+    // check the property name
+    cy.get('.prop-skos_narrower .property-label').invoke('text').should('equal', 'Narrower concepts')
+
+    // check that we have the correct number of narrower concepts
+    cy.get('.prop-skos_narrower .property-value').find('li').should('have.length', 8)
+  })
+  it('contains related concepts', () => {
+    cy.visit('/yso/en/page/p21685') // go to "music research" concept page
+
+    // check the property name
+    cy.get('.prop-skos_related .property-label').invoke('text').should('equal', 'Related concepts')
+
+    // check that we have the correct number of related concepts
+    cy.get('.prop-skos_related .property-value').find('li').should('have.length', 3)
+  })
+  it('contains altLabels (entry terms)', () => {
+    cy.visit('/yso/en/page/p21685') // go to "music research" concept page
+
+    // check the property name
+    cy.get('.prop-skos_altLabel .property-label').invoke('text').should('equal', 'Entry terms')
+
+    // check that we have the correct number of altLabels
+    cy.get('.prop-skos_altLabel .property-value').find('li').should('have.length', 1)
+
+    // check the altLabel value
+    cy.get('.prop-skos_altLabel .property-value li').invoke('text').should('equal', 'musicology (research activity)')
+  })
+  it('contains groups', () => {
+    cy.visit('/yso/en/page/p38289') // go to "music archaeology" concept page
+
+    // check the property name
+    cy.get('.prop-skosmos_memberOf .property-label').invoke('text').should('equal', 'Belongs to group')
+
+    // check that we have the correct number of groups
+    cy.get('.prop-skosmos_memberOf .property-value').find('li').should('have.length', 1)
+
+    // check the first group value
+    cy.get('.prop-skosmos_memberOf .property-value a').invoke('text').should('equal', '51 Archaeology')
+  })
+  it('contains terms in other languages', () => {
+    cy.visit('/yso/en/page/p21685') // go to "music research" concept page
+
+    // check the property name
+    cy.get('.prop-foreignlabels .property-label').invoke('text').should('equal', 'In other languages')
+
+    // check that we have the correct number of languages
+    cy.get('#concept-other-languages').find('.row').should('have.length', 3)
   })
   it('contains concept URI', () => {
     cy.visit('/yso/en/page/p21685') // go to "music research" concept page

--- a/tests/cypress/template/concept.cy.js
+++ b/tests/cypress/template/concept.cy.js
@@ -1,3 +1,47 @@
 describe('Concept page', () => {
-  it('no-op test', () => {})
+  it('contains concept preflabel', () => {
+    cy.visit('/test/en/page/ta122') // go to "Black sea bass" concept page
+
+    // check that the vocabulary title is correct
+    cy.get('#vocab-title > a').invoke('text').should('equal', 'Test ontology')
+
+    // check the concept prefLabel
+    cy.get('#pref-label').invoke('text').should('equal', 'Black sea bass')
+  })
+  it('contains concept type', () => {
+    cy.visit('/test/en/page/ta122') // go to "Black sea bass" concept page
+
+    // check the property name
+    cy.get('.prop-rdf_type .main-table-label').invoke('text').should('equal', 'Type')
+
+    // check the concept type
+    cy.get('.prop-rdf_type .align-middle > p').invoke('text').should('equal', 'Test class')
+  })
+  it('contains definition', () => {
+    cy.visit('/test/en/page/ta122') // go to "Black sea bass" concept page
+
+    // check the property name
+    cy.get('.prop-skos_definition .main-table-label').invoke('text').should('equal', 'Definition')
+
+    // check the definition text
+    cy.get('.prop-skos_definition .reified-property-value').invoke('text').should('contain', 'The black sea bass')
+  })
+  it('contains broader concept', () => {
+    cy.visit('/test/en/page/ta122') // go to "Black sea bass" concept page
+
+    // check the property name
+    cy.get('.prop-skos_broader .main-table-label').invoke('text').should('equal', 'Broader concept')
+
+    // check the broader concept
+    cy.get('.prop-skos_broader .align-middle a').invoke('text').should('equal', 'Bass')
+  })
+  it('contains concept URI', () => {
+    cy.visit('/test/en/page/ta122') // go to "Black sea bass" concept page
+
+    // check the property name
+    cy.get('.prop-uri .main-table-label').invoke('text').should('equal', 'URI')
+
+    // check the broader concept
+    cy.get('.prop-uri .align-middle').invoke('text').should('equal', 'http://www.skosmos.skos/test/ta122')
+  })
 })

--- a/tests/cypress/template/concept.cy.js
+++ b/tests/cypress/template/concept.cy.js
@@ -15,7 +15,7 @@ describe('Concept page', () => {
     cy.get('.prop-rdf_type .property-label').invoke('text').should('equal', 'Type')
 
     // check the concept type
-    cy.get('.prop-rdf_type .property-value a').invoke('text').should('equal', 'General concept')
+    cy.get('.prop-rdf_type .property-value li').invoke('text').should('equal', 'General concept')
   })
   it('contains definition in Finnish', () => {
     cy.visit('/yso/en/page/p21685?clang=fi') // go to "music research" concept page (Finnish content language)

--- a/tests/cypress/template/vocab-home.cy.js
+++ b/tests/cypress/template/vocab-home.cy.js
@@ -2,7 +2,7 @@ describe('Vocabulary home page', () => {
   it('contains vocabulary title', () => {
     cy.visit('/test/en') // go to the "Test ontology" home page
 
-    // check that the vocabulary title is not empty
+    // check that the vocabulary title is correct
     cy.get('#vocab-title > a').invoke('text').should('equal', 'Test ontology')
   })
   it('shows alphabetical index letters', () => {


### PR DESCRIPTION
## Reasons for creating this PR

Reimplement the concept page template so it follows the new Skosmos 3 design.
Also add Cypress tests verifying the existing functionality.

This implements just the basic functionality. Many features and special cases are not implemented yet; see checklist in https://github.com/NatLibFi/Skosmos/issues/1484#issuecomment-1739297570

## Link to relevant issue(s), if any

- Implements first parts of #1484

## Description of the changes in this PR

- refactor Vocabulary.getConceptInfo() so it returns a single concept (instead of an array of size 1)
- rewrite the concept page template based on the static example (but adapting it heavily to use Bootstrap Grid instead of a HTML table)
- add some Cypress tests for the concept page / template

## Known problems or uncertainties in this PR

n/a

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
