### PR TITLE
Better template and styling for the concept mappings component

### DIFF
--- a/resource/css/skosmos.css
+++ b/resource/css/skosmos.css
@@ -587,7 +587,7 @@ body {
 
   .main-content-section {
     background-color: var(--vocab-bg);
-    margin-bottom: 3px;
+    margin-bottom: .3rem;
   }
 
   #concept-heading {
@@ -597,6 +597,10 @@ body {
   .property {
     border-top: 1px solid var(--vocab-table-border);
     padding: .5rem 0;
+  }
+
+  .property.prop-mapping {
+    border-top: none;
   }
 
   .property-label h2 {

--- a/resource/css/skosmos.css
+++ b/resource/css/skosmos.css
@@ -587,7 +587,7 @@ body {
 
   .main-content-section {
     background-color: var(--vocab-bg);
-    margin-bottom: .3rem;
+    margin-bottom: .2rem;
   }
 
   #concept-heading {

--- a/resource/css/skosmos.css
+++ b/resource/css/skosmos.css
@@ -587,7 +587,7 @@ body {
 
   .main-content-section {
     background-color: var(--vocab-bg);
-    border-bottom: 2px solid var(--main-bg-2);
+    margin-bottom: 3px;
   }
 
   #concept-heading {

--- a/resource/js/concept-mappings.js
+++ b/resource/js/concept-mappings.js
@@ -60,20 +60,17 @@ conceptMappingsApp.component('concept-mappings', {
   props: ['mappings'],
   inject: ['content_lang'],
   template: `
-    <table>
-      <tr v-for="mapping in Object.entries(mappings)">
-        <td :title="mapping[1][0].description">{{ mapping[0]}}</td>
-        <td>
-          <template v-for="m in mapping[1]">
-            <a :href="m.hrefLink">{{ m.prefLabel }}</a>
-            <span v-if="m.lang !== this.content_lang"> ({{ m.lang }})</span><br>
-          </template>
-        </td>
-        <td>
-          <template v-for="m in mapping[1]">{{ m.vocabName }}<br></template>
-        </td>
-      </tr>
-    </table>
+    <div class="row prop-mapping" v-for="mapping in Object.entries(mappings)">
+      <div class="col-sm-4 px-0 property-label" :title="mapping[1][0].description"><h2>{{ mapping[0] }}</h2></div>
+      <div class="col-sm-8">
+        <div class="row mb-2" v-for="m in mapping[1]">
+          <div class="col-sm-4">
+            <a :href="m.hrefLink">{{ m.prefLabel }}</a><span v-if="m.lang && m.lang !== this.content_lang"> ({{ m.lang }})</span>
+          </div>
+          <div class="col-sm-8">{{ m.vocabName }}</div>
+        </div>
+      </div>
+    </div>
   `
 })
 

--- a/resource/js/concept-mappings.js
+++ b/resource/js/concept-mappings.js
@@ -64,10 +64,10 @@ conceptMappingsApp.component('concept-mappings', {
       <div class="col-sm-4 px-0 property-label" :title="mapping[1][0].description"><h2>{{ mapping[0] }}</h2></div>
       <div class="col-sm-8">
         <div class="row mb-2" v-for="m in mapping[1]">
-          <div class="col-sm-4 prop-mapping-label">
+          <div class="col-sm-5 prop-mapping-label">
             <a :href="m.hrefLink">{{ m.prefLabel }}</a><span v-if="m.lang && m.lang !== this.content_lang"> ({{ m.lang }})</span>
           </div>
-          <div class="col-sm-8 prop-mapping-vocab">{{ m.vocabName }}</div>
+          <div class="col-sm-7 prop-mapping-vocab">{{ m.vocabName }}</div>
         </div>
       </div>
     </div>

--- a/resource/js/concept-mappings.js
+++ b/resource/js/concept-mappings.js
@@ -60,14 +60,14 @@ conceptMappingsApp.component('concept-mappings', {
   props: ['mappings'],
   inject: ['content_lang'],
   template: `
-    <div class="row prop-mapping" v-for="mapping in Object.entries(mappings)">
+    <div class="row property prop-mapping" v-for="mapping in Object.entries(mappings)">
       <div class="col-sm-4 px-0 property-label" :title="mapping[1][0].description"><h2>{{ mapping[0] }}</h2></div>
       <div class="col-sm-8">
         <div class="row mb-2" v-for="m in mapping[1]">
-          <div class="col-sm-4">
+          <div class="col-sm-4 prop-mapping-label">
             <a :href="m.hrefLink">{{ m.prefLabel }}</a><span v-if="m.lang && m.lang !== this.content_lang"> ({{ m.lang }})</span>
           </div>
-          <div class="col-sm-8">{{ m.vocabName }}</div>
+          <div class="col-sm-8 prop-mapping-vocab">{{ m.vocabName }}</div>
         </div>
       </div>
     </div>

--- a/src/view/concept-card.inc
+++ b/src/view/concept-card.inc
@@ -83,11 +83,10 @@
           </ul>
         </div>
       </div>
-
+    </div>
+    <!-- appendix / concept mapping properties -->
+    <div id="concept-mappings" class="main-content-section p-5">
     </div>
 
-  </div>
-  <!-- appendix / concept mapping properties -->
-  <div id="concept-mappings">
   </div>
 </div>

--- a/src/view/concept-card.inc
+++ b/src/view/concept-card.inc
@@ -41,8 +41,8 @@
         <div class="col-sm-8" id="concept-other-languages">
           {% for language,labels in foreignLabels %}
           <div class="row">
-            <div class="col-sm-6 order-last"><h3>{{ language }}</h3></div>
-            <div class="col-sm-6">
+            <div class="col-sm-7 order-last"><h3>{{ language }}</h3></div>
+            <div class="col-sm-5">
               <ul>
                 {% for value in labels.prefLabel|default([])|merge(labels.altLabel|default([])) %}
                 {% if value.type == "skos:prefLabel" and value.lang in request.vocab.config.languages %}

--- a/tests/cypress/template/concept.cy.js
+++ b/tests/cypress/template/concept.cy.js
@@ -116,5 +116,26 @@ describe('Concept page', () => {
     // check that we have some mappings
     cy.get('#concept-mappings').should('not.be.empty')
 
+    // check the first mapping property name
+    cy.get('.prop-mapping h2').eq(0).contains('Closely matching concepts')
+    // check the first mapping property values
+    cy.get('.prop-mapping').eq(0).find('.prop-mapping-label').eq(0).contains('Musicology')
+    cy.get('.prop-mapping').eq(0).find('.prop-mapping-label').eq(0).find('a').should('have.attr', 'href', 'http://id.loc.gov/authorities/subjects/sh85089048')
+    cy.get('.prop-mapping').eq(0).find('.prop-mapping-vocab').eq(0).contains('Library of Congress Subject Headings')
+    cy.get('.prop-mapping').eq(0).find('.prop-mapping-label').eq(1).contains('musicology')
+    cy.get('.prop-mapping').eq(0).find('.prop-mapping-label').eq(1).find('a').should('have.attr', 'href', 'http://www.wikidata.org/entity/Q164204')
+    cy.get('.prop-mapping').eq(0).find('.prop-mapping-vocab').eq(1).contains('www.wikidata.org')
+    // check that the second mapping property has the right number of entries
+    cy.get('.prop-mapping').eq(0).find('.prop-mapping-label').should('have.length', 2)
+
+    // check the second mapping property name
+    cy.get('.prop-mapping h2').eq(1).contains('Exactly matching concepts')
+    // check the second mapping property values (only one should be enough)
+    cy.get('.prop-mapping').eq(1).find('.prop-mapping-label').eq(0).contains('musiikintutkimus (fi)')
+    cy.get('.prop-mapping').eq(1).find('.prop-mapping-label').eq(0).find('a').invoke('text').should('equal', 'musiikintutkimus')
+    cy.get('.prop-mapping').eq(1).find('.prop-mapping-label').eq(0).find('a').should('have.attr', 'href', 'http://www.yso.fi/onto/ysa/Y155072')
+    cy.get('.prop-mapping').eq(1).find('.prop-mapping-vocab').eq(0).contains('YSA - Yleinen suomalainen asiasanasto')
+    // check that the second mapping property has the right number of entries
+    cy.get('.prop-mapping').eq(1).find('.prop-mapping-label').should('have.length', 3)
   })
 })


### PR DESCRIPTION
## Reasons for creating this PR

The concept mappings Vue component was implemented using a very basic HTML table layout without any proper styling. This PR changes the template to use Bootstrap Grid and adds CSS rules to make it look as it should (hopefully). It also adds more specific Cypress tests for the mappings.

This is how it looks on Firefox:

![image](https://github.com/NatLibFi/Skosmos/assets/1132830/8d00b951-9b49-42d5-be6a-f79fe7cf2f2c)


## Link to relevant issue(s), if any

- Part of #1484

## Description of the changes in this PR

- move location of concept mappings DIV element one level deeper
- reimplement concept mappings HTML template using Bootstrap Grid instead of HTML tables
- adjust CSS rules to follow Skosmos 3 visual design
- add more specific Cypress tests for the mappings

## Known problems or uncertainties in this PR

We don't have a good specification for the visual layout of the mappings, in particular for the case where there are two or more types of mappings. This is my best guess.

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
