### PR TITLE
Harden JSONP callback filter

### DIFF
--- a/controller/RestController.php
+++ b/controller/RestController.php
@@ -25,7 +25,7 @@ class RestController extends Controller
         // wrap with JSONP callback if requested
         if (filter_input(INPUT_GET, 'callback', FILTER_SANITIZE_FULL_SPECIAL_CHARS)) {
             header("Content-type: application/javascript; charset=utf-8");
-            echo filter_input(INPUT_GET, 'callback', FILTER_UNSAFE_RAW) . "(" . json_encode($data) . ");";
+            echo filter_input(INPUT_GET, 'callback', FILTER_SANITIZE_FULL_SPECIAL_CHARS) . "(" . json_encode($data) . ");";
             return;
         }
 


### PR DESCRIPTION
## Reasons for creating this PR

I noticed that the FILTER_UNSAFE_RAW input filter was still used once in the Controller, for processing the name of the JSONP callback method/function. As the name implies, this filter is unsafe by design. In PR #1385, other input filters were changed but not this one. I don't see why a stricter filter couldn't be used here, because JSONP callbacks are typically just alphanumeric function names, so this PR switches to FILTER_SANITIZE_FULL_SPECIAL_CHARS.

In practice, this is very unlikely to be exploitable at least in the normal JSONP usage scenario (which itself has gone out of fashion as applications have switched to CORS). The application constructing the JSONP URL already has full control of the JS environment, so being able to run arbitrary JS code via the callback method name doesn't add any new capabilities. But better safe than sorry, and maybe code scanning tools will be happier.

## Link to relevant issue(s), if any

- follow-up fix to #1385

## Description of the changes in this PR

- switch the input filter used for JSONP callback method names to FILTER_SANITIZE_FULL_SPECIAL_CHARS

## Known problems or uncertainties in this PR

This needs to be adapted to Skosmos 3 as well and applied to the `skosmos-3` branch.

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
