### PR TITLE
Harden JSONP callback filter (Skosmos 3)

### DIFF
--- a/src/controller/RestController.php
+++ b/src/controller/RestController.php
@@ -25,7 +25,7 @@ class RestController extends Controller
         // wrap with JSONP callback if requested
         if (filter_input(INPUT_GET, 'callback', FILTER_SANITIZE_FULL_SPECIAL_CHARS)) {
             header("Content-type: application/javascript; charset=utf-8");
-            echo filter_input(INPUT_GET, 'callback', FILTER_UNSAFE_RAW) . "(" . json_encode($data) . ");";
+            echo filter_input(INPUT_GET, 'callback', FILTER_SANITIZE_FULL_SPECIAL_CHARS) . "(" . json_encode($data) . ");";
             return;
         }
 


### PR DESCRIPTION
## Reasons for creating this PR

Same as PR #1553, but for Skosmos 3. See that PR for rationale and details.

## Link to relevant issue(s), if any

- follow-up fix for #1385

## Description of the changes in this PR

- switch the input filter used for JSONP callback method names to FILTER_SANITIZE_FULL_SPECIAL_CHARS

## Known problems or uncertainties in this PR

n/a

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
