### PR TITLE
Add styling to sidebar

### DIFF
--- a/resource/css/skosmos.css
+++ b/resource/css/skosmos.css
@@ -13,6 +13,12 @@
   --feedback-form-button-bg: var(--dark-color);
   --sidebar-search-bg: var(--dark-color);
   --sidebar-search-text: var(--white-color);
+  --sidebar-tab-inactive-bg: var(--light-color);
+  --sidebar-tab-inactive-text: var(--dark-color);
+  --sidebar-tab-active-bg: var(--dark-color);
+  --sidebar-tab-active-text: var(--white-color);
+  --sidebar-scrollbar-bg: var(--light-color);
+  --sidebar-scrollbar-thumb: var(--secondary-medium-color);
   --vocab-bg: var(--white-color);
   --vocab-table-border: var(--medium-color);
   --vocab-link: var(--secondary-dark-color);
@@ -70,6 +76,7 @@ body {
   #main-container.vocabpage .fa-arrow-right, #main-container.termpage .fa-arrow-right {
     color: var(--vocab-text);
     font-size: 12px;
+    margin: 0 5px;
   }
 
   #main-container.termpage .fa-copy {
@@ -377,12 +384,25 @@ body {
   }
 
   /*** Sidebar termpage & vocabpage ***/
-  #main-container.vocabpage #sidebar .nav-item, #main-container.termpage #sidebar .nav-item {
+  #main-container.vocabpage #sidebar-col, #main-container.termpage #sidebar-col {
+    background-color: var(--vocab-bg);
+    background-clip: content-box, padding-box;
+  }
+
+  #main-container.vocabpage #sidebar, #main-container.termpage #sidebar {
+    background-color: var(--vocab-bg);
+  }
+
+  #main-container.vocabpage #sidebar .nav, #main-container.termpage #sidebar .nav {
     background-color: var(--sidebar-tab-inactive-bg);
   }
 
   #main-container.vocabpage #sidebar .nav-link, #main-container.termpage #sidebar .nav-link {
     color: var(--sidebar-tab-inactive-text) !important;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     transition: none;
   }
 
@@ -407,45 +427,50 @@ body {
     border-radius: 0 !important;
     margin: 0 !important;
     transition: none;
+    width: 35px;
   }
 
-  /* Not sure what these should be, probably something though */
-  #main-container.vocabpage #sidebar .page-link:hover, #main-container.vocabpage #sidebar .page-link:active, #main-container.vocabpage #sidebar .page-link:focus
+  #main-container.vocabpage #sidebar .page-link, #main-container.termpage #sidebar .page-link {
+    display: flex;
+    align-content: center;
+    text-align: center;
+  }
+
+  /* what to do with these */
+  #main-container.vocabpage #sidebar .page-link:hover, #main-container.vocabpage #sidebar .page-link:active, #main-container.vocabpage #sidebar .page-link:focus,
   #main-container.termpage #sidebar .page-link:hover, #main-container.termpage #sidebar .page-link:active, #main-container.termpage #sidebar .page-link:focus {
     background-color: var(--sidebar-tab-active-bg);
     color: var(--sidebar-tab-active-text);
     box-shadow: none;
   }
 
-  #alpha-list {
+  .sidebar-list {
     padding: 2rem 1rem;
-    overflow: hidden;
     overflow-y: scroll;
     scrollbar-color: var(--sidebar-scrollbar-thumb) var(--sidebar-scrollbar-bg);
-    height: 600px; /*remove*/
+    max-height: 1000px; /* needs to be changed */
   }
 
-  #alpha-list::-webkit-scrollbar {
+  .sidebar-list::-webkit-scrollbar {
     background: var(--sidebar-scrollbar-bg);
   }
 
-  #alpha-list::-webkit-scrollbar-thumb {
+  .sidebar-list::-webkit-scrollbar-thumb {
     background: var(--sidebar-scrollbar-thumb);
   }
 
-  #alpha-list li {
+  .sidebar-list li {
     border: none;
     border-radius: none;
   }
 
-  #alpha-list .list-group-item.selected a {
-    color: var(--vocab-text);
-    font-size: 18px;
+  .sidebar-list a {
+    font-weight: bold !important;
   }
 
-  #tab-hierarchy {
-    background-color: var(--sidebar-tab-active-bg);
-    color: var(--sidebar-tab-active-text);
+  .sidebar-list .list-group-item a.selected {
+    color: var(--vocab-text) !important;
+    font-weight: bold !important;
   }
 
   /*** sidebar serachpage ***/
@@ -698,12 +723,14 @@ body {
   #alphabetical-menu > .list-group > .list-group-item {
     border: none !important;
   }
+  
+  /*** Sidebar ***/
+  /*
   #sidebar > div > .nav-tabs > .nav-item {
     border: none !important;
     border-image: none !important;
     transition: none;
   }
-  /*** Sidebar ***/
   #sidebar .nav-item {
     background-color: var(--light-color);
   }
@@ -749,6 +776,7 @@ body {
     margin: 0 !important;
     transition: none;
   }
+  */
   tr > td {
     color: var(--dark-color);
   }

--- a/resource/css/skosmos.css
+++ b/resource/css/skosmos.css
@@ -791,59 +791,6 @@ body {
     border: none !important;
   }
   
-  /*** Sidebar ***/
-  /*
-  #sidebar > div > .nav-tabs > .nav-item {
-    border: none !important;
-    border-image: none !important;
-    transition: none;
-  }
-  #sidebar .nav-item {
-    background-color: var(--light-color);
-  }
-  #sidebar .nav-link {
-    color: var(--dark-color) !important;
-  }
-  #sidebar .nav .active {
-    background-color: var(--dark-color);
-    color: var(--white-color) !important;
-  }
-  #sidebar .pagination {
-    background-color: var(--dark-color);
-    color: var(--white-color);
-  }
-  #sidebar .page-item, #sidebar .page-link {
-    background-color: var(--dark-color);
-    color: var(--white-color) !important;
-  }
-  #sidebar .page-link:hover, #sidebar .page-link:active, #sidebar .page-link:focus {
-    background-color: var(--dark-color);
-    color: var(--white-color);
-    scrollbar-color: var(--secondary-medium-color) var(--light-color);
-    background: var(--light-color);
-    background: var(--secondary-medium-color);
-    padding: 0.25rem 0.5rem;
-  }
-  #alpha-list a {
-    color: var(--secondary-dark-color);
-  }
-  #alpha-list .list-group-item.selected a {
-    color: var(--dark-color);
-    font-size: 18px;
-  }
-  #tab-hierarchy {
-    background-color: var(--dark-color);
-    color: var(--white-color);
-  }
-  #sidebar .page-item, #sidebar .page-link {
-    background-color: var(--dark-color);
-    color: var(--white-color) !important;
-    font-weight: normal !important;
-    border-radius: 0 !important;
-    margin: 0 !important;
-    transition: none;
-  }
-  */
   tr > td {
     color: var(--dark-color);
   }

--- a/resource/css/skosmos.css
+++ b/resource/css/skosmos.css
@@ -20,6 +20,7 @@
   --sidebar-scrollbar-bg: var(--light-color);
   --sidebar-scrollbar-thumb: var(--secondary-medium-color);
   --vocab-bg: var(--white-color);
+  --vocab-text: var(--dark-color);
   --vocab-table-border: var(--medium-color);
   --vocab-link: var(--secondary-dark-color);
 
@@ -459,7 +460,7 @@ body {
     background: var(--sidebar-scrollbar-thumb);
   }
 
-  .sidebar-list li {
+  .sidebar-list .list-group-item {
     border: none;
     border-radius: none;
   }
@@ -468,9 +469,78 @@ body {
     font-weight: bold !important;
   }
 
-  .sidebar-list .list-group-item a.selected {
+  /*** sidebar hierarchy tab ***/
+  #tab-hierarchy .sidebar-list .list-group-item {
+    border-left: 1px dashed var(--vocab-text);
+    border-radius: 0;
+  }
+
+  #tab-hierarchy .sidebar-list .list-group-item.top-concept {
+    border: none;
+  }
+
+  #tab-hierarchy .sidebar-list .list-group-item span {
+    display: inline-block;
+    border-left: 1px dashed var(--vocab-text);
+    margin-left: 16px;
+    padding-left: 14px;
+  }
+
+  /* horizontal line before concept */
+  #tab-hierarchy .sidebar-list .list-group-item span::before {
+    content: '';
+    position: absolute;
+    left: 16px;
+    bottom: 0;
+    width: 10px;
+    height: 50%;
+    border-top: 1px dashed var(--vocab-text);
+  }
+
+  /* hiding bottom of vertical line on last concept of list */
+  #tab-hierarchy .sidebar-list .list-group-item span.last::before {
+    border-left: 1px solid var(--vocab-bg);
+  }
+
+  /* horizontal line before opened concept */
+  #tab-hierarchy .sidebar-list .list-group-item span.open::before {
+    top: 0;
+    height: 13px;
+    border-bottom: 1px dashed var(--vocab-text);
+    border-top: none;
+  }
+
+  #tab-hierarchy .sidebar-list .list-group-item a.selected {
     color: var(--vocab-text) !important;
-    font-weight: bold !important;
+  }
+
+  .hierarchy-button {
+    background-color: transparent;
+    color: var(--vocab-text);
+    border: none;
+    padding: 0;
+    font-size: 10px;
+  }
+
+  .hierarchy-button:hover, .hierarchy-button:active {
+    background-color: transparent !important;
+    color: var(--vocab-text) !important;
+  }
+
+  .hierarchy-button i {
+    transform: rotate(-45deg);
+    position: absolute;
+    top: 4px;
+    left: 5px;
+    width: 15px;
+    z-index: 1;
+  }
+
+  .hierarchy-button.open i {
+    transform: rotate(0deg);
+    top: 1px;
+    left: 5px;
+    width: 20px;
   }
 
   /*** sidebar serachpage ***/

--- a/resource/css/skosmos.css
+++ b/resource/css/skosmos.css
@@ -447,7 +447,7 @@ body {
 
   .sidebar-list {
     padding: 2rem 1rem;
-    overflow-y: scroll;
+    overflow: auto;
     scrollbar-color: var(--sidebar-scrollbar-thumb) var(--sidebar-scrollbar-bg);
     max-height: 1000px; /* needs to be changed */
   }
@@ -491,23 +491,20 @@ body {
     content: '';
     position: absolute;
     left: 16px;
-    bottom: 0;
+    top: 0;
     width: 10px;
-    height: 50%;
-    border-top: 1px dashed var(--vocab-text);
+    height: 13px;
+    border-bottom: 1px dashed var(--vocab-text);
   }
 
   /* hiding bottom of vertical line on last concept of list */
   #tab-hierarchy .sidebar-list .list-group-item span.last::before {
+    top: auto;
+    bottom: 0;
+    height: calc(100% - 13px);
     border-left: 1px solid var(--vocab-bg);
-  }
-
-  /* horizontal line before opened concept */
-  #tab-hierarchy .sidebar-list .list-group-item span.open::before {
-    top: 0;
-    height: 13px;
-    border-bottom: 1px dashed var(--vocab-text);
-    border-top: none;
+    border-top: 1px dashed var(--vocab-text);
+    border-bottom: none;
   }
 
   #tab-hierarchy .sidebar-list .list-group-item a.selected {

--- a/resource/js/tab-alpha.js
+++ b/resource/js/tab-alpha.js
@@ -7,7 +7,9 @@ const tabAlphaApp = Vue.createApp({
     return {
       indexLetters: [],
       indexConcepts: [],
-      selectedLetter: ''
+      selectedConcept: '',
+      loadingLetters: false,
+      loadingConcepts: false
     }
   },
   provide () {
@@ -18,39 +20,55 @@ const tabAlphaApp = Vue.createApp({
   },
   mounted () {
     // load alphabetical index if alphabetical tab is active when the page is first opened (otherwise only load the index when the tab is clicked)
-    // this should probably be done differently
     if (document.querySelector('#alphabetical > a').classList.contains('active')) {
       this.loadLetters()
     }
   },
   methods: {
-    loadLetters () {
-      // only load index the first time the page is opened or the alphabetical tab is clicked
-      if (this.indexLetters.length === 0) {
-        fetch('rest/v1/' + SKOSMOS.vocab + '/index/?lang=' + SKOSMOS.lang)
-          .then(data => {
-            return data.json()
-          })
-          .then(data => {
-            this.indexLetters = data.indexLetters
-            this.loadConcepts(this.indexLetters[0])
-          })
+    handleClickAlphabeticalEvent () {
+      // only load index the first time the page is opened or if selected concept has changed
+      if (this.indexLetters.length === 0 || this.selectedConcept !== SKOSMOS.uri) {
+        this.selectedConcept = ''
+        this.indexLetters = []
+        this.indexConcepts = []
+        this.loadLetters()
       }
     },
+    loadLetters () {
+      this.loadingLetters = true
+      fetch('rest/v1/' + SKOSMOS.vocab + '/index/?lang=' + SKOSMOS.lang)
+        .then(data => {
+          return data.json()
+        })
+        .then(data => {
+          this.indexLetters = data.indexLetters
+          this.loadingLetters = false
+          this.loadConcepts(this.indexLetters[0])
+        })
+    },
     loadConcepts (letter) {
-      this.selectedLetter = letter
-      fetch('rest/v1/' + SKOSMOS.vocab + '/index/' + this.selectedLetter + '?lang=' + SKOSMOS.lang + '&limit=50')
+      this.loadingConcepts = true
+      fetch('rest/v1/' + SKOSMOS.vocab + '/index/' + letter + '?lang=' + SKOSMOS.lang + '&limit=50')
         .then(data => {
           return data.json()
         })
         .then(data => {
           this.indexConcepts = data.indexConcepts
+          this.loadingConcepts = false
         })
     }
   },
   template: `
-    <div v-click-tab-alphabetical="loadLetters">
-      <tab-alpha :index-letters="indexLetters" :index-concepts="indexConcepts" v-if="indexLetters" @load-concepts="loadConcepts($event)"></tab-alpha>
+    <div v-click-tab-alphabetical="handleClickAlphabeticalEvent">
+      <tab-alpha
+        :index-letters="indexLetters"
+        :index-concepts="indexConcepts"
+        :selected-concept="selectedConcept"
+        :loading-letters="loadingLetters"
+        :loading-concepts="loadingConcepts"
+        @load-concepts="loadConcepts($event)"
+        @select-concept="selectedConcept = $event"
+      ></tab-alpha>
     </div>
   `
 })
@@ -69,28 +87,51 @@ tabAlphaApp.directive('click-tab-alphabetical', {
 })
 
 tabAlphaApp.component('tab-alpha', {
-  props: ['indexLetters', 'indexConcepts'],
-  emits: ['loadConcepts'],
+  props: ['indexLetters', 'indexConcepts', 'selectedConcept', 'loadingLetters', 'loadingConcepts'],
+  emits: ['loadConcepts', 'selectConcept'],
   inject: ['partialPageLoad', 'getConceptURL'],
   methods: {
     loadConcepts (event, letter) {
       event.preventDefault()
       this.$emit('loadConcepts', letter)
+    },
+    loadConcept (event, uri) {
+      partialPageLoad(event, getConceptURL(uri))
+      this.$emit('selectConcept', uri)
     }
   },
   template: `
-    <ul class="pagination">
-      <li v-for="letter in indexLetters" class="page-item">
-        <a class="page-link" href="#" @click="loadConcepts($event, letter)" style="background-color: darkblue;">{{ letter }}</a>
-      </li>
-    </ul>
-
-    <ul class="list-group" id="alpha-list">
-      <li v-for="concept in indexConcepts" class="list-group-item py-1">
-        <template v-if="concept.altLabel">{{ concept.altLabel }} -> </template>
-        <a :href="getConceptURL(concept.uri)" @click="partialPageLoad($event, getConceptURL(concept.uri))">{{ concept.prefLabel }}</a>
-      </li>
-    </ul>
+    <template v-if="loadingLetters">
+      <div>
+        Loading...
+      </div>
+    </template>
+    <template v-else>
+      <ul class="pagination" v-if="indexLetters.length !== 0">
+        <li v-for="letter in indexLetters" class="page-item">
+          <a class="page-link" href="#" @click="loadConcepts($event, letter)">{{ letter }}</a>
+        </li>
+      </ul>
+    </template>
+    
+    <template v-if="loadingConcepts">
+      <div>
+        Loading...
+      </div>
+    </template>
+    <template v-else>
+      <ul class="list-group sidebar-list" v-if="indexConcepts.length !== 0">
+        <li v-for="concept in indexConcepts" class="list-group-item py-1 px-2">
+          <template v-if="concept.altLabel">
+            <span class="fst-italic">{{ concept.altLabel }}</span>
+            <i class="fa-solid fa-arrow-right"></i>
+          </template>
+          <a :class="{ 'selected': selectedConcept === concept.uri }"
+            :href="getConceptURL(concept.uri)" @click="loadConcept($event, concept.uri)"
+          >{{ concept.prefLabel }}</a>
+        </li>
+      </ul>
+    </template>
   `
 })
 

--- a/resource/js/tab-hierarchy.js
+++ b/resource/js/tab-hierarchy.js
@@ -145,11 +145,13 @@ const tabHierApp = Vue.createApp({
   },
   template: `
     <div v-click-tab-hierarchy="handleClickHierarchyEvent">
-      <ul class="list-group sidebar-list" v-if="!loading">
-        <template v-for="c in hierarchy">
+      <ul class="list-group sidebar-list p-0" v-if="!loading">
+        <template v-for="(c, i) in hierarchy">
           <tab-hier
             :concept="c"
             :selectedConcept="selectedConcept"
+            :isTopConcept="true"
+            :isLast="i == hierarchy.length - 1 && !c.isOpen"
             @load-children="loadChildren($event)"
             @select-concept="selectedConcept = $event"
           ></tab-hier>
@@ -173,7 +175,7 @@ tabHierApp.directive('click-tab-hierarchy', {
 })
 
 tabHierApp.component('tab-hier', {
-  props: ['concept', 'selectedConcept'],
+  props: ['concept', 'selectedConcept', 'isTopConcept', 'isLast'],
   emits: ['loadChildren', 'selectConcept'],
   inject: ['partialPageLoad', 'getConceptURL'],
   methods: {
@@ -195,20 +197,27 @@ tabHierApp.component('tab-hier', {
     }
   },
   template: `
-    <li class="list-group-item">
-      <div>
-        <button v-if="concept.hasChildren" @click="handleClickOpenEvent(concept)"></button>
-        <a 
-          :class="{ 'selected': selectedConcept === concept.uri }"
+    <li class="list-group-item p-0" :class="{ 'top-concept': isTopConcept }">
+      <button type="button" class="hierarchy-button btn btn-primary"
+        :class="{ 'open': concept.isOpen }"
+        v-if="concept.hasChildren"
+        @click="handleClickOpenEvent(concept)"
+      >
+        <i>{{ concept.isOpen ? '&#x25E2;' : '&#x25FF;' }}</i>
+      </button>
+      <span :class="{ 'last': isLast, 'open': concept.isOpen }">
+        <a :class="{ 'selected': selectedConcept === concept.uri }"
           :href="getConceptURL(concept.uri)"
           @click="handleClickConceptEvent($event, concept)"
         >{{ concept.label }}</a>
-      </div>
-      <ul class="list-group" v-if="concept.children.length !== 0 && concept.isOpen">
-        <template v-for="c in concept.children">
+      </span>
+      <ul class="list-group px-3" v-if="concept.children.length !== 0 && concept.isOpen">
+        <template v-for="(c, i) in concept.children">
           <tab-hier
             :concept="c"
             :selectedConcept="selectedConcept"
+            :isTopConcept="false"
+            :isLast="i == concept.children.length - 1 && !c.isOpen"
             @load-children="loadChildrenRecursive($event)"
             @select-concept="selectConceptRecursive($event)"
           ></tab-hier>

--- a/resource/js/tab-hierarchy.js
+++ b/resource/js/tab-hierarchy.js
@@ -205,7 +205,7 @@ tabHierApp.component('tab-hier', {
       >
         <i>{{ concept.isOpen ? '&#x25E2;' : '&#x25FF;' }}</i>
       </button>
-      <span :class="{ 'last': isLast, 'open': concept.isOpen }">
+      <span :class="{ 'last': isLast }">
         <a :class="{ 'selected': selectedConcept === concept.uri }"
           :href="getConceptURL(concept.uri)"
           @click="handleClickConceptEvent($event, concept)"

--- a/src/view/sidebar.inc
+++ b/src/view/sidebar.inc
@@ -1,5 +1,5 @@
-<div class="col-md-4">
-  <div class="bg-light" id="sidebar">
+<div class="col-md-4" id="sidebar-col">
+  <div id="sidebar">
   {% block sidebar %}
     <div class="sidebar-buttons">
       <h2 class="visually-hidden">{{'Sidebar listing: list and traverse vocabulary contents by a criterion' | trans}}</h2>
@@ -33,9 +33,7 @@
         {# active_class is used to set initial active tab #}
         {# On vocab page active tab is set to defaultSidebarView, on concept page active tab is set to defaultConceptSidebarView #}
         {% set active_class = (request.page == 'vocab' and view == vocab.config.defaultSidebarView) or (request.page == 'page' and view == vocab.config.defaultConceptSidebarView) %}
-        <div class="tab-pane{% if active_class %} active{% endif %}" id="tab-{{ view }}" role="tabpanel">
-          {{ view }} {# should be removed #}
-        </div>
+        <div class="tab-pane{% if active_class %} active{% endif %}" id="tab-{{ view }}" role="tabpanel"></div>
       {% endfor %}
     </div>
 

--- a/tests/cypress/template/vocab-home.cy.js
+++ b/tests/cypress/template/vocab-home.cy.js
@@ -19,7 +19,7 @@ describe('Vocabulary home page', () => {
   it('shows alphabetical index entries', () => {
     cy.visit('/test/en') // go to the "Test ontology" home page
 
-    const entries = cy.get('#alpha-list').children()
+    const entries = cy.get('#tab-alphabetical .sidebar-list').children()
 
     // check that we have the correct number of entries
     entries.should('have.length', 3)
@@ -34,9 +34,9 @@ describe('Vocabulary home page', () => {
     cy.get('#tab-alphabetical .pagination :nth-child(2) > .page-link').click()
 
     // check that we have the correct number of entries
-    cy.get('#alpha-list').children().should('have.length', 2)
+    cy.get('#tab-alphabetical .sidebar-list').children().should('have.length', 2)
 
     // check that the first entry is Carp
-    cy.get('#alpha-list').children().first().invoke('text').should('equal', 'Carp')
+    cy.get('#tab-alphabetical .sidebar-list').children().first().invoke('text').should('equal', 'Carp')
   })
 })


### PR DESCRIPTION
## Reasons for creating this PR

The sidebar is missing almost all styling, this PR adds proper styles for alphabetical and hierarchical views.

## Link to relevant issue(s), if any

- Part of #1521

## Description of the changes in this PR

- Proper styles for sidebar tab buttons
- Proper styles for alphabetical view
- Proper styles for hierarchical view
- Highlight currently opened concept in alphabetical and hierarchical view
- Show loading of letters and concepts in alphabetical view

This PR addresses requirements 3b, 3d, 3f in #1521

## Known problems or uncertainties in this PR

- Sidebar height is hard coded as 1000px
- In hierarchy, white button icons for closed concepts are transparent
- In hierarchy, children of the last top concept have an outer border

## Checklist

- [ ] phpUnit tests pass locally with my changes
- [ ] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [ ] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [ ] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
