### PR TITLE
Implement max length for input fields on the feedback page

### DIFF
--- a/controller/WebController.php
+++ b/controller/WebController.php
@@ -215,9 +215,9 @@ class WebController extends Controller
         if ($request->getQueryParamPOST('message')) {
             $feedbackSent = true;
             $feedbackMsg = $request->getQueryParamPOST('message');
-            $feedbackName = $request->getQueryParamPOST('name');
-            $feedbackEmail = $request->getQueryParamPOST('email');
-            $msgSubject = $request->getQueryParamPOST('msgsubject');
+            $feedbackName = substr($request->getQueryParamPOST('name'), 0, 255);
+            $feedbackEmail = substr($request->getQueryParamPOST('email'), 0, 255);
+            $msgSubject = substr($request->getQueryParamPOST('msgsubject'), 0, 255);
             $feedbackVocab = $request->getQueryParamPOST('vocab');
             $feedbackVocabEmail = ($feedbackVocab !== null && $feedbackVocab !== '') ?
                 $this->model->getVocabulary($feedbackVocab)->getConfig()->getFeedbackRecipient() : null;

--- a/view/feedback.twig
+++ b/view/feedback.twig
@@ -32,15 +32,15 @@
         <p>{% trans "feedback_enter_name_email" %}</p>
         <p>
           <label for="name" class="form-label">{% trans %}Name:{% endtrans %}</label>
-          <input id="name" class="form-control" type="text" size="40" name="name" placeholder="{% trans %}Enter your name{% endtrans %}">
+          <input id="name" class="form-control" type="text" size="40" maxlength="255" name="name" placeholder="{% trans %}Enter your name{% endtrans %}">
         </p>
         <p>
           <label for="email" class="form-label">{% trans %}E-mail:{% endtrans %}</label>
-          <input id="email" class="form-control" type="text" size="40" name="email" placeholder="{% trans %}Enter your e-mail address{% endtrans %}">
+          <input id="email" class="form-control" type="text" size="40" maxlength="255" name="email" placeholder="{% trans %}Enter your e-mail address{% endtrans %}">
         </p>
         <p>
           <label for="msgsubject" class="form-label">{% trans %}Subject:{% endtrans %} *</label>
-          <input id="msgsubject" class="form-control" type="text" size="40" name="msgsubject" placeholder="{% trans %}Write a subject{% endtrans %}" >
+          <input id="msgsubject" class="form-control" type="text" size="40" maxlength="255" name="msgsubject" placeholder="{% trans %}Write a subject{% endtrans %}" >
         </p>
         <p>
           <label for="message" class="form-label">{% trans %}Message:{% endtrans %} *</label>


### PR DESCRIPTION
…fields

## Reasons for creating this PR

This PR adds a maximum input length to the "name", "email", and "subject" input fields on the feedback page, both to the frontend and backend. A maximum length was not previously implemented, and allows users to input very large strings either in the form, or by hijacking the POST-request.

## Link to relevant issue(s), if any

- none

## Description of the changes in this PR

This PR imposes a limit of 255 characters to the "name", "email", and "subject" input fields on the feedback page; both in the frontend (feedback.twig, by using attribute "maxlength") and the backend (WebController, by using "substr").

## Known problems or uncertainties in this PR

- The limit of 255 characters is hard coded.

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
