### PR TITLE
fix guessVocabularyFromURI when some vocabulary has no URI space

### DIFF
--- a/model/Model.php
+++ b/model/Model.php
@@ -515,7 +515,10 @@ class Model
         if ($this->vocabsByUriSpace === null) { // initialize cache
             $this->vocabsByUriSpace = array();
             foreach ($this->getVocabularies() as $voc) {
-                $this->vocabsByUriSpace[$voc->getUriSpace()][] = $voc;
+                $uriSpace = $voc->getUriSpace();
+                if ($uriSpace) {
+                    $this->vocabsByUriSpace[$uriSpace][] = $voc;
+                }
             }
         }
 


### PR DESCRIPTION
## Reasons for creating this PR

I ran into a bug when displaying external mappings (to LCSH and Wikidata) on a YSO concept page. I've configured one unrelated vocabulary (YSO-time) without setting a URI space. That breaks the mappings display:

![image](https://github.com/NatLibFi/Skosmos/assets/1132830/9001fa98-3777-4c04-9cee-5cbeba9d2452)

It turns out that if there is a vocabulary without a defined URI space, then external mappings of other vocabularies do not resolve properly because the Model.guessVocabularyFromURI method breaks. This PR fixes the problem by using an additional if check for empty URI space.

## Link to relevant issue(s), if any

- Follow-up fix to #1409 which made it possible to omit URI space from vocabulary configuration

## Description of the changes in this PR

When constructing a cache of URI space to vocabulary mappings, don't include vocabularies that don't have a URI space.

## Known problems or uncertainties in this PR

Ideally there should be a unit test, but we don't have any existing tests for empty URI space either.

The same fix should be applied to Skosmos 3 as well. I will do that in a separate PR.

## Checklist

- [x] phpUnit tests pass locally with my changes
- [ ] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
