### PR TITLE
fix guessVocabularyFromURI when some vocabulary has no URI space (Skosmos 3)

### DIFF
--- a/src/model/Model.php
+++ b/src/model/Model.php
@@ -571,7 +571,10 @@ class Model
         if ($this->vocabsByUriSpace === null) { // initialize cache
             $this->vocabsByUriSpace = array();
             foreach ($this->getVocabularies() as $voc) {
-                $this->vocabsByUriSpace[$voc->getUriSpace()][] = $voc;
+                $uriSpace = $voc->getUriSpace();
+                if ($uriSpace) {
+                    $this->vocabsByUriSpace[$uriSpace][] = $voc;
+                }
             }
         }
 


### PR DESCRIPTION
## Reasons for creating this PR

Same as PR #1559 but for Skosmos 3.

## Link to relevant issue(s), if any

- Follow-up fix to #1409 which made it possible to omit URI space from vocabulary configuration

## Description of the changes in this PR

When constructing a cache of URI space to vocabulary mappings, don't include vocabularies that don't have a URI space.

## Known problems or uncertainties in this PR

Ideally there should be a unit test, but we don't have any existing tests for empty URI space either.

## Checklist

- [x] phpUnit tests pass locally with my changes
- [ ] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
