### PR TITLE
Fix feedback form limit php81 deprecation warning

### DIFF
--- a/controller/WebController.php
+++ b/controller/WebController.php
@@ -215,9 +215,9 @@ class WebController extends Controller
         if ($request->getQueryParamPOST('message')) {
             $feedbackSent = true;
             $feedbackMsg = $request->getQueryParamPOST('message');
-            $feedbackName = substr($request->getQueryParamPOST('name'), 0, 255);
-            $feedbackEmail = substr($request->getQueryParamPOST('email'), 0, 255);
-            $msgSubject = substr($request->getQueryParamPOST('msgsubject'), 0, 255);
+            $feedbackName = $request->getQueryParamPOST('name', 255);
+            $feedbackEmail = $request->getQueryParamPOST('email', 255);
+            $msgSubject = $request->getQueryParamPOST('msgsubject', 255);
             $feedbackVocab = $request->getQueryParamPOST('vocab');
             $feedbackVocabEmail = ($feedbackVocab !== null && $feedbackVocab !== '') ?
                 $this->model->getVocabulary($feedbackVocab)->getConfig()->getFeedbackRecipient() : null;

--- a/model/Request.php
+++ b/model/Request.php
@@ -66,6 +66,16 @@ class Request
     }
 
     /**
+     * Set a POST query parameter to mock it in tests.
+     * @param string $paramName parameter name
+     * @param string $value parameter value
+     */
+    public function setQueryParamPOST($paramName, $value)
+    {
+        $this->queryParamsPOST[$paramName] = $value;
+    }
+
+    /**
      * Set a SERVER constant to mock it in tests.
      * @param string $paramName parameter name
      * @param string $value parameter value
@@ -107,10 +117,21 @@ class Request
         return isset($this->queryParams[$paramName]) ? $this->queryParams[$paramName] : null;
     }
 
-    public function getQueryParamPOST($paramName)
+    /**
+     * Return the requested POST query parameter as a string. Backslashes are stripped for security reasons.
+     * @param string $paramName parameter name
+     * @param int $maxlength maximum length of parameter, or null if unlimited
+     * @return string parameter content, or null if no parameter found
+     */
+    public function getQueryParamPOST($paramName, $maxlength=null)
     {
         if (!isset($this->queryParamsPOST[$paramName])) return null;
-        return filter_var($this->queryParamsPOST[$paramName], FILTER_SANITIZE_FULL_SPECIAL_CHARS);
+        $val = filter_var($this->queryParamsPOST[$paramName], FILTER_SANITIZE_FULL_SPECIAL_CHARS);
+        if ($maxlength !== null) {
+            return substr($val, 0, $maxlength);
+        } else {
+            return $val;
+        }
     }
 
     public function getQueryParamBoolean($paramName, $default)

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -34,6 +34,37 @@ class RequestTest extends PHPUnit\Framework\TestCase
   }
 
   /**
+   * @covers Request::getQueryParamPOST
+   */
+  public function testGetQueryParamPOSTDefaultNull() {
+      $this->assertNull($this->request->getQueryParamPOST('notfoundatall'));
+  }
+
+  /**
+   * @covers Request::getQueryParamPOST
+   */
+  public function testGetQueryParamPOSTSimple() {
+      $this->request->setQueryParamPOST('simple', 'value123');
+      $this->assertEquals($this->request->getQueryParamPOST('simple'), 'value123');
+  }
+
+  /**
+   * @covers Request::getQueryParamPOST
+   */
+  public function testGetQueryParamPOSTTruncated() {
+      $this->request->setQueryParamPOST('truncated', 'very-long-value');
+      $this->assertEquals($this->request->getQueryParamPOST('truncated', 9), 'very-long');
+  }
+
+  /**
+   * @covers Request::getQueryParamPOST
+   */
+  public function testGetQueryParamPOSTNotTruncated() {
+      $this->request->setQueryParamPOST('truncated', 'very-long-value');
+      $this->assertEquals($this->request->getQueryParamPOST('truncated', 20), 'very-long-value');
+  }
+
+  /**
    * @covers Request::getVocabList
    */
   public function testGetVocabList() {

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -41,6 +41,7 @@ class RequestTest extends PHPUnit\Framework\TestCase
   }
 
   /**
+   * @covers Request::setQueryParamPOST
    * @covers Request::getQueryParamPOST
    */
   public function testGetQueryParamPOSTSimple() {
@@ -49,6 +50,7 @@ class RequestTest extends PHPUnit\Framework\TestCase
   }
 
   /**
+   * @covers Request::setQueryParamPOST
    * @covers Request::getQueryParamPOST
    */
   public function testGetQueryParamPOSTTruncated() {
@@ -57,6 +59,7 @@ class RequestTest extends PHPUnit\Framework\TestCase
   }
 
   /**
+   * @covers Request::setQueryParamPOST
    * @covers Request::getQueryParamPOST
    */
   public function testGetQueryParamPOSTNotTruncated() {


### PR DESCRIPTION
## Reasons for creating this PR

Follow-up fix to PR #1566 to address PHP 8.1 deprecation warnings. That PR used `substr` for truncation in a way that could trigger deprecation warnings when `null` values were encountered. This PR instead adds a `maxlimit` parameter to the Request.getQueryParamPOST method and uses that instead of plain substr, avoiding the problem.

## Link to relevant issue(s), if any

- follow-up to #1566

## Description of the changes in this PR

- support maxlimit parameter in Request.getQueryParamPOST
- add unit tests to verify above
- switch WebController to use getQueryParamPost with maxlimit instead of plain substr

## Known problems or uncertainties in this PR

n/a

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
