### PR TITLE
Avoid showing vocabulary modified timestamp on concept page when the concept doesn't have a specific modification date

### DIFF
--- a/model/Concept.php
+++ b/model/Concept.php
@@ -698,9 +698,9 @@ class Concept extends VocabularyDataObject implements Modifiable
     }
 
     /**
-     * @return DateTime|null the modified date, or null if not available
+     * @return DateTime|null the modified date of this concept, or null if not available
      */
-    public function getModifiedDate()
+    public function getConceptModifiedDate()
     {
         // finding the modified properties
         /** @var \EasyRdf\Resource|\EasyRdf\Literal|null $modifiedResource */
@@ -709,9 +709,25 @@ class Concept extends VocabularyDataObject implements Modifiable
             return $modifiedResource->getValue();
         }
 
-        // if the concept does not have a modified date, we look for it in its
-        // vocabulary
-        return $this->getVocab()->getModifiedDate();
+        return null;
+    }
+
+
+    /**
+     * @return DateTime|null the modified date, or null if not available
+     */
+    public function getModifiedDate()
+    {
+        // check if this concept has a specific modified date
+        $conceptModified = $this->getConceptModifiedDate();
+
+        if ($conceptModified !== null) {
+            return $conceptModified;
+        } else {
+            // if the concept does not have a modified date, return the
+            // modified date of the vocabulary instead
+            return $this->getVocab()->getModifiedDate();
+        }
     }
 
     /**
@@ -728,7 +744,7 @@ class Concept extends VocabularyDataObject implements Modifiable
                 $created = $this->resource->get('dc:created')->getValue();
             }
 
-            $modified = $this->getModifiedDate();
+            $modified = $this->getConceptModifiedDate();
 
             // making a human readable string from the timestamps
             if ($created != '') {

--- a/tests/ConceptTest.php
+++ b/tests/ConceptTest.php
@@ -638,6 +638,17 @@ class ConceptTest extends PHPUnit\Framework\TestCase
   }
 
   /**
+   * @covers Concept::getConceptModifiedDate
+   */
+  public function testGetConceptModifiedDateNullWhenNotAvailable() {
+    $vocab = $this->model->getVocabulary('test');
+    $results = $vocab->getConceptInfo('http://www.skosmos.skos/test/ta111', 'en');
+    $concept = reset($results);
+    $modifiedDate = $concept->getConceptModifiedDate();
+    $this->assertNull($modifiedDate);
+  }
+
+  /**
    * @covers Concept::hasXlLabel
    */
   public function testHasXlLabelTrue() {


### PR DESCRIPTION
## Reasons for creating this PR

See #1343

## Link to relevant issue(s), if any

- Closes #1343

## Description of the changes in this PR

- introduce a new method Concept.getConceptModifiedDate that only returns the specific modification date of the concept but doesn't fall back to the vocabulary-level modified timestamp
- use getConceptModifiedDate when showing modified timestamps on the concept page
- unit test to verify

## Known problems or uncertainties in this PR

Some unit tests will fail with deprecation warnings on PHP 8.1 for unrelated reasons - see PR #1567 for the explanation and fix.

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
