### PR TITLE
don't perform HTML escaping for server constants to avoid breaking alphabetical index for diacritics

### DIFF
--- a/model/Request.php
+++ b/model/Request.php
@@ -146,7 +146,7 @@ class Request
     public function getServerConstant($paramName)
     {
         if (!isset($this->serverConstants[$paramName])) return null;
-        return filter_var($this->serverConstants[$paramName], FILTER_SANITIZE_FULL_SPECIAL_CHARS);
+        return filter_var($this->serverConstants[$paramName], FILTER_SANITIZE_ADD_SLASHES);
     }
 
     public function getCookie($paramName)

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -274,4 +274,31 @@ class RequestTest extends PHPUnit\Framework\TestCase
     $this->assertEquals("http//example.com", $langurl);
   }
 
+  /**
+   * @covers Request::getServerConstant
+   */
+  public function testGetServerConstant() {
+    $this->request->setServerConstant('PATH_INFO', '/myvocab/index/X');
+    $path_info = $this->request->getServerConstant('PATH_INFO');
+    $this->assertEquals('/myvocab/index/X', $path_info);
+  }
+
+  /**
+   * @covers Request::getServerConstant
+   */
+  public function testGetServerConstantDiacriticNotEncoded() {
+    $this->request->setServerConstant('PATH_INFO', '/myvocab/index/Ä');
+    $path_info = $this->request->getServerConstant('PATH_INFO');
+    $this->assertEquals('/myvocab/index/Ä', $path_info);
+  }
+
+  /**
+   * @covers Request::getServerConstant
+   */
+  public function testGetServerConstantQuoteIsEncoded() {
+    $this->request->setServerConstant('PATH_INFO', "/myvocab/index/'");
+    $path_info = $this->request->getServerConstant('PATH_INFO');
+    $this->assertEquals("/myvocab/index/\'", $path_info);
+  }
+
 }


### PR DESCRIPTION
## Reasons for creating this PR

Alphabetical index was broken for diacritics like Ä, Ä, Ö. This happened because of too strict/eager input sanitizing. This PR fixes the problem (on the `master` branch, but not `skosmos-3` which may be affected too) by reducing the input sanitizing, just performing escaping of quotes. (I'm not sure that's 100% correct either)

## Link to relevant issue(s), if any

- Closes #1574 

## Description of the changes in this PR

* switch input filtering of server constants from FILTER_SANITIZE_FULL_SPECIAL_CHARS to FILTER_SANITIZE_ADD_SLASHES

## Known problems or uncertainties in this PR

* See if the same problem applies for the `skosmos-3` branch and fix it there as well

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
