### PR TITLE
Update README.md and SECURITY.md after branch rename 'skosmos-3' to 'main' + upgrade CodeClimate action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
         configuration: phpunit.xml
 
     - name: Publish code coverage to Code Climate
-      uses: paambaati/codeclimate-action@v4.0.0
+      uses: paambaati/codeclimate-action@v5.0.0
       env:
         CC_TEST_REPORTER_ID: fb98170a5c7ea9cc2bbab19ff26268335e6a11a4f8267ca935e5e8ff4624886c
       with:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![CI tests](https://github.com/NatLibFi/Skosmos/actions/workflows/ci.yml/badge.svg)](https://github.com/NatLibFi/Skosmos/actions/workflows/ci.yml)
 [![Test Coverage](https://codeclimate.com/github/NatLibFi/Skosmos/badges/coverage.svg)](https://codeclimate.com/github/NatLibFi/Skosmos/coverage)
 [![Code Climate](https://codeclimate.com/github/NatLibFi/Skosmos/badges/gpa.svg)](https://codeclimate.com/github/NatLibFi/Skosmos)
-[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/NatLibFi/Skosmos/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/NatLibFi/Skosmos/?branch=master)
+[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/NatLibFi/Skosmos/badges/quality-score.png?b=main)](https://scrutinizer-ci.com/g/NatLibFi/Skosmos/?branch=main)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=NatLibFi_Skosmos&metric=alert_status)](https://sonarcloud.io/dashboard?id=NatLibFi_Skosmos)
 [![Average time to resolve an issue](http://isitmaintained.com/badge/resolution/NatLibFi/Skosmos.svg)](http://isitmaintained.com/project/NatLibFi/Skosmos "Average time to resolve an issue")
 [![Percentage of issues still open](http://isitmaintained.com/badge/open/NatLibFi/Skosmos.svg)](http://isitmaintained.com/project/NatLibFi/Skosmos "Percentage of issues still open")

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,13 +2,18 @@
 
 ## Supported Versions
 
-Following Skosmos versions are currently being supported with security updates by the Skosmos development team at the National Library of Finland. The "current development branch" means the master branch of the repository, whereas the "maintenance branch" is a branch called `vX.X-maintenance`, where the version number `X.X` corresponds to the latest [release](https://github.com/NatLibFi/Skosmos/releases) of Skosmos.
+The following Skosmos versions are currently being supported with security updates by the Skosmos development team at the National Library of Finland.
 
-| Version                     | Supported          |
-| --------------------------- | ------------------ |
-| Current development branch  |  ✔️                 |
-| Current maintenance branch  |  ✔️                 |
-| Older versions              | :x:                |
+* The "current Skosmos 3 development branch" means the `main` branch of the repository.
+* The "current Skosmos 2 development branch" means the `skosmos-2` branch of the repository
+* The "maintenance branch" is a branch called `vX.X-maintenance`, where the version number `X.X` corresponds to the latest [release](https://github.com/NatLibFi/Skosmos/releases) of Skosmos
+
+| Version                               | Supported          |
+| ------------------------------------- | ------------------ |
+| Current Skosmos 3 development branch  | :x:                |
+| Current Skosmos 2 development branch  |  ✔️                 |
+| Current maintenance branch            |  ✔️                 |
+| Older versions                        | :x:                |
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
## Reasons for creating this PR

Fixing up documentation within the repo after the branch renames. This PR handles the new `main` branch (which used to be `skosmos-3`). PR #1578 does the same for the new `skosmos-2` branch (old `master`).

## Link to relevant issue(s), if any

- part of #1577

## Description of the changes in this PR

* upadte link to Scrutinizer in README to point to the right branch `main`
* rewrite SECURITY.md to make a difference between Skosmos 2 and 3 development branches
* upgrade paambaati/codeclimate-action to v5.0.0 so that GitHub Actions CI won't fail

## Known problems or uncertainties in this PR

n/a

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
