### PR TITLE
Fix diacritic letters in alphabetical index (Skosmos 3)

### DIFF
--- a/src/model/Request.php
+++ b/src/model/Request.php
@@ -130,7 +130,7 @@ class Request
         if (!isset($this->serverConstants[$paramName])) {
             return null;
         }
-        return filter_var($this->serverConstants[$paramName], FILTER_SANITIZE_FULL_SPECIAL_CHARS);
+        return filter_var($this->serverConstants[$paramName], FILTER_SANITIZE_ADD_SLASHES);
     }
 
     public function getCookie($paramName)

--- a/tests/GlobalConfigTest.php
+++ b/tests/GlobalConfigTest.php
@@ -61,7 +61,7 @@ class GlobalConfigTest extends PHPUnit\Framework\TestCase
 
     public function testGetLanguages()
     {
-        $this->assertEquals(array('en' => 'en_GB.utf8', 'fi' => 'fi_FI.utf8', 'fr' => 'fr_FR.utf8'), $this->config->getLanguages());
+        $this->assertEquals(array('en' => 'en_GB.utf8', 'fi' => 'fi_FI.utf8', 'fr' => 'fr_FR.utf8', 'sv' => 'sv_SE.utf8'), $this->config->getLanguages());
     }
 
     public function testGetSearchResultsSize()

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -256,4 +256,31 @@ class RequestTest extends PHPUnit\Framework\TestCase
         $this->assertEquals("http//example.com", $langurl);
     }
 
+  /**
+   * @covers Request::getServerConstant
+   */
+  public function testGetServerConstant() {
+    $this->request->setServerConstant('PATH_INFO', '/myvocab/index/X');
+    $path_info = $this->request->getServerConstant('PATH_INFO');
+    $this->assertEquals('/myvocab/index/X', $path_info);
+  }
+
+  /**
+   * @covers Request::getServerConstant
+   */
+  public function testGetServerConstantDiacriticNotEncoded() {
+    $this->request->setServerConstant('PATH_INFO', '/myvocab/index/Ä');
+    $path_info = $this->request->getServerConstant('PATH_INFO');
+    $this->assertEquals('/myvocab/index/Ä', $path_info);
+  }
+
+  /**
+   * @covers Request::getServerConstant
+   */
+  public function testGetServerConstantQuoteIsEncoded() {
+    $this->request->setServerConstant('PATH_INFO', "/myvocab/index/'");
+    $path_info = $this->request->getServerConstant('PATH_INFO');
+    $this->assertEquals("/myvocab/index/\'", $path_info);
+  }
+
 }

--- a/tests/WebControllerTest.php
+++ b/tests/WebControllerTest.php
@@ -257,7 +257,7 @@ class WebControllerTest extends TestCase
 
     public function testGuessLanguageAcceptLanguageBestMatch() {
         $request = new Request($this->model);
-        $request->setServerConstant('HTTP_ACCEPT_LANGUAGE', 'sv, de;q=0.9, fi;q=0.8, fr;q=0.5');
+        $request->setServerConstant('HTTP_ACCEPT_LANGUAGE', 'da, de;q=0.9, fi;q=0.8, fr;q=0.5');
         $guessedLanguage = $this->webController->guessLanguage($request);
         // configured/available languages are en, fi, fr
         // the best matching language for the given Accept-Language is fi

--- a/tests/cypress/template/vocab-home.cy.js
+++ b/tests/cypress/template/vocab-home.cy.js
@@ -39,4 +39,15 @@ describe('Vocabulary home page', () => {
     // check that the first entry is Carp
     cy.get('#tab-alphabetical .sidebar-list').children().first().invoke('text').should('equal', 'Carp')
   })
-})
+  it('alphabetical index diacritic letters are clickable', () => {
+    cy.visit('/yso/sv/') // go to the YSO home page in Swedish language
+
+    // click on the last letter (Ö)
+    cy.get('#tab-alphabetical .pagination :nth-last-child(1) > .page-link').click()
+
+    // check that we have the correct number of entries
+    cy.get('#tab-alphabetical .sidebar-list').children().should('have.length', 4)
+
+    // check that the first entry is "östliga handelsvägar"
+    cy.get('#tab-alphabetical .sidebar-list').children().first().children().first().invoke('text').should('equal', 'östliga handelsvägar')
+  })})

--- a/tests/testconfig.ttl
+++ b/tests/testconfig.ttl
@@ -38,6 +38,7 @@
     # interface languages available, and the corresponding system locales
     skosmos:languages ( [ rdfs:label "en" ; rdf:value "en_GB.utf8" ]
                         [ rdfs:label "fi" ; rdf:value "fi_FI.utf8" ]
+                        [ rdfs:label "sv" ; rdf:value "sv_SE.utf8" ]
                         [ rdfs:label "fr" ; rdf:value "fr_FR.utf8" ] ) ;
     # how many results (maximum) to load at a time on the search results page
     skosmos:searchResultsSize 5 ;


### PR DESCRIPTION
## Reasons for creating this PR

Fix the problem of diacritic letters (ÅÄÖ...) in Skosmos 3. It was already fixed for Skosmos 2 in PR #1575; this PR includes the fixes from that PR and also adds a Cypress test to verify it on the UI level.

## Link to relevant issue(s), if any

- Closes #1574

## Description of the changes in this PR

* switch input filtering of server constants from FILTER_SANITIZE_FULL_SPECIAL_CHARS to FILTER_SANITIZE_ADD_SLASHES
* add PHPUnit test to verify server constant sanitizing
* add Cypress test to verify that diacritic letters work in alphabetical index

## Known problems or uncertainties in this PR

n/a

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
