### PR TITLE
Concept page features: scopeNotes with HTML, hide subprops of hiddenLabel, timestamps

### DIFF
--- a/resource/css/skosmos.css
+++ b/resource/css/skosmos.css
@@ -709,6 +709,10 @@ body {
     display: inline-block;
   }
 
+  #date-info {
+    font-size: 0.85rem;
+  }
+
   /***** Main content searchpage & searchpage multi vocab *****/
   #search-results {
     background-color: var(--vocab-bg);

--- a/src/view/concept-card.inc
+++ b/src/view/concept-card.inc
@@ -14,7 +14,7 @@
         </div>
       </div>
 
-      {% for property in concept.properties %}
+      {% for property in concept.properties %}{% if property.getSubPropertyOf != 'skos:hiddenLabel' %}
       <div class="row property prop-{{property.ID}}">
         <div class="col-sm-4 px-0 property-label"><h2>{{ property.label}}</h2></div>
         <div class="col-sm-8 align-self-center property-value">
@@ -33,7 +33,7 @@
           </ul>
         </div>
       </div>
-      {% endfor %}
+      {% endif %}{% endfor %}
       {% set foreignLabels = concept.foreignLabels %}
       {% if foreignLabels %}
       <div class="row property prop-foreignlabels">

--- a/src/view/concept-card.inc
+++ b/src/view/concept-card.inc
@@ -81,6 +81,9 @@
               <a href="rest/v1/{{ vocab.id }}/data?uri={{ concept.uri|url_encode }}&amp;format=application/ld%2Bjson">JSON-LD</a>
             </li>
           </ul>
+          {% if concept.date %}
+          <div id="date-info">{{ concept.date }}</div>
+          {% endif %}
         </div>
       </div>
     </div>

--- a/src/view/concept-card.inc
+++ b/src/view/concept-card.inc
@@ -27,7 +27,7 @@
               </a>
             </li>
             {% else %} {# literals, e.g. altLabels #}
-            <li>{{ propval.label }}</li>
+            <li>{% if propval.containsHtml %}{{ propval.label|raw }}{% else %}{{ propval.label }}{% endif %}</li>
             {% endif %}
           {% endfor %}
           </ul>

--- a/tests/cypress/template/concept.cy.js
+++ b/tests/cypress/template/concept.cy.js
@@ -80,6 +80,21 @@ describe('Concept page', () => {
     // check the altLabel value
     cy.get('.prop-skos_altLabel .property-value li').invoke('text').should('equal', 'musicology (research activity)')
   })
+  it('contains scope notes, with HTML links', () => {
+    cy.visit('/yso/fi/page/p39138') // go to "ukonvaajat" concept page (in Finnish)
+
+    // check the property name
+    cy.get('.prop-skos_scopeNote .property-label').invoke('text').should('equal', 'Käyttöhuomautus')
+
+    // check that we have the correct number of scopeNotes
+    cy.get('.prop-skos_scopeNote .property-value').find('li').should('have.length', 1)
+
+    // check the scopeNote value
+    cy.get('.prop-skos_scopeNote .property-value li').invoke('text').should('equal', 'Ukonvaajoiksi on nimitetty myös maahan osuneen salamaniskun muodostamia mineraalirakenteita. Näistä käytetään käsitettä fulguriitit.')
+
+    // check the link within the scopeNote
+    cy.get('.prop-skos_scopeNote .property-value li a').should('have.attr', 'href', 'http://www.yso.fi/onto/yso/p39144')
+  })
   it('contains groups', () => {
     cy.visit('/yso/en/page/p38289') // go to "music archaeology" concept page
 
@@ -91,6 +106,13 @@ describe('Concept page', () => {
 
     // check the first group value
     cy.get('.prop-skosmos_memberOf .property-value a').invoke('text').should('equal', '51 Archaeology')
+  })
+  it("doesn't contain subproperties of skos:hiddenLabel", () => {
+    cy.visit('/subclass/en/page/d1') // go to "ukonvaajat" concept page (in Finnish)
+
+    // make sure that the hidden property is not shown
+    cy.contains('This subproperty should not be shown in the UI').should('not.exist')
+    cy.contains('Do not show this').should('not.exist')
   })
   it('contains terms in other languages', () => {
     cy.visit('/yso/en/page/p21685') // go to "music research" concept page
@@ -109,6 +131,16 @@ describe('Concept page', () => {
 
     // check the broader concept
     cy.get('#concept-uri').invoke('text').should('equal', 'http://www.yso.fi/onto/yso/p21685')
+  })
+  it('contains created & modified times (English)', () => {
+    cy.visit('/yso/en/page/p21685') // go to "music research" concept page (English)
+
+    cy.get('#date-info').invoke('text').should('equal', 'Created 10/25/07, last modified 2/8/23')
+  })
+  it('contains created & modified times (Finnish)', () => {
+    cy.visit('/yso/fi/page/p21685') // go to "musiikintutkimus" concept page (Finnish)
+
+    cy.get('#date-info').invoke('text').should('equal', 'Luotu 25.10.2007, viimeksi muokattu 8.2.2023')
   })
   it('contains mappings', () => {
     cy.visit('/yso/en/page/p21685') // go to "music research" concept page


### PR DESCRIPTION
## Reasons for creating this PR

Adding more features to the concept page:
- scopeNotes with HTML links
- don't show subproperties of skos:hiddenLabel
- show created & modified timestamps

## Link to relevant issue(s), if any

- part of #1484

## Description of the changes in this PR

- changes to the concept page template & CSS to implement above mentioned features
- new Cypress tests to verify them

## Known problems or uncertainties in this PR

n/a

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
