### PR TITLE
initial rough implementation of breadcrumbs on concept page

### DIFF
--- a/resource/css/skosmos.css
+++ b/resource/css/skosmos.css
@@ -671,6 +671,28 @@ body {
   }
 
   /*** Main content termpage ***/
+  nav#concept-breadcrumbs ol {
+    list-style: none;
+  }
+
+  nav#concept-breadcrumbs li, nav#concept-breadcrumbs li.collapse.show {
+    display: inline;
+  }
+
+  nav#concept-breadcrumbs li.collapse {
+    display: none;
+  }
+
+  nav#concept-breadcrumbs li + li::before {
+    display: inline-block;
+    content: ">";
+  }
+
+  nav#concept-breadcrumbs .breadcrumb-current {
+    color: black;
+    font-weight: normal;
+  }
+
   #concept-property-label {
     align-self: start;
     padding-top: 1.25rem;

--- a/src/controller/WebController.php
+++ b/src/controller/WebController.php
@@ -199,8 +199,8 @@ class WebController extends Controller
             'concept_uri' => $uri,
             'languages' => $this->languages,
             'explicit_langcodes' => $langcodes,
-            'bread_crumbs' => $crumbs['breadcrumbs'],
-            'combined' => $crumbs['combined'],
+            'visible_breadcrumbs' => $crumbs['breadcrumbs'],
+            'hidden_breadcrumbs' => $crumbs['combined'],
             'request' => $request,
             'plugin_params' => $pluginParameters,
             'custom_labels' => $customLabels)

--- a/src/view/concept-card.inc
+++ b/src/view/concept-card.inc
@@ -3,6 +3,33 @@
 
     <div class="main-content-section p-5">
 
+      <nav class="row" id="concept-breadcrumbs" aria-label="Breadcrumb">
+        {% for path in visible_breadcrumbs %}
+        <ol>
+          {% for crumb in path %}
+            {% if crumb.hiddenLabel %}
+              <li class="breadcrumb-toggle">
+                <a href=".breadcrumb-collapse" data-bs-target=".breadcrumb-collapse" data-bs-toggle="collapse" role="button" aria-expanded="false">...</a>
+              </li>
+              {% for hiddenCrumb in hidden_breadcrumbs[loop.index] %}
+              <li class="collapse multi-collapse breadcrumb-collapse">
+                <a href="{{ hiddenCrumb.uri|link_url(vocab,request.lang,'page',request.contentLang) }}">{{ hiddenCrumb.hiddenLabel }}</a>
+              </li>
+              {% endfor %}
+            {% else %}
+              <li>
+                <a
+                  {% if loop.last %}aria-current="page" class="breadcrumb-current"
+                  {% else %}href="{{ crumb.uri|link_url(vocab,request.lang,'page',request.contentLang) }}"
+                  {% endif %}
+                  >{{ crumb.prefLabel }}</a>
+              </li>
+            {% endif %}
+          {% endfor %}
+        </ol>
+        {% endfor %}
+      </nav>
+
       <div class="row" id="concept-heading">
         <div class="col-sm-4 px-0" id="concept-property-label">{{ "skos:prefLabel" | trans }}</div>
         <div class="col-sm-8" id="concept-label">


### PR DESCRIPTION
## Reasons for creating this PR

Implement the breadcrumb display on the concept page.

With long paths, the top levels are initially hidden. Clicking on the first `...` will display the hidden paths. This is implemented using the Collapse functionality in Bootstrap.

## Link to relevant issue(s), if any

- part of #1484

## Description of the changes in this PR

* add a section to the concept page template that displays breadcrumbs
* add corresponding CSS styles
* rename some variables passed from WebController to the twig templates to give them more descriptive names

## Known problems or uncertainties in this PR

- needs Cypress tests
- the `...` link should be hidden when clicked (similar to how it works in Skosmos 2)
- aria-label="Breadcrumbs" should be translated
- verify accessibility

## Checklist

- [ ] phpUnit tests pass locally with my changes
- [ ] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [ ] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [ ] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
