### PR TITLE
Copy to clipboard functionality for concept page

### DIFF
--- a/resource/css/skosmos.css
+++ b/resource/css/skosmos.css
@@ -694,7 +694,7 @@ body {
     display: inline;
   }
 
-  #copy-preflabel .fa-copy {
+  #copy-preflabel {
     color: var(--vocab-text);
     font-size: 30px;
     position: relative;
@@ -702,15 +702,15 @@ body {
     left: 5px;
   }
 
-  #copy-uri .fa-copy {
+  #copy-uri {
     color: var(--vocab-text);
     position: relative;
-    bottom: 3px;
-    left: -0.6rem;
+    bottom: 4px;
   }
 
-  .copy-clipboard, .copy-clipboard:active, .copy-clipboard:focus, .copy-clipboard:active:focus {
-    border: none;
+  .copy-clipboard:focus {
+    border: 1px solid var(--vocab-text);
+    border-radius: 3px;
   }
 
   .property ul, .property li {

--- a/resource/css/skosmos.css
+++ b/resource/css/skosmos.css
@@ -691,14 +691,15 @@ body {
   }
 
   #concept-label h1 {
-    float: left;
+    display: inline;
   }
 
   #copy-preflabel .fa-copy {
     color: var(--vocab-text);
     font-size: 30px;
     position: relative;
-    bottom: -3px;
+    bottom: 10px;
+    left: 5px;
   }
 
   #copy-uri .fa-copy {

--- a/resource/css/skosmos.css
+++ b/resource/css/skosmos.css
@@ -98,11 +98,6 @@ body {
     text-align: center;
   }
 
-  #main-container.searchpage .fa-copy, #main-container.searchpage-multi-vocab .fa-copy {
-    position: relative;
-    bottom: 5px;
-  }
-
   .fa-magnifying-glass {
     color: var(--search-button-text);
     font-size: 22px;

--- a/resource/css/skosmos.css
+++ b/resource/css/skosmos.css
@@ -85,13 +85,6 @@ body {
     margin: 0 5px;
   }
 
-  #main-container.termpage .fa-copy {
-    color: var(--vocab-text);
-    font-size: 30px;
-    position: relative;
-    bottom: -3px;
-  }
-
   #main-container.searchpage .fa-arrow-right, #main-container.searchpage-multi-vocab .fa-arrow-right {
     color: var(--vocab-text);
     font-size: 12px;
@@ -706,12 +699,21 @@ body {
     float: left;
   }
 
-  .copy-clipboard {
-    border: none;
-    font-size: 20px;
+  #copy-preflabel .fa-copy {
+    color: var(--vocab-text);
+    font-size: 30px;
+    position: relative;
+    bottom: -3px;
   }
 
-  .copy-clipboard:active, .copy-clipboard:focus, .copy-clipboard:active:focus {
+  #copy-uri .fa-copy {
+    color: var(--vocab-text);
+    position: relative;
+    bottom: 3px;
+    left: -0.6rem;
+  }
+
+  .copy-clipboard, .copy-clipboard:active, .copy-clipboard:focus, .copy-clipboard:active:focus {
     border: none;
   }
 

--- a/resource/js/copy-to-clipboard.js
+++ b/resource/js/copy-to-clipboard.js
@@ -17,14 +17,18 @@ async function copyToClipboard (id) {
 // register the copyToClipboard function as event an handler for the copy buttons
 const copyPrefElem = document.getElementById('copy-preflabel')
 if (copyPrefElem) {
-  copyPrefElem.addEventListener('click', async () => {
-    await copyToClipboard('concept-preflabel')
+  copyPrefElem.addEventListener('click', () => {
+    (async () => {
+      await copyToClipboard('concept-preflabel')
+    })()
   })
 }
 
 const copyUriElem = document.getElementById('copy-uri')
 if (copyUriElem) {
-  copyUriElem.addEventListener('click', async () => {
-    await copyToClipboard('concept-uri')
+  copyUriElem.addEventListener('click', () => {
+    (async () => {
+      await copyToClipboard('concept-preflabel')
+    })()
   })
 }

--- a/resource/js/copy-to-clipboard.js
+++ b/resource/js/copy-to-clipboard.js
@@ -17,10 +17,14 @@ async function copyToClipboard (id) {
 // register the copyToClipboard function as event an handler for the copy buttons
 const copyPrefElem = document.getElementById('copy-preflabel')
 if (copyPrefElem) {
-  copyPrefElem.addEventListener('click', () => copyToClipboard('concept-preflabel'))
+  copyPrefElem.addEventListener('click', async () => {
+    await copyToClipboard('concept-preflabel')
+  })
 }
 
 const copyUriElem = document.getElementById('copy-uri')
 if (copyUriElem) {
-  copyUriElem.addEventListener('click', () => copyToClipboard('concept-uri'))
+  copyUriElem.addEventListener('click', async () => {
+    await copyToClipboard('concept-uri')
+  })
 }

--- a/resource/js/copy-to-clipboard.js
+++ b/resource/js/copy-to-clipboard.js
@@ -1,0 +1,26 @@
+// function for copying the content from a specific element (by id) to the clipboard
+async function copyToClipboard (id) {
+  const copyElem = document.getElementById(id)
+  const sel = window.getSelection()
+  const range = document.createRange()
+  range.selectNodeContents(copyElem)
+  sel.removeAllRanges()
+  sel.addRange(range)
+
+  try {
+    await navigator.clipboard.writeText(copyElem.innerText)
+  } catch (err) {
+    console.log('Failed to copy text to clipboard: ', err)
+  }
+}
+
+// register the copyToClipboard function as event an handler for the copy buttons
+const copyPrefElem = document.getElementById('copy-preflabel')
+if (copyPrefElem) {
+  copyPrefElem.addEventListener('click', () => copyToClipboard('concept-preflabel'))
+}
+
+const copyUriElem = document.getElementById('copy-uri')
+if (copyUriElem) {
+  copyUriElem.addEventListener('click', () => copyToClipboard('concept-uri'))
+}

--- a/resource/js/copy-to-clipboard.js
+++ b/resource/js/copy-to-clipboard.js
@@ -11,13 +11,20 @@ function copyToClipboard (id) {
     console.error('Failed to copy text to clipboard: ', err))
 }
 
-// register the copyToClipboard function as event an handler for the copy buttons
-const copyPrefElem = document.getElementById('copy-preflabel')
-if (copyPrefElem) {
-  copyPrefElem.addEventListener('click', () => copyToClipboard('concept-preflabel'))
+function registerCopyToClipboardEvents () {
+  const copyPrefElem = document.getElementById('copy-preflabel')
+  if (copyPrefElem) {
+    copyPrefElem.addEventListener('click', () => copyToClipboard('concept-preflabel'))
+  }
+
+  const copyUriElem = document.getElementById('copy-uri')
+  if (copyUriElem) {
+    copyUriElem.addEventListener('click', () => copyToClipboard('concept-uri'))
+  }
 }
 
-const copyUriElem = document.getElementById('copy-uri')
-if (copyUriElem) {
-  copyUriElem.addEventListener('click', () => copyToClipboard('concept-uri'))
-}
+// register the copyToClipboard function as event an handler for the copy buttons
+registerCopyToClipboardEvents()
+
+// re-register the event handlers after partial page loads
+document.addEventListener('loadConceptPage', registerCopyToClipboardEvents)

--- a/resource/js/copy-to-clipboard.js
+++ b/resource/js/copy-to-clipboard.js
@@ -1,5 +1,5 @@
 // function for copying the content from a specific element (by id) to the clipboard
-async function copyToClipboard (id) {
+function copyToClipboard (id) {
   const copyElem = document.getElementById(id)
   const sel = window.getSelection()
   const range = document.createRange()
@@ -7,28 +7,17 @@ async function copyToClipboard (id) {
   sel.removeAllRanges()
   sel.addRange(range)
 
-  try {
-    await navigator.clipboard.writeText(copyElem.innerText)
-  } catch (err) {
-    console.log('Failed to copy text to clipboard: ', err)
-  }
+  navigator.clipboard.writeText(copyElem.innerText).catch((err) =>
+    console.error('Failed to copy text to clipboard: ', err))
 }
 
 // register the copyToClipboard function as event an handler for the copy buttons
 const copyPrefElem = document.getElementById('copy-preflabel')
 if (copyPrefElem) {
-  copyPrefElem.addEventListener('click', () => {
-    (async () => {
-      await copyToClipboard('concept-preflabel')
-    })()
-  })
+  copyPrefElem.addEventListener('click', () => copyToClipboard('concept-preflabel'))
 }
 
 const copyUriElem = document.getElementById('copy-uri')
 if (copyUriElem) {
-  copyUriElem.addEventListener('click', () => {
-    (async () => {
-      await copyToClipboard('concept-preflabel')
-    })()
-  })
+  copyUriElem.addEventListener('click', () => copyToClipboard('concept-uri'))
 }

--- a/resource/translations/skosmos_en.po
+++ b/resource/translations/skosmos_en.po
@@ -879,3 +879,6 @@ msgstr "Information"
 
 msgid "Breadcrumbs"
 msgstr "Breadcrumbs"
+
+msgid "Copy to clipboard"
+msgstr "Copy to clipboard"

--- a/resource/translations/skosmos_fi.po
+++ b/resource/translations/skosmos_fi.po
@@ -888,3 +888,6 @@ msgstr "Tietoja"
 
 msgid "Breadcrumbs"
 msgstr "Murupolut"
+
+msgid "Copy to clipboard"
+msgstr "Kopioi leikepöydälle"

--- a/resource/translations/skosmos_sv.po
+++ b/resource/translations/skosmos_sv.po
@@ -887,3 +887,6 @@ msgstr "Information"
 
 msgid "Breadcrumbs"
 msgstr "Brödsmulor"
+
+msgid "Copy to clipboard"
+msgstr "Kopiera till urklipp"

--- a/src/view/concept-card.inc
+++ b/src/view/concept-card.inc
@@ -30,8 +30,9 @@
       <div class="row" id="concept-heading">
         <div class="col-sm-4 px-0" id="concept-property-label">{{ "skos:prefLabel" | trans }}</div>
         <div class="col-sm-8" id="concept-label">
-          <h1 id="concept-preflabel" class="mb-0 user-select-all">{{ concept.label }}</h1>
-          <button class="btn btn-default copy-clipboard px-0" type="button" id="copy-preflabel"
+          <h1 id="concept-preflabel"
+              class="mb-0 user-select-all">{{ concept.label }}</h1><button
+                  class="btn btn-default copy-clipboard px-1" type="button" id="copy-preflabel"
                   data-bs-toggle="tooltip" data-bs-placement="button" title="{{ 'Copy to clipboard' | trans }}">
             <i class="fa-regular fa-copy"></i>
           </button>
@@ -88,8 +89,9 @@
       <div class="row property prop-uri">
         <div class="col-sm-4 px-0 property-label"><h2>URI</h2></div>
         <div class="col-sm-8">
-          <span id="concept-uri" class="user-select-all">{{ concept.uri }}</span>
-          <button class="btn btn-default copy-clipboard" type="button" id="copy-uri"
+          <span id="concept-uri"
+                class="user-select-all">{{ concept.uri }}</span><button
+                  class="btn btn-default copy-clipboard px-1" type="button" id="copy-uri"
                   data-bs-toggle="tooltip" data-bs-placement="button" title="{{ 'Copy to clipboard' | trans }}">
             <i class="fa-regular fa-copy"></i>
           </button>

--- a/src/view/concept-card.inc
+++ b/src/view/concept-card.inc
@@ -31,7 +31,7 @@
         <div class="col-sm-4 px-0" id="concept-property-label">{{ "skos:prefLabel" | trans }}</div>
         <div class="col-sm-8" id="concept-label">
           <h1 id="concept-preflabel" class="mb-0 user-select-all">{{ concept.label }}</h1>
-          <button class="btn btn-default copy-clipboard" type="button" id="copy-preflabel"
+          <button class="btn btn-default copy-clipboard px-0" type="button" id="copy-preflabel"
                   data-bs-toggle="tooltip" data-bs-placement="button" title="{{ 'Copy to clipboard' | trans }}">
             <i class="fa-regular fa-copy"></i>
           </button>

--- a/src/view/concept-card.inc
+++ b/src/view/concept-card.inc
@@ -28,12 +28,12 @@
       {% endif %}
 
       <div class="row" id="concept-heading">
-        <div class="col-sm-4 px-0" id="concept-property-label">{{ "skos:prefLabel" | trans }}</div>
+        <div class="col-sm-4 px-0 user-select-all" id="concept-property-label">{{ "skos:prefLabel" | trans }}</div>
         <div class="col-sm-8" id="concept-label">
-          <h1 class="mb-0">{{ concept.label }}</h1>
-          <button class="btn btn-default copy-clipboard" type="button"
+          <h1 id="concept-preflabel" class="mb-0">{{ concept.label }}</h1>
+          <button class="btn btn-default copy-clipboard" type="button" id="copy-preflabel"
                   data-bs-toggle="tooltip" data-bs-placement="button" title="{{ 'Copy to clipboard' | trans }}">
-          <i class="fa-regular fa-copy"></i>
+            <i class="fa-regular fa-copy"></i>
           </button>
         </div>
       </div>
@@ -87,7 +87,13 @@
       {% endif %}
       <div class="row property prop-uri">
         <div class="col-sm-4 px-0 property-label"><h2>URI</h2></div>
-        <div class="col-sm-8" id="concept-uri"><a href="#">{{ concept.uri }}</a></div>
+        <div class="col-sm-8">
+          <a href="#" id="concept-uri">{{ concept.uri }}</a>
+          <button class="btn btn-default copy-clipboard" type="button" id="copy-uri"
+                  data-bs-toggle="tooltip" data-bs-placement="button" title="{{ 'Copy to clipboard' | trans }}">
+            <i class="fa-regular fa-copy"></i>
+          </button>
+        </div>
       </div>
       <div class="row property prop-download">
         <div class="col-sm-4 px-0 property-label">

--- a/src/view/concept-card.inc
+++ b/src/view/concept-card.inc
@@ -28,9 +28,9 @@
       {% endif %}
 
       <div class="row" id="concept-heading">
-        <div class="col-sm-4 px-0 user-select-all" id="concept-property-label">{{ "skos:prefLabel" | trans }}</div>
+        <div class="col-sm-4 px-0" id="concept-property-label">{{ "skos:prefLabel" | trans }}</div>
         <div class="col-sm-8" id="concept-label">
-          <h1 id="concept-preflabel" class="mb-0">{{ concept.label }}</h1>
+          <h1 id="concept-preflabel" class="mb-0 user-select-all">{{ concept.label }}</h1>
           <button class="btn btn-default copy-clipboard" type="button" id="copy-preflabel"
                   data-bs-toggle="tooltip" data-bs-placement="button" title="{{ 'Copy to clipboard' | trans }}">
             <i class="fa-regular fa-copy"></i>
@@ -88,7 +88,7 @@
       <div class="row property prop-uri">
         <div class="col-sm-4 px-0 property-label"><h2>URI</h2></div>
         <div class="col-sm-8">
-          <a href="#" id="concept-uri">{{ concept.uri }}</a>
+          <span id="concept-uri" class="user-select-all">{{ concept.uri }}</span>
           <button class="btn btn-default copy-clipboard" type="button" id="copy-uri"
                   data-bs-toggle="tooltip" data-bs-placement="button" title="{{ 'Copy to clipboard' | trans }}">
             <i class="fa-regular fa-copy"></i>

--- a/src/view/scripts.inc
+++ b/src/view/scripts.inc
@@ -24,7 +24,7 @@ const SKOSMOS = {
   {%- if request.plugins.callbacks ~%}
   "pluginCallbacks": [{% for function in request.plugins.callbacks %}{% if not loop.first %}, {% endif %}"{{ function }}"{% endfor %}],
   {%- endif ~%}
-  "language_strings" :{ "fi": { "fi": "suomi",
+  "language_strings": { "fi": { "fi": "suomi",
                                 "en": "englanti",
                                 "se": "pohjoissaame",
                                 "sv": "ruotsi",

--- a/src/view/scripts.inc
+++ b/src/view/scripts.inc
@@ -73,3 +73,6 @@ const SKOSMOS = {
 <script src="resource/js/tab-alpha.js"></script>
 <script src="resource/js/tab-hierarchy.js"></script>
 <script src="resource/js/vocab-search.js"></script>
+
+<!-- Other (non-Vue) JS functionality -->
+<script src="resource/js/copy-to-clipboard.js"></script>

--- a/src/view/search-results.inc
+++ b/src/view/search-results.inc
@@ -103,7 +103,6 @@
   <li class="list-group-item px-0 py-1">
       <span class="uri-icon">URI</span>
       <span class="search-result-uri">{{ concept.uri }}</span>
-    <i class="fa-regular fa-copy"></i> <!-- no copy to clipboard functionality yet -->
   </li>
 {%~ endif ~%}
   </ul>

--- a/tests/cypress/template/concept.cy.js
+++ b/tests/cypress/template/concept.cy.js
@@ -95,6 +95,13 @@ describe('Concept page', () => {
     // check the concept prefLabel
     cy.get('#concept-heading h1').invoke('text').should('equal', 'music research')
   })
+  it('concept preflabel can be copied to clipboard', () => {
+    cy.visit('/yso/en/page/p21685') // go to "music research" concept page
+
+    cy.get('#copy-preflabel').click()
+
+    cy.window().its('navigator.clipboard').invoke('readText').then((result) => {}).should('equal', 'music research');
+  })
   it('contains concept type', () => {
     cy.visit('/yso/en/page/p21685') // go to "music research" concept page
 
@@ -218,6 +225,13 @@ describe('Concept page', () => {
 
     // check the broader concept
     cy.get('#concept-uri').invoke('text').should('equal', 'http://www.yso.fi/onto/yso/p21685')
+  })
+  it('concept URI can be copied to clipboard', () => {
+    cy.visit('/yso/en/page/p21685') // go to "music research" concept page
+
+    cy.get('#copy-uri').click()
+
+    cy.window().its('navigator.clipboard').invoke('readText').then((result) => {}).should('equal', 'http://www.yso.fi/onto/yso/p21685');
   })
   it('contains created & modified times (English)', () => {
     cy.visit('/yso/en/page/p21685') // go to "music research" concept page (English)

--- a/tests/cypress/template/concept.cy.js
+++ b/tests/cypress/template/concept.cy.js
@@ -98,8 +98,13 @@ describe('Concept page', () => {
   it('concept preflabel can be copied to clipboard', () => {
     cy.visit('/yso/en/page/p21685') // go to "music research" concept page
 
+    // click the copy to clipboard button next to the prefLabel
     cy.get('#copy-preflabel').click()
 
+    // check that the clipboard now contains "music research"
+    // NOTE: This test may fail when running Cypress interactively in a browser.
+    // The reason is browser security policies for accessing the clipboard.
+    // If that happens, make sure the browser window has focus and re-run the test.
     cy.window().its('navigator.clipboard').invoke('readText').then((result) => {}).should('equal', 'music research');
   })
   it('contains concept type', () => {
@@ -229,8 +234,13 @@ describe('Concept page', () => {
   it('concept URI can be copied to clipboard', () => {
     cy.visit('/yso/en/page/p21685') // go to "music research" concept page
 
+    // click the copy to clipboard button next to the URI
     cy.get('#copy-uri').click()
 
+    // check that the clipboard now contains "http://www.yso.fi/onto/yso/p21685"
+    // NOTE: This test may fail when running Cypress interactively in a browser.
+    // The reason is browser security policies for accessing the clipboard.
+    // If that happens, make sure the browser window has focus and re-run the test.
     cy.window().its('navigator.clipboard').invoke('readText').then((result) => {}).should('equal', 'http://www.yso.fi/onto/yso/p21685');
   })
   it('contains created & modified times (English)', () => {


### PR DESCRIPTION
## Reasons for creating this PR

Implement copy to clipboard functionality, which is one of the required features for the concept page (#1484).

## Link to relevant issue(s), if any

- part of #1484 
- Closes #1504
- Closes #926

## Description of the changes in this PR

- add a vanilla JS function copyToClipboard
- use the copyToClipboard method for the prefLabel and URI on the concept page
- add translations (fi, sv, en) for the "Copy to clipboard" alt text used for the copy buttons
- remove the copy to clipboard icons from the search results page (this was probably a misunderstanding during layout design)
- add Cypress tests for copy to clipboard functionality

## Known problems or uncertainties in this PR

- the Cypress tests that access the clipboard may fail when run interactively (`npx cypress open`) if the Cypress window isn't focused (for example when working in an IDE) due to browser security policy; they always work when run headless (`npx cypress run`) and under CI

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
