### PR TITLE
fix problem introduced by docker compose 2.24.6 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,9 +40,6 @@ services:
       dockerfile: dockerfiles/Dockerfile.ubuntu
     ports:
       - ${SKOSMOS_PORT:-9090}:80
-    depends_on:
-      - fuseki
-      - fuseki-cache
     volumes:
       - type: bind
         source: ./dockerfiles/config/config-docker-compose.ttl


### PR DESCRIPTION
This PR fixes a problem that appeared with the update of docker compose 2.24.6. Docker compose no longer supports a configuration where a base service declares a dependency on other services, and the base service is extended by another service. We had in the top level `docker-compose.yml` a base service `skosmos` that depends_on services `fuseki` and `fuseki-cache`, but for executing the test suite, there was another version of the `skosmos` service declared in `tests/docker-compose.yml` that extended the base service with the same name but with slightly different settings (e.g. environment variables). This used to work fine, now it breaks with the error message

    service "skosmos" can't be used with `extends` as it declare `depends_on`

This was reported as a bug in docker compose in https://github.com/docker/compose/issues/11544 but swiftly closed as apparently this kind of configuration was never allowed by the [docker compose specification](https://github.com/compose-spec/compose-spec/blob/master/05-services.md#restrictions).

This PR "solves" the problem by dropping the `depends_on` declarations from the base `skosmos` service. It's not ideal, because the dependencies are real (Skosmos doesn't work without Fuseki), but a typical `docker compose up` command will start up all three containers in any case and the Skosmos container doesn't really suffer badly from not having access to Fuseki right after startup, so the order of starting up the containers (which is affected by depends_on) doesn't matter much.

## Reasons for creating this PR

Make it possible to start up the test containers for running the test suite.

## Link to relevant issue(s), if any

n/a

## Description of the changes in this PR

- drop the `depends_on` declarations from the base service `skosmos` in top level `docker-compose.yml`

## Known problems or uncertainties in this PR

This isn't ideal, but I can't think of a better solution right now.

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
