### PR TITLE
Scheduled Actions CI run every Monday morning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,12 @@
 name: CI
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    # run the CI workflow at 6:00am UTC every Monday
+    - cron: '0 6 * * MON'
 
 jobs:
   build-test:


### PR DESCRIPTION
## Reasons for creating this PR

We want to catch problems with the test suite early. Recently, our test container setup has broken twice due to changes in docker compose. This PR introduces a scheduled CI run every Monday morning at 6am UTC, regardless of whether any changes have been made in the repository. It should catch situations where the test suite is breaking due to changes in the surrounding ecosystem.

## Link to relevant issue(s), if any

- follow-up enhancement after #1599 

## Description of the changes in this PR

* define a scheduled CI run every Monday morning at 6am UTC

## Known problems or uncertainties in this PR

It's only once per week, so could miss some events. We can change the frequency later if this turns out to be a problem. Running too frequently could create noise as well.

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
