### PR TITLE
Order mappings on concept page first by source vocabulary, then by label

### DIFF
--- a/src/model/ConceptMappingPropertyValue.php
+++ b/src/model/ConceptMappingPropertyValue.php
@@ -55,6 +55,11 @@ class ConceptMappingPropertyValue extends VocabularyDataObject
         return $label;
     }
 
+    public function getSortKey()
+    {
+        return strtolower($this->getVocabName() . ": " . $this->getLabel());
+    }
+
     private function queryLabel($lang = '', $queryExVocabs = true)
     {
         if ($this->clang) {

--- a/src/model/ConceptProperty.php
+++ b/src/model/ConceptProperty.php
@@ -142,8 +142,8 @@ class ConceptProperty
                 });
             } else {
                 uasort($this->values, function ($a, $b) {
-                    // assume that labels are unique
-                    return strcoll(strtolower($a->getLabel()), strtolower($b->getLabel()));
+                    // assume that sort keys are unique
+                    return strcoll($a->getSortKey(), $b->getSortKey());
                 });
             }
         }

--- a/src/model/ConceptPropertyValue.php
+++ b/src/model/ConceptPropertyValue.php
@@ -41,6 +41,11 @@ class ConceptPropertyValue extends VocabularyDataObject
         return $this->model->getLocale();
     }
 
+    public function getSortKey()
+    {
+        return strtolower($this->getLabel());
+    }
+
     public function getLabel($lang = '', $fallbackToUri = 'uri')
     {
         if ($this->clang) {

--- a/src/model/ConceptPropertyValueLiteral.php
+++ b/src/model/ConceptPropertyValueLiteral.php
@@ -76,6 +76,11 @@ class ConceptPropertyValueLiteral extends VocabularyDataObject
         return $this->literal->getValue();
     }
 
+    public function getSortKey()
+    {
+        return strtolower($this->getLabel());
+    }
+
     public function getUri()
     {
         return null;

--- a/tests/ConceptMappingPropertyValueTest.php
+++ b/tests/ConceptMappingPropertyValueTest.php
@@ -27,6 +27,18 @@ class ConceptMappingPropertyValueTest extends PHPUnit\Framework\TestCase
     }
 
     /**
+     * @covers ConceptMappingPropertyValue::getSortKey
+     * @covers ConceptMappingPropertyValue::getLabel
+     * @covers ConceptMappingPropertyValue::queryLabel
+     * @covers DataObject::getExternalLabel
+     */
+    public function testGetSortKey()
+    {
+        $propvals = $this->props['skos:exactMatch']->getValues();
+        $this->assertEquals('test ontology: eel', $propvals['Eel http://www.skosmos.skos/test/ta115']->getSortKey());
+    }
+
+    /**
      * @covers ConceptMappingPropertyValue::getLabel
      * @covers ConceptMappingPropertyValue::queryLabel
      * @covers DataObject::getExternalLabel

--- a/tests/ConceptPropertyValueLiteralTest.php
+++ b/tests/ConceptPropertyValueLiteralTest.php
@@ -25,6 +25,16 @@ class ConceptPropertyValueLiteralTest extends PHPUnit\Framework\TestCase
     }
 
     /**
+     * @covers ConceptPropertyValueLiteral::getSortKey
+     */
+    public function testGetSortKey()
+    {
+        $props = $this->concept->getProperties();
+        $propvals = $props['skos:scopeNote']->getValues();
+        $this->assertEquals('carp are oily freshwater fish', $propvals['Carp are oily freshwater fish']->getSortKey());
+    }
+
+    /**
      * @covers ConceptPropertyValueLiteral::getLabel
      */
     public function testGetLabel()

--- a/tests/ConceptPropertyValueTest.php
+++ b/tests/ConceptPropertyValueTest.php
@@ -35,6 +35,16 @@ class ConceptPropertyValueTest extends PHPUnit\Framework\TestCase
     }
 
     /**
+     * @covers ConceptPropertyValue::getSortKey
+     */
+    public function testGetSortKey()
+    {
+        $props = $this->concept->getProperties();
+        $propvals = $props['skos:narrower']->getValues();
+        $this->assertEquals('crucian carp', $propvals['Crucian carp http://www.skosmos.skos/test/ta121']->getSortKey());
+    }
+
+    /**
      * @covers ConceptPropertyValue::getLabel
      */
     public function testGetLabel()

--- a/tests/cypress/template/concept.cy.js
+++ b/tests/cypress/template/concept.cy.js
@@ -274,10 +274,10 @@ describe('Concept page', () => {
     // check the second mapping property name
     cy.get('.prop-mapping h2').eq(1).contains('Exactly matching concepts')
     // check the second mapping property values (only one should be enough)
-    cy.get('.prop-mapping').eq(1).find('.prop-mapping-label').eq(0).contains('musiikintutkimus (fi)')
-    cy.get('.prop-mapping').eq(1).find('.prop-mapping-label').eq(0).find('a').invoke('text').should('equal', 'musiikintutkimus')
-    cy.get('.prop-mapping').eq(1).find('.prop-mapping-label').eq(0).find('a').should('have.attr', 'href', 'http://www.yso.fi/onto/ysa/Y155072')
-    cy.get('.prop-mapping').eq(1).find('.prop-mapping-vocab').eq(0).contains('YSA - Yleinen suomalainen asiasanasto')
+    cy.get('.prop-mapping').eq(1).find('.prop-mapping-label').eq(2).contains('musiikintutkimus (fi)')
+    cy.get('.prop-mapping').eq(1).find('.prop-mapping-label').eq(2).find('a').invoke('text').should('equal', 'musiikintutkimus')
+    cy.get('.prop-mapping').eq(1).find('.prop-mapping-label').eq(2).find('a').should('have.attr', 'href', 'http://www.yso.fi/onto/ysa/Y155072')
+    cy.get('.prop-mapping').eq(1).find('.prop-mapping-vocab').eq(2).contains('YSA - Yleinen suomalainen asiasanasto')
     // check that the second mapping property has the right number of entries
     cy.get('.prop-mapping').eq(1).find('.prop-mapping-label').should('have.length', 3)
   })


### PR DESCRIPTION
## Reasons for creating this PR

Cypress tests for the mappings on the concept page were failing, because the two mappings on the example page to "musicology" from Wikidata and "Musicology" from LCSH were not in the expected order. It turned out that the order of mappings depended on the labels only and wasn't stable in a case like this were the labels are the same (case insensitive).

This PR causes the mappings on the concept page (of each type) to be displayed in a consistent order: first by source vocabulary, then by label. This is implemented on the backend side, so that the data returned by the `mappings` REST API method is sorted. (An alternative approach would have been to do the sorting in the frontend only.)

Result can be seen e.g. on the YSO concept page for "musicology":

![image](https://github.com/NatLibFi/Skosmos/assets/1132830/96e95fa1-0ffd-490d-889d-166492f2d70d)

Note that the closeMatch mappings are ordered by vocabulary (LCSH < Wikidata) and likewise the exactMatch mappings are now ordered by vocabulary (Allärs < KOKO < YSA). Before this PR, the order could be different as it was based only on the labels (e.g. music research < musiikintutkimus < musikforskning) and could be arbitrary when labels are the same (musicology vs Musicology).

## Link to relevant issue(s), if any

- part of #1484

## Description of the changes in this PR

* add a getSortKey method to the classes ConceptPropertyValue, ConceptPropertyValueLiteral and ConceptMappingPropertyValue (for the two former, based on label only; for the mappings, based first on vocabulary name, then by label)
* use the getSortKey method when sorting property values in ConceptProperty.sortValues()
* add PHPUnit tests for the getSortKey methods
* adjust the Cypress test for the concept page mappings so that it matches the new order of mapping values

## Known problems or uncertainties in this PR

n/a

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
