### PR TITLE
Updated Cypress to the latest version 13.6.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "axe-core": "^4.7.1",
-    "cypress": "^12.17.4",
+    "cypress": "^13.6.6",
     "cypress-axe": "^1.4.0",
     "standard": "^17.0.0"
   }


### PR DESCRIPTION
## Reasons for creating this PR

We were running an older version of cypress, and it started to have problems. Everything seems to work after this version update.

## Notes

Remember to run `npm install` locally afterwards!
