### PR TITLE
Add Cypress tests for partial page load

### DIFF
--- a/resource/js/concept-mappings.js
+++ b/resource/js/concept-mappings.js
@@ -1,5 +1,4 @@
 /* global Vue */
-/* global SKOSMOS */
 
 const conceptMappingsApp = Vue.createApp({
   data () {
@@ -8,11 +7,11 @@ const conceptMappingsApp = Vue.createApp({
     }
   },
   provide: {
-    content_lang: SKOSMOS.content_lang
+    content_lang: window.SKOSMOS.content_lang
   },
   methods: {
     loadMappings () {
-      fetch('rest/v1/' + SKOSMOS.vocab + '/mappings?uri=' + SKOSMOS.uri + '&external=true&clang=' + SKOSMOS.lang + '&lang=' + SKOSMOS.content_lang)
+      fetch('rest/v1/' + window.SKOSMOS.vocab + '/mappings?uri=' + window.SKOSMOS.uri + '&external=true&clang=' + window.SKOSMOS.lang + '&lang=' + window.SKOSMOS.content_lang)
         .then(data => {
           return data.json()
         })
@@ -31,8 +30,8 @@ const conceptMappingsApp = Vue.createApp({
   },
   mounted () {
     // Only load mappings when on the concept page
-    // SKOSMOS variable should maybe have a separate property for current page
-    if (SKOSMOS.uri) {
+    // window.SKOSMOS variable should maybe have a separate property for current page
+    if (window.SKOSMOS.uri) {
       this.loadMappings()
     }
   },

--- a/resource/js/get-concept-url.js
+++ b/resource/js/get-concept-url.js
@@ -1,13 +1,11 @@
-/* global SKOSMOS */
-
 /* eslint-disable no-unused-vars */
 const getConceptURL = (uri) => {
-  const clangParam = (SKOSMOS.content_lang !== SKOSMOS.lang) ? 'clang=' + SKOSMOS.content_lang : ''
+  const clangParam = (window.SKOSMOS.content_lang !== window.SKOSMOS.lang) ? 'clang=' + window.SKOSMOS.content_lang : ''
   let clangSeparator = '?'
   let page = ''
 
-  if (uri.indexOf(SKOSMOS.uriSpace) !== -1) {
-    page = uri.substr(SKOSMOS.uriSpace.length)
+  if (uri.indexOf(window.SKOSMOS.uriSpace) !== -1) {
+    page = uri.substr(window.SKOSMOS.uriSpace.length)
 
     if (/[^a-zA-Z0-9-_.~]/.test(page) || page.indexOf('/') > -1) {
       // contains special characters or contains an additional '/' - fall back to full URI
@@ -20,6 +18,6 @@ const getConceptURL = (uri) => {
     clangSeparator = '&'
   }
 
-  return SKOSMOS.vocab + '/' + SKOSMOS.lang + '/page/' + page + (clangParam !== '' ? clangSeparator + clangParam : '')
+  return window.SKOSMOS.vocab + '/' + window.SKOSMOS.lang + '/page/' + page + (clangParam !== '' ? clangSeparator + clangParam : '')
 }
 /* eslint-disable no-unused-vars */

--- a/resource/js/partial-page-load.js
+++ b/resource/js/partial-page-load.js
@@ -1,5 +1,3 @@
-/* global SKOSMOS */
-
 const updateMainContent = (conceptHTML) => {
   // concept card
   const conceptMainContent = conceptHTML.querySelectorAll('#main-content > :not(#concept-mappings)') // all elements from concept card except concept mappings
@@ -39,14 +37,14 @@ const updateJsonLD = (conceptHTML) => {
 }
 
 const updateSKOSMOS = (conceptHTML) => {
-  // new SKOSMOS object from concept page
+  // new window.SKOSMOS object from concept page
   const skosmosScript = conceptHTML.querySelector('#skosmos-global-vars').innerHTML
   const skosmosObject = skosmosScript.slice(skosmosScript.indexOf('{'))
   const newSKOSMOS = JSON.parse(skosmosObject)
 
-  // replacing all values in the old SKOSMOS object with new ones
+  // replacing all values in the old window.SKOSMOS object with new ones
   for (const i in newSKOSMOS) {
-    SKOSMOS[i] = newSKOSMOS[i]
+    window.SKOSMOS[i] = newSKOSMOS[i]
   }
 }
 

--- a/resource/js/tab-alpha.js
+++ b/resource/js/tab-alpha.js
@@ -1,5 +1,4 @@
 /* global Vue */
-/* global SKOSMOS */
 /* global partialPageLoad, getConceptURL */
 
 const tabAlphaApp = Vue.createApp({
@@ -27,7 +26,7 @@ const tabAlphaApp = Vue.createApp({
   methods: {
     handleClickAlphabeticalEvent () {
       // only load index the first time the page is opened or if selected concept has changed
-      if (this.indexLetters.length === 0 || this.selectedConcept !== SKOSMOS.uri) {
+      if (this.indexLetters.length === 0 || this.selectedConcept !== window.SKOSMOS.uri) {
         this.selectedConcept = ''
         this.indexLetters = []
         this.indexConcepts = []
@@ -36,7 +35,7 @@ const tabAlphaApp = Vue.createApp({
     },
     loadLetters () {
       this.loadingLetters = true
-      fetch('rest/v1/' + SKOSMOS.vocab + '/index/?lang=' + SKOSMOS.lang)
+      fetch('rest/v1/' + window.SKOSMOS.vocab + '/index/?lang=' + window.SKOSMOS.lang)
         .then(data => {
           return data.json()
         })
@@ -48,7 +47,7 @@ const tabAlphaApp = Vue.createApp({
     },
     loadConcepts (letter) {
       this.loadingConcepts = true
-      fetch('rest/v1/' + SKOSMOS.vocab + '/index/' + letter + '?lang=' + SKOSMOS.lang + '&limit=50')
+      fetch('rest/v1/' + window.SKOSMOS.vocab + '/index/' + letter + '?lang=' + window.SKOSMOS.lang + '&limit=50')
         .then(data => {
           return data.json()
         })

--- a/resource/js/tab-hierarchy.js
+++ b/resource/js/tab-hierarchy.js
@@ -1,5 +1,4 @@
 /* global Vue */
-/* global SKOSMOS */
 /* global partialPageLoad, getConceptURL */
 
 const tabHierApp = Vue.createApp({
@@ -31,7 +30,7 @@ const tabHierApp = Vue.createApp({
     },
     loadHierarchy () {
       // if we are on a concept page, load hierarchy for the concept, otherwise load top concepts
-      if (SKOSMOS.uri) {
+      if (window.SKOSMOS.uri) {
         this.loadConceptHierarchy()
       } else {
         this.loadTopConcepts()
@@ -39,7 +38,7 @@ const tabHierApp = Vue.createApp({
     },
     loadTopConcepts () {
       this.loading = true
-      fetch('rest/v1/' + SKOSMOS.vocab + '/topConcepts/?lang=' + SKOSMOS.lang)
+      fetch('rest/v1/' + window.SKOSMOS.vocab + '/topConcepts/?lang=' + window.SKOSMOS.lang)
         .then(data => {
           return data.json()
         })
@@ -58,7 +57,7 @@ const tabHierApp = Vue.createApp({
     },
     loadConceptHierarchy () {
       this.loading = true
-      fetch('rest/v1/' + SKOSMOS.vocab + '/hierarchy/?uri=' + SKOSMOS.uri + '&lang=' + SKOSMOS.lang)
+      fetch('rest/v1/' + window.SKOSMOS.vocab + '/hierarchy/?uri=' + window.SKOSMOS.uri + '&lang=' + window.SKOSMOS.lang)
         .then(data => {
           return data.json()
         })
@@ -122,14 +121,14 @@ const tabHierApp = Vue.createApp({
           }
 
           this.loading = false
-          this.selectedConcept = SKOSMOS.uri
+          this.selectedConcept = window.SKOSMOS.uri
           console.log(this.hierarchy)
         })
     },
     loadChildren (concept) {
       // load children only if concept has children but they have not been loaded yet
       if (concept.children.length === 0 && concept.hasChildren) {
-        fetch('rest/v1/' + SKOSMOS.vocab + '/children?uri=' + concept.uri + '&lang=' + SKOSMOS.lang)
+        fetch('rest/v1/' + window.SKOSMOS.vocab + '/children?uri=' + concept.uri + '&lang=' + window.SKOSMOS.lang)
           .then(data => {
             return data.json()
           })

--- a/resource/js/term-counts.js
+++ b/resource/js/term-counts.js
@@ -1,5 +1,4 @@
 /* global Vue */
-/* global SKOSMOS */
 
 const termCountsApp = Vue.createApp({
   data () {
@@ -8,7 +7,7 @@ const termCountsApp = Vue.createApp({
     }
   },
   mounted () {
-    fetch('rest/v1/' + SKOSMOS.vocab + '/labelStatistics?lang=' + SKOSMOS.lang)
+    fetch('rest/v1/' + window.SKOSMOS.vocab + '/labelStatistics?lang=' + window.SKOSMOS.lang)
       .then(data => {
         return data.json()
       })

--- a/resource/js/vocab-counts.js
+++ b/resource/js/vocab-counts.js
@@ -1,5 +1,4 @@
 /* global Vue */
-/* global SKOSMOS */
 
 const resourceCountsApp = Vue.createApp({
   data () {
@@ -10,7 +9,7 @@ const resourceCountsApp = Vue.createApp({
     }
   },
   mounted () {
-    fetch('rest/v1/' + SKOSMOS.vocab + '/vocabularyStatistics?lang=' + SKOSMOS.lang)
+    fetch('rest/v1/' + window.SKOSMOS.vocab + '/vocabularyStatistics?lang=' + window.SKOSMOS.lang)
       .then(data => {
         return data.json()
       })

--- a/resource/js/vocab-search.js
+++ b/resource/js/vocab-search.js
@@ -1,5 +1,4 @@
 /* global Vue */
-/* global SKOSMOS */
 
 const vocabSearch = Vue.createApp({
   data () {
@@ -12,9 +11,9 @@ const vocabSearch = Vue.createApp({
     }
   },
   mounted () {
-    this.languages = SKOSMOS.languageOrder
-    this.selectedLanguage = SKOSMOS.content_lang
-    this.languageStrings = SKOSMOS.language_strings[SKOSMOS.lang]
+    this.languages = window.SKOSMOS.languageOrder
+    this.selectedLanguage = window.SKOSMOS.content_lang
+    this.languageStrings = window.SKOSMOS.language_strings[window.SKOSMOS.lang]
   },
   methods: {
     autoComplete () {
@@ -23,15 +22,15 @@ const vocabSearch = Vue.createApp({
     gotoSearchPage () {
       if (!this.searchTerm) return
 
-      const currentVocab = SKOSMOS.vocab + '/' + SKOSMOS.lang + '/'
-      const vocabHref = window.location.href.substring(0, window.location.href.lastIndexOf(SKOSMOS.vocab)) + currentVocab
-      let langParam = '&clang=' + SKOSMOS.content_lang
+      const currentVocab = window.SKOSMOS.vocab + '/' + window.SKOSMOS.lang + '/'
+      const vocabHref = window.location.href.substring(0, window.location.href.lastIndexOf(window.SKOSMOS.vocab)) + currentVocab
+      let langParam = '&clang=' + window.SKOSMOS.content_lang
       if (this.selectedLanguage === 'all') langParam += '&anylang=on'
       const searchUrl = vocabHref + 'search?q=' + this.searchTerm + langParam
       window.location.href = searchUrl
     },
     changeLang () {
-      SKOSMOS.content_lang = this.selectedLanguage
+      window.SKOSMOS.content_lang = this.selectedLanguage
       // TODO: Impelemnt partial page load to change content according to the new content language
     }
   },

--- a/src/view/scripts.inc
+++ b/src/view/scripts.inc
@@ -1,7 +1,7 @@
 <!-- Skosmos variables passed from the backend to the frontend code-->
 <!-- NB: Do not add comments inside the JS object as it would break JSON parsing -->
 <script id="skosmos-global-vars">
-const SKOSMOS = {
+window.SKOSMOS = {
   "content_lang": "{{ request.contentLang }}",
   "explicitLangCodes": {{ explicit_langcodes ? "true" : "false" }},
   "lang": "{{ request.lang }}",

--- a/tests/cypress/template/concept.cy.js
+++ b/tests/cypress/template/concept.cy.js
@@ -70,6 +70,42 @@ describe('Concept page', () => {
       // If that happens, make sure the browser window has focus and re-run the test.
       cy.window().its('navigator.clipboard').invoke('readText').then((result) => {}).should('equal', 'http://www.yso.fi/onto/yso/p39473');
     })
+    it('contains mappings / ' + pageLoadType, () => {
+      if (pageLoadType == "full") {
+        cy.visit('/yso/en/page/p14174') // go to "labyrinths" concept page
+      } else {
+        cy.visit('/yso/en/page/p5714') // go to "prehistoric graves" concept page
+        // click on the link to "labyrinths" to trigger partial page load
+        cy.get('#tab-hierarchy').contains('a', 'labyrinths').click()
+      }
+
+      // check that we have some mappings
+      cy.get('#concept-mappings').should('not.be.empty')
+
+      // check the first mapping property name
+      cy.get('.prop-mapping h2').eq(0).contains('Closely matching concepts')
+      // check the first mapping property values
+      cy.get('.prop-mapping').eq(0).find('.prop-mapping-label').eq(0).contains('Labyrinths')
+      cy.get('.prop-mapping').eq(0).find('.prop-mapping-label').eq(0).find('a').should('have.attr', 'href', 'http://id.loc.gov/authorities/subjects/sh85073793')
+      cy.get('.prop-mapping').eq(0).find('.prop-mapping-vocab').eq(0).contains('Library of Congress Subject Headings')
+      // check that the first mapping property has the right number of entries
+      cy.get('.prop-mapping').eq(0).find('.prop-mapping-label').should('have.length', 1)
+
+      // check the second mapping property name
+      cy.get('.prop-mapping h2').eq(1).contains('Exactly matching concepts')
+      // check the second mapping property values
+      cy.get('.prop-mapping').eq(1).find('.prop-mapping-label').eq(0).contains('labyrinter (sv)')
+      cy.get('.prop-mapping').eq(1).find('.prop-mapping-label').eq(0).find('a').invoke('text').should('equal', 'labyrinter')
+      cy.get('.prop-mapping').eq(1).find('.prop-mapping-label').eq(0).find('a').should('have.attr', 'href', 'http://www.yso.fi/onto/allars/Y21700')
+      cy.get('.prop-mapping').eq(1).find('.prop-mapping-vocab').eq(0).contains('Allärs - General thesaurus in Swedish')
+      // skipping the middle one (mapping to KOKO concept) as it's similar to the others
+      cy.get('.prop-mapping').eq(1).find('.prop-mapping-label').eq(2).contains('labyrintit (fi)')
+      cy.get('.prop-mapping').eq(1).find('.prop-mapping-label').eq(2).find('a').invoke('text').should('equal', 'labyrintit')
+      cy.get('.prop-mapping').eq(1).find('.prop-mapping-label').eq(2).find('a').should('have.attr', 'href', 'http://www.yso.fi/onto/ysa/Y108389')
+      cy.get('.prop-mapping').eq(1).find('.prop-mapping-vocab').eq(2).contains('YSA - Yleinen suomalainen asiasanasto')
+      // check that the second mapping property has the right number of entries
+      cy.get('.prop-mapping').eq(1).find('.prop-mapping-label').should('have.length', 3)
+    })
 
   });
 
@@ -287,33 +323,5 @@ describe('Concept page', () => {
     cy.visit('/yso/fi/page/p21685') // go to "musiikintutkimus" concept page (Finnish)
 
     cy.get('#date-info').invoke('text').should('equal', 'Luotu 25.10.2007, viimeksi muokattu 8.2.2023')
-  })
-  it('contains mappings', () => {
-    cy.visit('/yso/en/page/p21685') // go to "music research" concept page
-
-    // check that we have some mappings
-    cy.get('#concept-mappings').should('not.be.empty')
-
-    // check the first mapping property name
-    cy.get('.prop-mapping h2').eq(0).contains('Closely matching concepts')
-    // check the first mapping property values
-    cy.get('.prop-mapping').eq(0).find('.prop-mapping-label').eq(0).contains('Musicology')
-    cy.get('.prop-mapping').eq(0).find('.prop-mapping-label').eq(0).find('a').should('have.attr', 'href', 'http://id.loc.gov/authorities/subjects/sh85089048')
-    cy.get('.prop-mapping').eq(0).find('.prop-mapping-vocab').eq(0).contains('Library of Congress Subject Headings')
-    cy.get('.prop-mapping').eq(0).find('.prop-mapping-label').eq(1).contains('musicology')
-    cy.get('.prop-mapping').eq(0).find('.prop-mapping-label').eq(1).find('a').should('have.attr', 'href', 'http://www.wikidata.org/entity/Q164204')
-    cy.get('.prop-mapping').eq(0).find('.prop-mapping-vocab').eq(1).contains('www.wikidata.org')
-    // check that the second mapping property has the right number of entries
-    cy.get('.prop-mapping').eq(0).find('.prop-mapping-label').should('have.length', 2)
-
-    // check the second mapping property name
-    cy.get('.prop-mapping h2').eq(1).contains('Exactly matching concepts')
-    // check the second mapping property values (only one should be enough)
-    cy.get('.prop-mapping').eq(1).find('.prop-mapping-label').eq(2).contains('musiikintutkimus (fi)')
-    cy.get('.prop-mapping').eq(1).find('.prop-mapping-label').eq(2).find('a').invoke('text').should('equal', 'musiikintutkimus')
-    cy.get('.prop-mapping').eq(1).find('.prop-mapping-label').eq(2).find('a').should('have.attr', 'href', 'http://www.yso.fi/onto/ysa/Y155072')
-    cy.get('.prop-mapping').eq(1).find('.prop-mapping-vocab').eq(2).contains('YSA - Yleinen suomalainen asiasanasto')
-    // check that the second mapping property has the right number of entries
-    cy.get('.prop-mapping').eq(1).find('.prop-mapping-label').should('have.length', 3)
   })
 })

--- a/tests/cypress/template/concept.cy.js
+++ b/tests/cypress/template/concept.cy.js
@@ -83,6 +83,7 @@ describe('Concept page', () => {
       cy.get('#concept-mappings').should('not.be.empty')
 
       // check the first mapping property name
+      // NOTE: we need to increase the timeout as the mappings can take a long time to load
       cy.get('.prop-mapping h2', {'timeout': 10000}).eq(0).contains('Closely matching concepts')
       // check the first mapping property values
       cy.get('.prop-mapping').eq(0).find('.prop-mapping-label').eq(0).contains('Labyrinths')

--- a/tests/cypress/template/concept.cy.js
+++ b/tests/cypress/template/concept.cy.js
@@ -83,7 +83,7 @@ describe('Concept page', () => {
       cy.get('#concept-mappings').should('not.be.empty')
 
       // check the first mapping property name
-      cy.get('.prop-mapping h2').eq(0).contains('Closely matching concepts')
+      cy.get('.prop-mapping h2', {'timeout': 10000}).eq(0).contains('Closely matching concepts')
       // check the first mapping property values
       cy.get('.prop-mapping').eq(0).find('.prop-mapping-label').eq(0).contains('Labyrinths')
       cy.get('.prop-mapping').eq(0).find('.prop-mapping-label').eq(0).find('a').should('have.attr', 'href', 'http://id.loc.gov/authorities/subjects/sh85073793')

--- a/tests/cypress/template/concept.cy.js
+++ b/tests/cypress/template/concept.cy.js
@@ -1,4 +1,46 @@
 describe('Concept page', () => {
+  const pageLoadTypes = ["full", "partial"]
+
+  // tests that should be executed both with and without partial page load
+
+  pageLoadTypes.forEach((pageLoadType) => {
+    it('contains concept preflabel / ' + pageLoadType, () => {
+      if (pageLoadType == "full") {
+        cy.visit('/yso/en/page/p39473') // go to "burial mounds" concept page
+      } else {
+        cy.visit('/yso/en/page/p5714') // go to "prehistoric graves" concept page
+        // click on the link to "burial mounds" to trigger partial page load
+        cy.get('#tab-hierarchy').contains('a', 'burial mounds').click()
+      }
+
+      // check that the vocabulary title is correct
+      cy.get('#vocab-title > a').invoke('text').should('equal', 'YSO - General Finnish ontology (archaeology)')
+
+      // check the concept prefLabel
+      cy.get('#concept-heading h1').invoke('text').should('equal', 'burial mounds')
+    })
+    it('concept preflabel can be copied to clipboard / ' + pageLoadType, () => {
+      if (pageLoadType == "full") {
+        cy.visit('/yso/en/page/p39473') // go to "burial mounds" concept page
+      } else {
+        cy.visit('/yso/en/page/p5714') // go to "prehistoric graves" concept page
+        // click on the link to "burial mounds" to trigger partial page load
+        cy.get('#tab-hierarchy').contains('a', 'burial mounds').click()
+      }
+
+      // click the copy to clipboard button next to the prefLabel
+      cy.get('#copy-preflabel').click()
+
+      // check that the clipboard now contains "music pyramids"
+      // NOTE: This test may fail when running Cypress interactively in a browser.
+      // The reason is browser security policies for accessing the clipboard.
+      // If that happens, make sure the browser window has focus and re-run the test.
+      cy.window().its('navigator.clipboard').invoke('readText').then((result) => {}).should('equal', 'burial mounds');
+    })
+  });
+
+  // tests that only need to be executed with full page load
+
   it("doesn't contain breadcrumbs for top concepts", () => {
     cy.visit('/yso/en/page/p4762') // go to "objects" concept page
 
@@ -86,27 +128,7 @@ describe('Concept page', () => {
     // check that there are 2 breadcrumb links currently shown
     cy.get('#concept-breadcrumbs ol').find('li.show').should('have.length', 4)
   })
-  it('contains concept preflabel', () => {
-    cy.visit('/yso/en/page/p21685') // go to "music research" concept page
 
-    // check that the vocabulary title is correct
-    cy.get('#vocab-title > a').invoke('text').should('equal', 'YSO - General Finnish ontology (archaeology)')
-
-    // check the concept prefLabel
-    cy.get('#concept-heading h1').invoke('text').should('equal', 'music research')
-  })
-  it('concept preflabel can be copied to clipboard', () => {
-    cy.visit('/yso/en/page/p21685') // go to "music research" concept page
-
-    // click the copy to clipboard button next to the prefLabel
-    cy.get('#copy-preflabel').click()
-
-    // check that the clipboard now contains "music research"
-    // NOTE: This test may fail when running Cypress interactively in a browser.
-    // The reason is browser security policies for accessing the clipboard.
-    // If that happens, make sure the browser window has focus and re-run the test.
-    cy.window().its('navigator.clipboard').invoke('readText').then((result) => {}).should('equal', 'music research');
-  })
   it('contains concept type', () => {
     cy.visit('/yso/en/page/p21685') // go to "music research" concept page
 

--- a/tests/cypress/template/concept.cy.js
+++ b/tests/cypress/template/concept.cy.js
@@ -37,6 +37,40 @@ describe('Concept page', () => {
       // If that happens, make sure the browser window has focus and re-run the test.
       cy.window().its('navigator.clipboard').invoke('readText').then((result) => {}).should('equal', 'burial mounds');
     })
+    it('contains concept URI / ' + pageLoadType, () => {
+      if (pageLoadType == "full") {
+        cy.visit('/yso/en/page/p39473') // go to "burial mounds" concept page
+      } else {
+        cy.visit('/yso/en/page/p5714') // go to "prehistoric graves" concept page
+        // click on the link to "burial mounds" to trigger partial page load
+        cy.get('#tab-hierarchy').contains('a', 'burial mounds').click()
+      }
+
+      // check the property name
+      cy.get('.prop-uri .property-label').invoke('text').should('equal', 'URI')
+
+      // check the concept URI
+      cy.get('#concept-uri').invoke('text').should('equal', 'http://www.yso.fi/onto/yso/p39473')
+    })
+    it('concept URI can be copied to clipboard / ' + pageLoadType, () => {
+      if (pageLoadType == "full") {
+        cy.visit('/yso/en/page/p39473') // go to "burial mounds" concept page
+      } else {
+        cy.visit('/yso/en/page/p5714') // go to "prehistoric graves" concept page
+        // click on the link to "burial mounds" to trigger partial page load
+        cy.get('#tab-hierarchy').contains('a', 'burial mounds').click()
+      }
+
+      // click the copy to clipboard button next to the URI
+      cy.get('#copy-uri').click()
+
+      // check that the clipboard now contains "http://www.yso.fi/onto/yso/p39473"
+      // NOTE: This test may fail when running Cypress interactively in a browser.
+      // The reason is browser security policies for accessing the clipboard.
+      // If that happens, make sure the browser window has focus and re-run the test.
+      cy.window().its('navigator.clipboard').invoke('readText').then((result) => {}).should('equal', 'http://www.yso.fi/onto/yso/p39473');
+    })
+
   });
 
   // tests that only need to be executed with full page load
@@ -243,27 +277,6 @@ describe('Concept page', () => {
 
     // check that we have the correct number of languages
     cy.get('#concept-other-languages').find('.row').should('have.length', 3)
-  })
-  it('contains concept URI', () => {
-    cy.visit('/yso/en/page/p21685') // go to "music research" concept page
-
-    // check the property name
-    cy.get('.prop-uri .property-label').invoke('text').should('equal', 'URI')
-
-    // check the broader concept
-    cy.get('#concept-uri').invoke('text').should('equal', 'http://www.yso.fi/onto/yso/p21685')
-  })
-  it('concept URI can be copied to clipboard', () => {
-    cy.visit('/yso/en/page/p21685') // go to "music research" concept page
-
-    // click the copy to clipboard button next to the URI
-    cy.get('#copy-uri').click()
-
-    // check that the clipboard now contains "http://www.yso.fi/onto/yso/p21685"
-    // NOTE: This test may fail when running Cypress interactively in a browser.
-    // The reason is browser security policies for accessing the clipboard.
-    // If that happens, make sure the browser window has focus and re-run the test.
-    cy.window().its('navigator.clipboard').invoke('readText').then((result) => {}).should('equal', 'http://www.yso.fi/onto/yso/p21685');
   })
   it('contains created & modified times (English)', () => {
     cy.visit('/yso/en/page/p21685') // go to "music research" concept page (English)

--- a/tests/cypress/template/vocab-home.cy.js
+++ b/tests/cypress/template/vocab-home.cy.js
@@ -54,14 +54,11 @@ describe('Vocabulary home page', () => {
   it('clicking on alphabetical index entries performs partial page load', () => {
     cy.visit('/yso/en/') // go to the YSO home page in English language
 
-    // click on the third letter (C)
-    cy.get('#tab-alphabetical .pagination :nth-child(3) > .page-link').click()
+    // click on the the letter C
+    cy.get('#tab-alphabetical').contains('a', 'C').click()
 
-    // check that the first entry is "care institutions"
-    cy.get('#tab-alphabetical .sidebar-list').children().first().invoke('text').should('equal', 'care institutions')
-
-    // click on the first entry (should trigger partial page load)
-    cy.get('#tab-alphabetical .sidebar-list').children().first().click()
+    // click on the link "care institutions" (should trigger partial page load)
+    cy.get('#tab-alphabetical').contains('a', 'care institutions').click()
 
     // check the concept prefLabel
     cy.get('#concept-heading h1').invoke('text').should('equal', 'care institutions')
@@ -75,11 +72,8 @@ describe('Vocabulary home page', () => {
     // open the hierarchy tab
     cy.get('#hierarchy a').click()
 
-    // check that the first entry is "Fish"
-    cy.get('#tab-hierarchy .sidebar-list a').invoke('text').should('equal', 'Fish')
-
-    // click on the link (should trigger partial page load)
-    cy.get('#tab-hierarchy .sidebar-list a').click()
+    // click on the link "Fish" (should trigger partial page load)
+    cy.get('#tab-hierarchy').contains('a', 'Fish').click()
 
     // check the concept prefLabel
     cy.get('#concept-heading h1').invoke('text').should('equal', 'Fish')

--- a/tests/cypress/template/vocab-home.cy.js
+++ b/tests/cypress/template/vocab-home.cy.js
@@ -50,4 +50,38 @@ describe('Vocabulary home page', () => {
 
     // check that the first entry is "östliga handelsvägar"
     cy.get('#tab-alphabetical .sidebar-list .list-group').children().first().children().first().invoke('text').should('equal', 'östliga handelsvägar')
-  })})
+  })
+  it('clicking on alphabetical index entries performs partial page load', () => {
+    cy.visit('/yso/en/') // go to the YSO home page in English language
+
+    // click on the third letter (C)
+    cy.get('#tab-alphabetical .pagination :nth-child(3) > .page-link').click()
+
+    // check that the first entry is "care institutions"
+    cy.get('#tab-alphabetical .sidebar-list').children().first().invoke('text').should('equal', 'care institutions')
+
+    // click on the first entry (should trigger partial page load)
+    cy.get('#tab-alphabetical .sidebar-list').children().first().click()
+
+    // check the concept prefLabel
+    cy.get('#concept-heading h1').invoke('text').should('equal', 'care institutions')
+
+    // check that concept mappings is not empty
+    cy.get('#concept-mappings').should('not.be.empty')
+  })
+  it('clicking on hierarchy entries performs partial page load', () => {
+    cy.visit('/test/en') // go to the "Test ontology" home page
+
+    // open the hierarchy tab
+    cy.get('#hierarchy a').click()
+
+    // check that the first entry is "Fish"
+    cy.get('#tab-hierarchy .sidebar-list a').invoke('text').should('equal', 'Fish')
+
+    // click on the link (should trigger partial page load)
+    cy.get('#tab-hierarchy .sidebar-list a').click()
+
+    // check the concept prefLabel
+    cy.get('#concept-heading h1').invoke('text').should('equal', 'Fish')
+  })
+})

--- a/tests/cypress/template/vocab-home.cy.js
+++ b/tests/cypress/template/vocab-home.cy.js
@@ -68,6 +68,24 @@ describe('Vocabulary home page', () => {
       expect(win.SKOSMOS.uri).to.equal('http://www.yso.fi/onto/yso/p6034');
       expect(win.SKOSMOS.prefLabels[0]['label']).to.equal("care institutions");
     })
+
+    // check that we have some mappings
+    cy.get('#concept-mappings').should('not.be.empty')
+
+    // check the second mapping property name
+    cy.get('.prop-mapping h2').eq(0).contains('Exactly matching concepts')
+    // check the second mapping property values
+    cy.get('.prop-mapping').eq(0).find('.prop-mapping-label').eq(0).contains('vårdinrättningar (sv)')
+    cy.get('.prop-mapping').eq(0).find('.prop-mapping-label').eq(0).find('a').invoke('text').should('equal', 'vårdinrättningar')
+    cy.get('.prop-mapping').eq(0).find('.prop-mapping-label').eq(0).find('a').should('have.attr', 'href', 'http://www.yso.fi/onto/allars/Y29009')
+    cy.get('.prop-mapping').eq(0).find('.prop-mapping-vocab').eq(0).contains('Allärs - General thesaurus in Swedish')
+    // skipping the middle one (mapping to KOKO concept) as it's similar to the others
+    cy.get('.prop-mapping').eq(0).find('.prop-mapping-label').eq(2).contains('hoitolaitokset (fi)')
+    cy.get('.prop-mapping').eq(0).find('.prop-mapping-label').eq(2).find('a').invoke('text').should('equal', 'hoitolaitokset')
+    cy.get('.prop-mapping').eq(0).find('.prop-mapping-label').eq(2).find('a').should('have.attr', 'href', 'http://www.yso.fi/onto/ysa/Y95404')
+    cy.get('.prop-mapping').eq(0).find('.prop-mapping-vocab').eq(2).contains('YSA - Yleinen suomalainen asiasanasto')
+    // check that the second mapping property has the right number of entries
+    cy.get('.prop-mapping').eq(0).find('.prop-mapping-label').should('have.length', 3)
   })
   it('clicking on hierarchy entries performs partial page load', () => {
     cy.visit('/test/en') // go to the "Test ontology" home page
@@ -86,5 +104,18 @@ describe('Vocabulary home page', () => {
       expect(win.SKOSMOS.uri).to.equal('http://www.skosmos.skos/test/ta1');
       expect(win.SKOSMOS.prefLabels[0]['label']).to.equal("Fish");
     })
+
+    // check that we have some mappings
+    cy.get('#concept-mappings').should('not.be.empty')
+
+    // check the second mapping property name
+    cy.get('.prop-mapping h2').eq(0).contains('Exactly matching concepts')
+    // check the second mapping property values
+    cy.get('.prop-mapping').eq(0).find('.prop-mapping-label').eq(0).find('a').invoke('text').should('equal', 'fish')
+    cy.get('.prop-mapping').eq(0).find('.prop-mapping-label').eq(0).find('a').should('have.attr', 'href', 'http://www.wikidata.org/entity/Q152')
+    cy.get('.prop-mapping').eq(0).find('.prop-mapping-vocab').eq(0).contains('www.wikidata.org')
+
+    // check that the second mapping property has the right number of entries
+    cy.get('.prop-mapping').eq(0).find('.prop-mapping-label').should('have.length', 1)
   })
 })

--- a/tests/cypress/template/vocab-home.cy.js
+++ b/tests/cypress/template/vocab-home.cy.js
@@ -63,8 +63,11 @@ describe('Vocabulary home page', () => {
     // check the concept prefLabel
     cy.get('#concept-heading h1').invoke('text').should('equal', 'care institutions')
 
-    // check that concept mappings is not empty
-    cy.get('#concept-mappings').should('not.be.empty')
+    // check that the SKOSMOS object matches the newly loaded concept
+    cy.window().then((win) => {
+      expect(win.SKOSMOS.uri).to.equal('http://www.yso.fi/onto/yso/p6034');
+      expect(win.SKOSMOS.prefLabels[0]['label']).to.equal("care institutions");
+    })
   })
   it('clicking on hierarchy entries performs partial page load', () => {
     cy.visit('/test/en') // go to the "Test ontology" home page
@@ -77,5 +80,11 @@ describe('Vocabulary home page', () => {
 
     // check the concept prefLabel
     cy.get('#concept-heading h1').invoke('text').should('equal', 'Fish')
+
+    // check that the SKOSMOS object matches the newly loaded concept
+    cy.window().then((win) => {
+      expect(win.SKOSMOS.uri).to.equal('http://www.skosmos.skos/test/ta1');
+      expect(win.SKOSMOS.prefLabels[0]['label']).to.equal("Fish");
+    })
   })
 })

--- a/tests/test-vocab-data/test.ttl
+++ b/tests/test-vocab-data/test.ttl
@@ -177,6 +177,7 @@ test:ta1 a skos:Concept, meta:TestClass ;
         test:ta119,
         test:ta120 ;
     skos:prefLabel "Fish"@en ;
+    skos:exactMatch <http://www.wikidata.org/entity/Q152> ;
     skos:topConceptOf test:conceptscheme .
 
 test:conceptscheme a skos:ConceptScheme ;


### PR DESCRIPTION
## Reasons for creating this PR

This PR adds more Cypress tests for verifying functionality during and after partial page loads.

## Link to relevant issue(s), if any

- Closes #1598

## Description of the changes in this PR

- modify the Cypress tests for the concept page so that the most important tests related to dynamic functionality (title, URI, copy to clipboard, mappings) are run both with full and partial page loads
- change the declaration of the SKOSMOS global object from `const SKOSMOS` to `window.SKOSMOS`, and all references to it to `window.SKOSMOS` (this makes it accessible on the Cypress side)
 - add tests to the vocab-home cypress test suite for verifying partial page load functionality when clicking concepts in the sidebar (hierarchy and alphabetical index); also verify that `window.SKOSMOS` has been properly updated after partial page load

## Known problems or uncertainties in this PR

Cypress/Electron appears to have problems getting stuck with `cy.visit(url)` in case the URL has already been loaded by the tested application using AJAX style requests. The code in the PR avoids this situation by using different example concept pages for the partial page load tests than for the subsequent tests that perform full page loads. See [this comment](https://github.com/cypress-io/cypress/issues/27501#issuecomment-1980986170) for some details.

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
