### PR TITLE
implement fetchWithAbort and use it for partial page load, mappings & alphabetical index

### DIFF
--- a/resource/js/concept-mappings.js
+++ b/resource/js/concept-mappings.js
@@ -12,7 +12,8 @@ const conceptMappingsApp = Vue.createApp({
   },
   methods: {
     loadMappings () {
-      fetchWithAbort('rest/v1/' + window.SKOSMOS.vocab + '/mappings?uri=' + window.SKOSMOS.uri + '&external=true&clang=' + window.SKOSMOS.lang + '&lang=' + window.SKOSMOS.content_lang)
+      const url = 'rest/v1/' + window.SKOSMOS.vocab + '/mappings?uri=' + window.SKOSMOS.uri + '&external=true&clang=' + window.SKOSMOS.lang + '&lang=' + window.SKOSMOS.content_lang
+      fetchWithAbort(url, 'concept')
         .then(data => {
           return data.json()
         })

--- a/resource/js/concept-mappings.js
+++ b/resource/js/concept-mappings.js
@@ -1,4 +1,5 @@
 /* global Vue */
+/* global fetchWithAbort */
 
 const conceptMappingsApp = Vue.createApp({
   data () {
@@ -11,12 +12,19 @@ const conceptMappingsApp = Vue.createApp({
   },
   methods: {
     loadMappings () {
-      fetch('rest/v1/' + window.SKOSMOS.vocab + '/mappings?uri=' + window.SKOSMOS.uri + '&external=true&clang=' + window.SKOSMOS.lang + '&lang=' + window.SKOSMOS.content_lang)
+      fetchWithAbort('rest/v1/' + window.SKOSMOS.vocab + '/mappings?uri=' + window.SKOSMOS.uri + '&external=true&clang=' + window.SKOSMOS.lang + '&lang=' + window.SKOSMOS.content_lang)
         .then(data => {
           return data.json()
         })
         .then(data => {
           this.mappings = this.group_by(data.mappings, 'typeLabel')
+        })
+        .catch(error => {
+          if (error.name === 'AbortError') {
+            console.log('Fetching of mappings aborted')
+          } else {
+            throw error
+          }
         })
     },
     // from https://stackoverflow.com/a/71505541

--- a/resource/js/partial-page-load.js
+++ b/resource/js/partial-page-load.js
@@ -1,23 +1,23 @@
 const fetchWithAbort = (function () {
-  let controller = null
+  const controllers = {}
 
-  return function (url, options = {}) {
-    // Abort the previous request if it exists
-    if (controller) {
-      controller.abort()
+  return function (url, category, options = {}) {
+    // Abort the previous request in the same category if it exists
+    if (controllers[category]) {
+      controllers[category].abort()
     }
 
     // Create a new AbortController instance for this request
-    controller = new AbortController()
+    controllers[category] = new AbortController()
 
     // Add the AbortController signal to the fetch options
-    options.signal = controller.signal
+    options.signal = controllers[category].signal
 
     // Perform the fetch request
     return fetch(url, options)
       .then(response => {
-        // Clear the controller after the request is done
-        controller = null
+        // Remove the abort controller after the request is done
+        delete controllers[category]
         return response
       })
   }
@@ -78,7 +78,7 @@ const partialPageLoad = (event, pageUri) => {
   event.preventDefault()
 
   // fetching html content of the concept page
-  fetchWithAbort(pageUri)
+  fetchWithAbort(pageUri, 'concept')
     .then(data => {
       return data.text()
     })

--- a/resource/js/tab-alpha.js
+++ b/resource/js/tab-alpha.js
@@ -1,5 +1,5 @@
 /* global Vue */
-/* global partialPageLoad, getConceptURL */
+/* global partialPageLoad, getConceptURL, fetchWithAbort */
 
 const tabAlphaApp = Vue.createApp({
   data () {
@@ -47,13 +47,21 @@ const tabAlphaApp = Vue.createApp({
     },
     loadConcepts (letter) {
       this.loadingConcepts = true
-      fetch('rest/v1/' + window.SKOSMOS.vocab + '/index/' + letter + '?lang=' + window.SKOSMOS.lang + '&limit=50')
+      const url = 'rest/v1/' + window.SKOSMOS.vocab + '/index/' + letter + '?lang=' + window.SKOSMOS.lang + '&limit=50'
+      fetchWithAbort(url, 'alpha')
         .then(data => {
           return data.json()
         })
         .then(data => {
           this.indexConcepts = data.indexConcepts
           this.loadingConcepts = false
+        })
+        .catch(error => {
+          if (error.name === 'AbortError') {
+            console.log('Fetch aborted for letter ' + letter)
+          } else {
+            throw error
+          }
         })
     }
   },

--- a/tests/cypress/template/concept.cy.js
+++ b/tests/cypress/template/concept.cy.js
@@ -84,7 +84,7 @@ describe('Concept page', () => {
 
       // check the first mapping property name
       // NOTE: we need to increase the timeout as the mappings can take a long time to load
-      cy.get('.prop-mapping h2', {'timeout': 10000}).eq(0).contains('Closely matching concepts')
+      cy.get('.prop-mapping h2', {'timeout': 15000}).eq(0).contains('Closely matching concepts')
       // check the first mapping property values
       cy.get('.prop-mapping').eq(0).find('.prop-mapping-label').eq(0).contains('Labyrinths')
       cy.get('.prop-mapping').eq(0).find('.prop-mapping-label').eq(0).find('a').should('have.attr', 'href', 'http://id.loc.gov/authorities/subjects/sh85073793')

--- a/tests/cypress/template/vocab-home.cy.js
+++ b/tests/cypress/template/vocab-home.cy.js
@@ -73,7 +73,7 @@ describe('Vocabulary home page', () => {
     cy.get('#concept-mappings').should('not.be.empty')
 
     // check the second mapping property name
-    cy.get('.prop-mapping h2').eq(0).contains('Exactly matching concepts')
+    cy.get('.prop-mapping h2', {'timeout': 15000}).eq(0).contains('Exactly matching concepts')
     // check the second mapping property values
     cy.get('.prop-mapping').eq(0).find('.prop-mapping-label').eq(0).contains('vårdinrättningar (sv)')
     cy.get('.prop-mapping').eq(0).find('.prop-mapping-label').eq(0).find('a').invoke('text').should('equal', 'vårdinrättningar')
@@ -109,7 +109,7 @@ describe('Vocabulary home page', () => {
     cy.get('#concept-mappings').should('not.be.empty')
 
     // check the second mapping property name
-    cy.get('.prop-mapping h2').eq(0).contains('Exactly matching concepts')
+    cy.get('.prop-mapping h2', {'timeout': 15000}).eq(0).contains('Exactly matching concepts')
     // check the second mapping property values
     cy.get('.prop-mapping').eq(0).find('.prop-mapping-label').eq(0).find('a').invoke('text').should('equal', 'fish')
     cy.get('.prop-mapping').eq(0).find('.prop-mapping-label').eq(0).find('a').should('have.attr', 'href', 'http://www.wikidata.org/entity/Q152')


### PR DESCRIPTION
## Reasons for creating this PR

Trying to address the AJAX race conditions related to partial page load (#1561).

This PR defines a new JS function `fetchWithAbort` that wraps the `fetch` method but also keeps track of pending fetches (per category - there can be different categories) and aborts them early when it's called again.

## Link to relevant issue(s), if any

- Closes #1561

## Description of the changes in this PR

- define function `fetchWithAbort`
- use `fetchWithAbort` when performing partial page load and also when loading mappings for the concept page
- use `fetchWithAbort` when loading entries for the alphabetical index

## Known problems or uncertainties in this PR

- The PR doesn't interact with the search field autocomplete widget, which is still WIP in PR #1589. I think the fetchWithAbort function would be useful there as well.
- Should there be Cypress tests? How would they work?

## Checklist

- [x] phpUnit tests pass locally with my changes
- [ ] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
