### PR TITLE
Add automatic scrolling to hierarchy view

### DIFF
--- a/resource/js/tab-hierarchy.js
+++ b/resource/js/tab-hierarchy.js
@@ -182,7 +182,7 @@ tabHierApp.directive('click-tab-hierarchy', {
 tabHierApp.component('tab-hier-wrapper', {
   props: ['hierarchy', 'selectedConcept'],
   emits: ['loadChildren', 'selectConcept'],
-  mounted() {
+  mounted () {
     // scroll automatically to selected concept after the whole hierarchy tree has been mounted
     if (this.selectedConcept) {
       const selected = document.querySelectorAll('.list-group-item .selected')[0]
@@ -199,7 +199,7 @@ tabHierApp.component('tab-hier-wrapper', {
 
       list.scrollBy({
         top: selectedTop - listTop - listHeight / 2, // scroll top of selected element to the middle of list element
-        behavior: "smooth"
+        behavior: 'smooth'
       })
     }
   },
@@ -209,7 +209,7 @@ tabHierApp.component('tab-hier-wrapper', {
     },
     selectConcept (concept) {
       this.$emit('selectConcept', concept)
-    },
+    }
   },
   template: `
     <template v-for="(c, i) in hierarchy" >

--- a/resource/js/tab-hierarchy.js
+++ b/resource/js/tab-hierarchy.js
@@ -183,8 +183,8 @@ tabHierApp.component('tab-hier-wrapper', {
   props: ['hierarchy', 'selectedConcept'],
   emits: ['loadChildren', 'selectConcept'],
   mounted() {
-    // check that selected concept exists
-    if (document.querySelector('.list-group-item .selected')) {
+    // scroll automatically to selected concept after the whole hierarchy tree has been mounted
+    if (this.selectedConcept) {
       const selected = document.querySelectorAll('.list-group-item .selected')[0]
       const list = document.querySelector('#hierarchy-list')
 
@@ -193,12 +193,12 @@ tabHierApp.component('tab-hier-wrapper', {
       const listTop = list.getBoundingClientRect().top
 
       // height of the visible portion of the list element
-      const listHeight = list.getBoundingClientRect().bottom < window.innerHeight ?
-        list.getBoundingClientRect().height :
-        window.innerHeight - listTop
+      const listHeight = list.getBoundingClientRect().bottom < window.innerHeight
+        ? list.getBoundingClientRect().height
+        : window.innerHeight - listTop
 
       list.scrollBy({
-        top: selectedTop - listTop - listHeight / 2, // set top selected element to the middle of list element
+        top: selectedTop - listTop - listHeight / 2, // scroll top of selected element to the middle of list element
         behavior: "smooth"
       })
     }


### PR DESCRIPTION
## Reasons for creating this PR

Hierarchical view should be automatically scrolled to currently open concept on page load

## Link to relevant issue(s), if any

- Part of #1521

## Description of the changes in this PR

- Add functionality to scroll open concept into view in hierarchy
- Add a wrapper component to `hierarchy-tab` Vue component in order to only scroll after the whole hierarchy tree has mounted

This PR addresses requirement 4 in #1521

## Known problems or uncertainties in this PR

If open concept is too low in hierarchy, it might not be visible even after scrolling

## Checklist

- [ ] phpUnit tests pass locally with my changes
- [ ] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [ ] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [ ] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
