### PR TITLE
Reverts back to the original implicit usage of WCAG rules and changes the parameterization of CLI and GUI functions to their original state (#1611)

### DIFF
--- a/tests/cypress/support/accessibility.js
+++ b/tests/cypress/support/accessibility.js
@@ -1,7 +1,7 @@
 const a11yOptions = {
   runOnly: {
     type: 'tag',
-    values: ['wcag21aa']
+    values: ['wcag21aa'] // WCAG 2.1 Level AA
   }
 }
 const checkA11y = options => {
@@ -38,11 +38,11 @@ export function accessibilityTestRunner () {
 }
 function getConfigurationForCLITests () {
   return it('Logs (CLI)', () => {
-    cy.checkA11y(null, a11yOptions, terminalLog)
+    cy.checkA11y(null, null, terminalLog)
   })
 }
 function getConfigurationForGUITests () {
   return it('Check for possible accessibility errors at all logging levels set below in accordance with WCAG AA requirements', () => {
-    checkA11y(a11yOptions)
+    checkA11y(null, a11yOptions)
   })
 }

--- a/tests/cypress/support/accessibility.js
+++ b/tests/cypress/support/accessibility.js
@@ -1,9 +1,3 @@
-const a11yOptions = {
-  runOnly: {
-    type: 'tag',
-    values: ['wcag21aa'] // WCAG 2.1 Level AA
-  }
-}
 const checkA11y = options => {
   cy.checkA11y(null, options, violations => {
     console.log(`${violations.length} violation(s) detected`)
@@ -43,6 +37,6 @@ function getConfigurationForCLITests () {
 }
 function getConfigurationForGUITests () {
   return it('Check for possible accessibility errors at all logging levels set below in accordance with WCAG AA requirements', () => {
-    checkA11y(null, a11yOptions)
+    checkA11y(null)
   })
 }


### PR DESCRIPTION
## Reasons for creating this PR
To ensure that the required level of accessibility is used in tests

## Link to relevant issue(s), if any
#1611
- Closes #

## Description of the changes in this PR
Only the parameters of the functions _getConfigurationForCLITests_ and _getConfigurationForGUITests_ were modified. Both functions implicitly use, among others level EN 301 549, which corresponds to the officially required WCAG 2.1 AA level by public organizations (https://www.deque.com/en-301-549-compliance/).

The achieved WCAG levels (verified from the information reported in the test browser console) are:

cat.aria
wcag2a
wcag131
EN-301-549
EN-9.1.3.1

Guidance for the reviewer:

Copy the following code into the axe-vocab-home.cy.js file and run the tests normally. For example in the browser's inspector, you should now see a table containing accessibility issues and the test itself should report any problems.


```
import { accessibilityTestRunner } from '../support/accessibility.js'
import 'cypress-axe';

/* If you want the test to be skipped, add a skip command after the describe part:
    - test enabled: describe('Check accessibility of ...
    - test to be skipped: describe.skip('Check accessibility of ... */
describe('Check accessibility of the vocab-home page', () => {
  before(() => {
    cy.visit('/yso/fi/')
    cy.injectAxe()
  })

  accessibilityTestRunner()
})
```


## Known problems or uncertainties in this PR
The implementation is not very sophisticated, but it works. However, later we need to focus on this case and make a better implementation. For now, the most important thing is that the checks work fine.

There are no direct issues, but the use of explicitly defined rules is not working, even though the overall functionality works (the test setup accurately identifies errors).


## Checklist

- [ ] phpUnit tests pass locally with my changes
- [ ] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
