### PR TITLE
Make LOC HTTP prefLabel header parsing case-insensitive (Skosmos 2)

### DIFF
--- a/model/resolver/LOCResource.php
+++ b/model/resolver/LOCResource.php
@@ -17,7 +17,7 @@ class LOCResource extends RemoteResource
             $fd = fopen($this->uri, 'rb', false, $context);
             $headers = stream_get_meta_data($fd)['wrapper_data'];
             foreach ($headers as $header) {
-                if (strpos($header, 'X-PrefLabel:') === 0) {
+                if (strpos(strtolower($header), 'x-preflabel:') === 0) {
                     $elems = explode(' ', $header, 2);
                     $prefLabel = $elems[1];
                     $graph->addLiteral($this->uri, 'skos:prefLabel', $prefLabel, 'en');


### PR DESCRIPTION
## Reasons for creating this PR

Fix LCSH label lookups by making HTTP header parsing case-insensitive. See #1619
This PR backports the fix from Skosmos 3 to Skosmos 2.

## Link to relevant issue(s), if any

- Closes #1619 (for Skosmos 2)

## Description of the changes in this PR

Make LOC HTTP prefLabel header parsing case-insensitive in LOCResolver.php

## Known problems or uncertainties in this PR

n/a

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
