### PR TITLE
Search result tweaks for autocomplete

### DIFF
--- a/resource/js/vocab-search.js
+++ b/resource/js/vocab-search.js
@@ -10,7 +10,8 @@ const vocabSearch = Vue.createApp({
       renderedResultsList: [],
       languageStrings: null,
       msgs: null,
-      showDropdown: false
+      showDropdown: false,
+      showNotation: null
     }
   },
   mounted () {
@@ -20,6 +21,7 @@ const vocabSearch = Vue.createApp({
     this.languageStrings = window.SKOSMOS.language_strings[window.SKOSMOS.lang] ?? window.SKOSMOS.language_strings.en
     this.msgs = window.SKOSMOS.msgs[window.SKOSMOS.lang] ?? window.SKOSMOS.msgs.en
     this.renderedResultsList = []
+    this.showNotation = true
   },
   methods: {
     autoComplete () {
@@ -44,7 +46,7 @@ const vocabSearch = Vue.createApp({
       this.searchCounter = mySearchCounter
 
       let skosmosSearchUrl = 'rest/v1/' + window.SKOSMOS.vocab + '/search?'
-      const skosmosSearchUrlParams = new URLSearchParams({ query: this.formatSearchTerm(), lang: window.SKOSMOS.lang })
+      const skosmosSearchUrlParams = new URLSearchParams({ query: this.formatSearchTerm(), lang: window.SKOSMOS.lang, unique: true })
       skosmosSearchUrl += skosmosSearchUrlParams.toString()
 
       fetch(skosmosSearchUrl)
@@ -59,6 +61,12 @@ const vocabSearch = Vue.createApp({
     formatSearchTerm () {
       if (this.searchTerm.includes('*')) { return this.searchTerm }
       return this.searchTerm + '*'
+    },
+    notationMatches (searchTerm, notation) {
+      if (notation && notation.toLowerCase().includes(searchTerm.toLowerCase())) {
+        return true
+      }
+      return false
     },
     renderMatchingPart (searchTerm, label) {
       if (label) {
@@ -96,9 +104,15 @@ const vocabSearch = Vue.createApp({
           result.hitType = 'alt'
           result.hit = this.renderMatchingPart(renderedSearchTerm, result.altLabel)
           result.hitPref = this.renderMatchingPart(renderedSearchTerm, result.prefLabel)
-        } else if ('prefLabel' in result) {
-          result.hitType = 'pref'
-          result.hit = this.renderMatchingPart(renderedSearchTerm, result.prefLabel)
+        } else {
+          if (this.notationMatches(renderedSearchTerm, result.notation)) {
+            const notationMatch = this.renderMatchingPart(renderedSearchTerm, result.notation)
+            result.hitType = 'notation'
+            result.hit = notationMatch
+          } else if ('prefLabel' in result) {
+            result.hitType = 'pref'
+            result.hit = this.renderMatchingPart(renderedSearchTerm, result.prefLabel)
+          }
         }
         if ('uri' in result) { // create relative Skosmos page URL from the search result URI
           result.pageUrl = window.SKOSMOS.vocab + '/' + window.SKOSMOS.lang + '/page?'
@@ -111,6 +125,7 @@ const vocabSearch = Vue.createApp({
         }
         // use the translateType function to map translations for the type IRIs
         result.renderedType = result.type.map(this.translateType).join(', ')
+        result.showNotation = this.showNotation
       })
 
       if (this.renderedResultsList.length === 0) { // show no results message
@@ -148,7 +163,6 @@ const vocabSearch = Vue.createApp({
      * Show the existing autocomplete list if it was hidden by onClickOutside()
      */
     showAutoComplete () {
-      console.log('Show autocomplete')
       this.showDropdown = true
       this.$forceUpdate()
     }
@@ -184,6 +198,9 @@ const vocabSearch = Vue.createApp({
                   <div class="row pb-1">
                     <div class="col" v-if="result.hitType == 'hidden'">
                       <span class="result">
+                        <template v-if="result.showNotation">
+                          {{ result.notation }}&nbsp;
+                        </template>
                         <template v-if="result.hit.hasOwnProperty('match')">
                           {{ result.hit.before }}<b>{{ result.hit.match }}</b>{{ result.hit.after }}
                         </template>
@@ -194,14 +211,22 @@ const vocabSearch = Vue.createApp({
                     </div>
                     <div class="col" v-else-if="result.hitType == 'alt'">
                       <span>
-                        <template v-if="result.hit.hasOwnProperty('match')">
-                          {{ result.hit.before }}<b>{{ result.hit.match }}</b>{{ result.hit.after }}
-                        </template>
-                        <template v-else>
-                          {{ result.hit }}
-                        </template>
+                        <i>
+                          <template v-if="result.showNotation">
+                            {{ result.notation }}&nbsp;
+                          </template>
+                          <template v-if="result.hit.hasOwnProperty('match')">
+                            {{ result.hit.before }}<b>{{ result.hit.match }}</b>{{ result.hit.after }}
+                          </template>
+                          <template v-else>
+                            {{ result.hit }}
+                          </template>
+                        </i>
                       </span>
                       <span> &rarr;&nbsp;<span class="result">
+                          <template v-if="result.showNotation">
+                            {{ result.notation }}&nbsp;
+                          </template>
                           <template v-if="result.hitPref.hasOwnProperty('match')">
                             {{ result.hitPref.before }}<b>{{ result.hitPref.match }}</b>{{ result.hitPref.after }}
                           </template>
@@ -211,8 +236,24 @@ const vocabSearch = Vue.createApp({
                         </span>
                       </span>
                     </div>
+                    <div class="col" v-else-if="result.hitType == 'notation'">
+                      <span class="result">
+                        <template v-if="result.hit.hasOwnProperty('match')">
+                          {{ result.hit.before }}<b>{{ result.hit.match }}</b>{{ result.hit.after }}
+                        </template>
+                        <template v-else>
+                          {{ result.hit }}
+                        </template>
+                      </span>
+                      <span>
+                        &nbsp;{{ result.prefLabel }}
+                      </span>
+                    </div>
                     <div class="col" v-else-if="result.hitType == 'pref'">
                       <span class="result">
+                        <template v-if="result.showNotation">
+                          {{ result.notation }}&nbsp;
+                        </template>
                         <template v-if="result.hit.hasOwnProperty('match')">
                           {{ result.hit.before }}<b>{{ result.hit.match }}</b>{{ result.hit.after }}
                         </template>

--- a/resource/js/vocab-search.js
+++ b/resource/js/vocab-search.js
@@ -107,7 +107,7 @@ const vocabSearch = Vue.createApp({
           if (this.notationMatches(renderedSearchTerm, result.notation)) {
             const notationMatch = this.renderMatchingPart(renderedSearchTerm, result.notation)
             result.hitType = 'notation'
-            result.hit = notationMatch
+            result.hit = this.renderMatchingPart(renderedSearchTerm, result.notation)
           } else if ('prefLabel' in result) {
             result.hitType = 'pref'
             result.hit = this.renderMatchingPart(renderedSearchTerm, result.prefLabel)

--- a/resource/js/vocab-search.js
+++ b/resource/js/vocab-search.js
@@ -105,7 +105,6 @@ const vocabSearch = Vue.createApp({
           result.hitPref = this.renderMatchingPart(renderedSearchTerm, result.prefLabel)
         } else {
           if (this.notationMatches(renderedSearchTerm, result.notation)) {
-            const notationMatch = this.renderMatchingPart(renderedSearchTerm, result.notation)
             result.hitType = 'notation'
             result.hit = this.renderMatchingPart(renderedSearchTerm, result.notation)
           } else if ('prefLabel' in result) {

--- a/resource/js/vocab-search.js
+++ b/resource/js/vocab-search.js
@@ -21,7 +21,7 @@ const vocabSearch = Vue.createApp({
     this.languageStrings = window.SKOSMOS.language_strings[window.SKOSMOS.lang] ?? window.SKOSMOS.language_strings.en
     this.msgs = window.SKOSMOS.msgs[window.SKOSMOS.lang] ?? window.SKOSMOS.msgs.en
     this.renderedResultsList = []
-    this.showNotation = SKOSMOS.showNotation
+    this.showNotation = window.SKOSMOS.showNotation
   },
   methods: {
     autoComplete () {

--- a/resource/js/vocab-search.js
+++ b/resource/js/vocab-search.js
@@ -21,7 +21,7 @@ const vocabSearch = Vue.createApp({
     this.languageStrings = window.SKOSMOS.language_strings[window.SKOSMOS.lang] ?? window.SKOSMOS.language_strings.en
     this.msgs = window.SKOSMOS.msgs[window.SKOSMOS.lang] ?? window.SKOSMOS.msgs.en
     this.renderedResultsList = []
-    this.showNotation = true
+    this.showNotation = SKOSMOS.showNotation
   },
   methods: {
     autoComplete () {
@@ -44,7 +44,6 @@ const vocabSearch = Vue.createApp({
     search () {
       const mySearchCounter = this.searchCounter + 1 // make sure we can identify this search later in case of several ongoing searches
       this.searchCounter = mySearchCounter
-
       let skosmosSearchUrl = 'rest/v1/' + window.SKOSMOS.vocab + '/search?'
       const skosmosSearchUrlParams = new URLSearchParams({ query: this.formatSearchTerm(), lang: window.SKOSMOS.lang, unique: true })
       skosmosSearchUrl += skosmosSearchUrlParams.toString()

--- a/tests/cypress/template/vocab-search-bar.cy.js
+++ b/tests/cypress/template/vocab-search-bar.cy.js
@@ -39,7 +39,7 @@ describe('Vocab search bar', () => {
     cy.visit('/yso/fi/')
 
     cy.get('#search-field').type('kas'); // perform autocomplete search
-    cy.get('#search-autocomplete-results', { timeout: 20000 }).should('be.visible').children().should('have.length.greaterThan', 4);
+    cy.get('#search-autocomplete-results', { timeout: 20000 }).should('be.visible').children().should('have.length.greaterThan', 2);
   })
 
   it('No results message is displayed if no results are found', () => {
@@ -69,9 +69,9 @@ describe('Vocab search bar', () => {
     cy.wait(300);
     cy.get('#search-field').type('i');
     cy.get('#search-autocomplete-results', { timeout: 20000 }).should('be.visible'); // the autocomplete should appear
-    cy.get('#search-autocomplete-results').children().should('have.length', 2)
+    cy.get('#search-autocomplete-results').children().should('have.length', 1)
     cy.wait(10000); // wait extra 10 seconds to see if the 'ka' search adds results to the list
-    cy.get('#search-autocomplete-results').children().should('have.length', 2)
+    cy.get('#search-autocomplete-results').children().should('have.length', 1)
   })
 
   it('Clear button should hide the autocomplete list', () => {
@@ -107,16 +107,39 @@ describe('Vocab search bar', () => {
     cy.get('#search-autocomplete-results').should('not.be.visible'); // the autocomplete should disappear
   })
 
-  it('AltLabel search results should bold the matching parts of altLabel and prefLabel', () => {
+  it('AltLabel search results should bold the matching parts of altLabel', () => {
     // go to YSO vocab front page
     cy.visit('/yso/fi/')
 
-    cy.get('#search-field').type('zikkur');
+    cy.get('#search-field').type('assyro');
     cy.get('#search-autocomplete-results', { timeout: 20000 }).should('be.visible'); // the autocomplete should appear
 
-    cy.get('#search-autocomplete-results').within(() => { // the first result should have text 'zikkur' appearing twice in bold
-      cy.get('li').last().find('b').eq(0).should('have.text', 'zikkur')
-      cy.get('li').last().find('b').eq(1).should('have.text', 'zikkur')
+    cy.get('#search-autocomplete-results').within(() => { // the first result should have matching part of text 'assyrologia' appearing in bold
+      cy.get('li').last().find('b').eq(0).should('have.text', 'assyro')
+    })
+  })
+
+  it('AltLabel search results should be displayed in italics', () => {
+    // go to YSO vocab front page
+    cy.visit('/yso/fi/')
+
+    cy.get('#search-field').type('assyro');
+    cy.get('#search-autocomplete-results', { timeout: 20000 }).should('be.visible'); // the autocomplete should appear
+
+    cy.get('#search-autocomplete-results').within(() => { // the first result should have text 'assyrologia' appearing in italics
+      cy.get('li').last().find('i').eq(0).should('contain.text', 'assyrologia')
+    })
+  })
+
+  it('Notation search results should bold the matching parts of the notation', () => {
+    // go to YSO vocab front page
+    cy.visit('/yso/fi/')
+
+    cy.get('#search-field').type('51');
+    cy.get('#search-autocomplete-results', { timeout: 20000 }).should('be.visible'); // the autocomplete should appear
+
+    cy.get('#search-autocomplete-results').within(() => { // the first result should have text '51' appearing in bold
+      cy.get('li').last().find('b').eq(0).should('have.text', '51')
     })
   })
 


### PR DESCRIPTION
## Link to relevant issue(s), if any

- #1514 

## Description of the changes in this PR

* Filtered duplicate results with `unique=true` parameter. This changes the amount of search results recieved
* Alternate labels are displayed in italics
* Notation codes are shown if showNotation configuration parameter is set for the vocabulary
* Notation code results are returned and bolded if they match the search term

## Known problems or uncertainties in this PR

The language for the search is not set yet. That fuctionality should come in the follow-up pull request.


## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
