### PR TITLE
Add infinite scrolling to alphabetical index

### DIFF
--- a/resource/css/skosmos.css
+++ b/resource/css/skosmos.css
@@ -522,6 +522,10 @@ body {
     box-shadow: none;
   }
 
+  #sidebar .loading-message {
+    padding: 2rem 1rem;
+  }
+
   .sidebar-list {
     padding: 2rem 1rem 0 1rem;
     overflow-y: scroll;

--- a/resource/css/skosmos.css
+++ b/resource/css/skosmos.css
@@ -523,7 +523,7 @@ body {
   }
 
   .sidebar-list {
-    padding: 2rem 1rem;
+    padding: 2rem 1rem 0 1rem;
     overflow-y: scroll;
     scrollbar-color: var(--sidebar-scrollbar-thumb) var(--sidebar-scrollbar-bg);
     position: absolute;

--- a/resource/js/tab-alpha.js
+++ b/resource/js/tab-alpha.js
@@ -104,7 +104,7 @@ const tabAlphaApp = Vue.createApp({
         })
     },
     handleScrollEvent () {
-      listElement = this.$refs.tabAlpha.$refs.list
+      const listElement = this.$refs.tabAlpha.$refs.list
       if (listElement.scrollTop + listElement.clientHeight >= listElement.scrollHeight - 1) {
         this.loadMoreConcepts()
       }

--- a/resource/js/tab-alpha.js
+++ b/resource/js/tab-alpha.js
@@ -11,6 +11,7 @@ const tabAlphaApp = Vue.createApp({
       loadingLetters: false,
       loadingConcepts: false,
       loadingMoreConcepts: false,
+      loadingMessage: '',
       currentOffset: 0
     }
   },
@@ -25,6 +26,7 @@ const tabAlphaApp = Vue.createApp({
     if (document.querySelector('#alphabetical > a').classList.contains('active')) {
       this.loadLetters()
     }
+    this.loadingMessage = window.SKOSMOS.msgs[window.SKOSMOS.lang]['Loading more items'] ?? window.SKOSMOS.msgs.en['Loading more items']
   },
   methods: {
     handleClickAlphabeticalEvent () {
@@ -119,6 +121,7 @@ const tabAlphaApp = Vue.createApp({
         :loading-letters="loadingLetters"
         :loading-concepts="loadingConcepts"
         :loading-more-concepts="loadingMoreConcepts"
+        :loading-message="loadingMessage"
         @load-concepts="loadConcepts($event)"
         @select-concept="selectedConcept = $event"
         ref="tabAlpha"
@@ -141,7 +144,7 @@ tabAlphaApp.directive('click-tab-alphabetical', {
 })
 
 tabAlphaApp.component('tab-alpha', {
-  props: ['indexLetters', 'indexConcepts', 'selectedConcept', 'loadingLetters', 'loadingConcepts', 'loadingMoreConcepts'],
+  props: ['indexLetters', 'indexConcepts', 'selectedConcept', 'loadingLetters', 'loadingConcepts', 'loadingMoreConcepts', 'loadingMessage'],
   emits: ['loadConcepts', 'selectConcept'],
   inject: ['partialPageLoad', 'getConceptURL'],
   methods: {
@@ -165,8 +168,8 @@ tabAlphaApp.component('tab-alpha', {
   },
   template: `
     <template v-if="loadingLetters">
-      <div>
-        Loading...
+      <div class="loading-message">
+        {{ this.loadingMessage }}
       </div>
     </template>
     <template v-else>
@@ -179,9 +182,7 @@ tabAlphaApp.component('tab-alpha', {
     
     <div class="sidebar-list" :style="getListStyle()" ref="list">
       <template v-if="loadingConcepts">
-        <div>
-          Loading...
-        </div>
+        {{ this.loadingMessage }}
       </template>
       <template v-else>
         <ul class="list-group" v-if="indexConcepts.length !== 0">
@@ -195,7 +196,7 @@ tabAlphaApp.component('tab-alpha', {
             >{{ concept.prefLabel }}</a>
           </li>
           <template v-if="loadingMoreConcepts">
-            Loading...
+            {{ this.loadingMessage }}
           </template>
         </ul>
       </template>

--- a/resource/js/tab-alpha.js
+++ b/resource/js/tab-alpha.js
@@ -64,7 +64,7 @@ const tabAlphaApp = Vue.createApp({
         .then(data => {
           this.indexConcepts = data.indexConcepts
           this.selectedLetter = letter
-          this.currentOffset += 250
+          this.currentOffset = 250
           this.loadingConcepts = false
           // Add scrolling event listener back after concepts are loaded
           this.$refs.tabAlpha.$refs.list.addEventListener('scroll', this.handleScrollEvent)

--- a/resource/js/tab-alpha.js
+++ b/resource/js/tab-alpha.js
@@ -7,8 +7,11 @@ const tabAlphaApp = Vue.createApp({
       indexLetters: [],
       indexConcepts: [],
       selectedConcept: '',
+      selectedLetter: '',
       loadingLetters: false,
-      loadingConcepts: false
+      loadingConcepts: false,
+      loadingMoreConcepts: false,
+      currentOffset: 0
     }
   },
   provide () {
@@ -35,26 +38,36 @@ const tabAlphaApp = Vue.createApp({
     },
     loadLetters () {
       this.loadingLetters = true
+      // Remove scrolling event listener while letters are loaded
+      this.$refs.tabAlpha.$refs.list.removeEventListener('scroll', this.handleScrollEvent)
       fetch('rest/v1/' + window.SKOSMOS.vocab + '/index/?lang=' + window.SKOSMOS.lang)
         .then(data => {
           return data.json()
         })
         .then(data => {
           this.indexLetters = data.indexLetters
+          this.selectedLetter = this.indexLetters[0]
           this.loadingLetters = false
           this.loadConcepts(this.indexLetters[0])
         })
     },
     loadConcepts (letter) {
       this.loadingConcepts = true
-      const url = 'rest/v1/' + window.SKOSMOS.vocab + '/index/' + letter + '?lang=' + window.SKOSMOS.lang + '&limit=50'
+      this.currentOffset = 0
+      // Remove scrolling event listener while concepts are loaded
+      this.$refs.tabAlpha.$refs.list.removeEventListener('scroll', this.handleScrollEvent)
+      const url = 'rest/v1/' + window.SKOSMOS.vocab + '/index/' + letter + '?lang=' + window.SKOSMOS.lang + '&limit=250'
       fetchWithAbort(url, 'alpha')
         .then(data => {
           return data.json()
         })
         .then(data => {
           this.indexConcepts = data.indexConcepts
+          this.selectedLetter = letter
+          this.currentOffset += 250
           this.loadingConcepts = false
+          // Add scrolling event listener back after concepts are loaded
+          this.$refs.tabAlpha.$refs.list.addEventListener('scroll', this.handleScrollEvent)
         })
         .catch(error => {
           if (error.name === 'AbortError') {
@@ -63,6 +76,38 @@ const tabAlphaApp = Vue.createApp({
             throw error
           }
         })
+    },
+    loadMoreConcepts () {
+      this.loadingMoreConcepts = true
+      // Remove scrolling event listener while new concepts are loaded
+      this.$refs.tabAlpha.$refs.list.removeEventListener('scroll', this.handleScrollEvent)
+      const url = 'rest/v1/' + window.SKOSMOS.vocab + '/index/' + this.selectedLetter + '?lang=' + window.SKOSMOS.lang + '&limit=250&offset=' + this.currentOffset
+      fetchWithAbort(url, 'alpha')
+        .then(data => {
+          return data.json()
+        })
+        .then(data => {
+          this.indexConcepts.push(...data.indexConcepts)
+          this.currentOffset += 250
+          this.loadingMoreConcepts = false
+          // Add scrolling event listener back if more concepts were loaded
+          if (data.indexConcepts.length > 0) {
+            this.$refs.tabAlpha.$refs.list.addEventListener('scroll', this.handleScrollEvent)
+          }
+        })
+        .catch(error => {
+          if (error.name === 'AbortError') {
+            console.log('Fetch aborted for letter ' + this.selectedLetter + ' and offset ' + this.currentOffset)
+          } else {
+            throw error
+          }
+        })
+    },
+    handleScrollEvent () {
+      listElement = this.$refs.tabAlpha.$refs.list
+      if (listElement.scrollTop + listElement.clientHeight >= listElement.scrollHeight - 1) {
+        this.loadMoreConcepts()
+      }
     }
   },
   template: `
@@ -73,8 +118,10 @@ const tabAlphaApp = Vue.createApp({
         :selected-concept="selectedConcept"
         :loading-letters="loadingLetters"
         :loading-concepts="loadingConcepts"
+        :loading-more-concepts="loadingMoreConcepts"
         @load-concepts="loadConcepts($event)"
         @select-concept="selectedConcept = $event"
+        ref="tabAlpha"
       ></tab-alpha>
     </div>
   `
@@ -94,7 +141,7 @@ tabAlphaApp.directive('click-tab-alphabetical', {
 })
 
 tabAlphaApp.component('tab-alpha', {
-  props: ['indexLetters', 'indexConcepts', 'selectedConcept', 'loadingLetters', 'loadingConcepts'],
+  props: ['indexLetters', 'indexConcepts', 'selectedConcept', 'loadingLetters', 'loadingConcepts', 'loadingMoreConcepts'],
   emits: ['loadConcepts', 'selectConcept'],
   inject: ['partialPageLoad', 'getConceptURL'],
   methods: {
@@ -130,13 +177,13 @@ tabAlphaApp.component('tab-alpha', {
       </ul>
     </template>
     
-    <template v-if="loadingConcepts">
-      <div>
-        Loading...
-      </div>
-    </template>
-    <template v-else>
-      <div class="sidebar-list" :style="getListStyle()">
+    <div class="sidebar-list" :style="getListStyle()" ref="list">
+      <template v-if="loadingConcepts">
+        <div>
+          Loading...
+        </div>
+      </template>
+      <template v-else>
         <ul class="list-group" v-if="indexConcepts.length !== 0">
           <li v-for="concept in indexConcepts" class="list-group-item py-1 px-2">
             <template v-if="concept.altLabel">
@@ -147,9 +194,12 @@ tabAlphaApp.component('tab-alpha', {
               :href="getConceptURL(concept.uri)" @click="loadConcept($event, concept.uri)"
             >{{ concept.prefLabel }}</a>
           </li>
+          <template v-if="loadingMoreConcepts">
+            Loading...
+          </template>
         </ul>
-      </div>
-    </template>
+      </template>
+    </div>
   `
 })
 

--- a/resource/js/tab-alpha.js
+++ b/resource/js/tab-alpha.js
@@ -169,7 +169,7 @@ tabAlphaApp.component('tab-alpha', {
   template: `
     <template v-if="loadingLetters">
       <div class="loading-message">
-        {{ this.loadingMessage }}
+        {{ this.loadingMessage }} <i class="fa-solid fa-spinner fa-spin-pulse"></i>
       </div>
     </template>
     <template v-else>
@@ -182,7 +182,9 @@ tabAlphaApp.component('tab-alpha', {
     
     <div class="sidebar-list" :style="getListStyle()" ref="list">
       <template v-if="loadingConcepts">
-        {{ this.loadingMessage }}
+        <div>
+          {{ this.loadingMessage }} <i class="fa-solid fa-spinner fa-spin-pulse"></i>
+        </div>
       </template>
       <template v-else>
         <ul class="list-group" v-if="indexConcepts.length !== 0">
@@ -196,7 +198,9 @@ tabAlphaApp.component('tab-alpha', {
             >{{ concept.prefLabel }}</a>
           </li>
           <template v-if="loadingMoreConcepts">
-            {{ this.loadingMessage }}
+            <li class="list-group-item py-1 px-2">
+              {{ this.loadingMessage }} <i class="fa-solid fa-spinner fa-spin-pulse"></i>
+            </li>
           </template>
         </ul>
       </template>

--- a/src/view/scripts.inc
+++ b/src/view/scripts.inc
@@ -42,15 +42,18 @@ window.SKOSMOS = {
   "msgs" : { "fi": { "No results": "Ei hakutuloksia",
                      "http://www.yso.fi/onto/yso-meta/Concept": "Yleiskäsite",
                      "http://www.yso.fi/onto/yso-meta/Hierarchy": "Hierarkisoiva käsite",
-                     "skos:Concept": "Käsite"},
+                     "skos:Concept": "Käsite",
+                     "Loading more items": "Ladataan sisältöä"},
              "sv": { "No results": "Inga sökresultat",
                      "http://www.yso.fi/onto/yso-meta/Concept": "Allmänbegrepp",
                      "http://www.yso.fi/onto/yso-meta/Hierarchy": "Hierarki",
-                     "skos:Concept": "Begrepp"},
+                     "skos:Concept": "Begrepp",
+                     "Loading more items": "Laddar mera resultat"},
              "en": { "No results": "No results",
                      "http://www.yso.fi/onto/yso-meta/Concept": "General concept",
                      "http://www.yso.fi/onto/yso-meta/Hierarchy": "Hierarchy",
-                     "skos:Concept": "Concept"}}
+                     "skos:Concept": "Concept",
+                     "Loading more items": "Loading more items"}}
 }
 </script>
 


### PR DESCRIPTION
## Reasons for creating this PR

Alphabetical index does not load more concepts as it's scrolled. This PR adds functionality to address this.

## Link to relevant issue(s), if any

- Part of #1563

## Description of the changes in this PR

- Add an event listener for scrolling alphabetical list
- Detect when scrolling reaches the bottom of the list and load more concepts
- Add messages for loading content to `SKOSMOS` variable
- Add spinners when loading content

Addresses requirement 2 in #1563

## Known problems or uncertainties in this PR

- There could still be some bugs with loading (i.e. loading happening in the wrong order, concepts being loaded twice, some offsets being skipped, etc).

## Checklist

- [ ] phpUnit tests pass locally with my changes
- [ ] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [ ] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [ ] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
