### PR TITLE
SEO: improved titles for Skosmos 3 generated HTML pages

### DIFF
--- a/resource/translations/skosmos_en.po
+++ b/resource/translations/skosmos_en.po
@@ -882,3 +882,6 @@ msgstr "Breadcrumbs"
 
 msgid "Copy to clipboard"
 msgstr "Copy to clipboard"
+
+msgid "Error"
+msgstr "Error"

--- a/resource/translations/skosmos_fi.po
+++ b/resource/translations/skosmos_fi.po
@@ -891,3 +891,6 @@ msgstr "Murupolut"
 
 msgid "Copy to clipboard"
 msgstr "Kopioi leikepöydälle"
+
+msgid "Error"
+msgstr "Virhe"

--- a/resource/translations/skosmos_se.po
+++ b/resource/translations/skosmos_se.po
@@ -878,3 +878,6 @@ msgstr "Dovddaldat, mii spesifisere doahpaga sátneráju siste. "
 
 msgid "Information"
 msgstr "Diehtu"
+
+msgid "Error"
+msgstr "Error"

--- a/resource/translations/skosmos_sv.po
+++ b/resource/translations/skosmos_sv.po
@@ -890,3 +890,6 @@ msgstr "Brödsmulor"
 
 msgid "Copy to clipboard"
 msgstr "Kopiera till urklipp"
+
+msgid "Error"
+msgstr "Fel"

--- a/src/controller/WebController.php
+++ b/src/controller/WebController.php
@@ -42,17 +42,9 @@ class WebController extends Controller
         $this->twig = new \Twig\Environment($loader, array('cache' => $tmpDir,'auto_reload' => true));
         // used for setting the base href for the relative urls
         $this->twig->addGlobal("BaseHref", $this->getBaseHref());
-        // setting the service name string from the config.ttl
-        $this->twig->addGlobal("ServiceName", $this->model->getConfig()->getServiceName());
 
-        // setting the service custom css file from the config.ttl
-        if ($this->model->getConfig()->getCustomCss() !== null) {
-            $this->twig->addGlobal("ServiceCustomCss", $this->model->getConfig()->getCustomCss());
-        }
-        // used for displaying the ui language selection as a dropdown
-        if ($this->model->getConfig()->getUiLanguageDropdown() !== null) {
-            $this->twig->addGlobal("LanguageDropdown", $this->model->getConfig()->getUiLanguageDropdown());
-        }
+        // pass the GlobalConfig object to templates so they can access configuration
+        $this->twig->addGlobal("GlobalConfig", $this->model->getConfig());
 
         // setting the list of properties to be displayed in the search results
         $this->twig->addGlobal("PreferredProperties", array('skos:prefLabel', 'skos:narrower', 'skos:broader', 'skosmos:memberOf', 'skos:altLabel', 'skos:related'));

--- a/src/view/about.twig
+++ b/src/view/about.twig
@@ -1,6 +1,6 @@
 {% set pageType = 'about' %}
 {% extends "base-template.twig" %}
-{% block title %}: "About"{% endblock %}
+{% block title %}{{ "About" | trans}} - {{ GlobalConfig.serviceName }}{% endblock %}
 {% block content %}
 
 <div class="container">

--- a/src/view/base-template.twig
+++ b/src/view/base-template.twig
@@ -3,11 +3,16 @@
 <head>
 <base href="{{ BaseHref }}">
 <link rel="shortcut icon" href="favicon.ico">
+<title>{% block title %}{{ GlobalConfig.serviceName }}{% endblock %}</title>
 <meta http-equiv="X-UA-Compatible" content="IE=Edge">
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="format-detection" content="telephone=no">
-<meta name="generator" content="Skosmos {{ request.version }}" />
+<meta name="generator" content="Skosmos {{ request.version }}">
+<meta name="title" content="{{ block('title') }}">
+<meta property="og:title" content="{{ block('title') }}">
+<meta name="twitter:title" content="{{ block('title') }}">
+<meta name="twitter:card" content="summary">
 <link href="node_modules/bootstrap/dist/css/bootstrap.min.css" media="screen, print" rel="stylesheet" type="text/css">
 <link href="resource/css/fonts.css" media="screen, print" rel="stylesheet" type="text/css">
 <link href="resource/css/skosmos.css" media="screen, print" rel="stylesheet" type="text/css">
@@ -18,7 +23,6 @@
 <link href="{{ GlobalConfig.customCss }}" media="screen, print" rel="stylesheet" type="text/css">
 {% endif %}
 {% for plugin, files in request.plugins.pluginsCSS %}{% for file in files %}<link href="{{ file }}" media="screen, print" rel="stylesheet" type="text/css">{% endfor %}{% endfor %}
-<title>{{ GlobalConfig.serviceName }}{% block title %}{% endblock %}</title>
 </head>
 <body{% if request.vocabid == '' and request.page != 'feedback' and request.page != 'about' and request.page != 'search' %} class="bg-light frontpage-logo"{% else %} class="bg-medium vocab-{{ request.vocabid }}"{% endif %}>
   <header>

--- a/src/view/base-template.twig
+++ b/src/view/base-template.twig
@@ -14,11 +14,11 @@
 <link href="resource/fontawesome/css/fontawesome.css" rel="stylesheet">
 <link href="resource/fontawesome/css/solid.css" rel="stylesheet">
 <link href="resource/fontawesome/css/regular.css" rel="stylesheet">
-{% if ServiceCustomCss %}
-<link href="{{ ServiceCustomCss }}" media="screen, print" rel="stylesheet" type="text/css">
+{% if GlobalConfig.customCss %}
+<link href="{{ GlobalConfig.customCss }}" media="screen, print" rel="stylesheet" type="text/css">
 {% endif %}
 {% for plugin, files in request.plugins.pluginsCSS %}{% for file in files %}<link href="{{ file }}" media="screen, print" rel="stylesheet" type="text/css">{% endfor %}{% endfor %}
-<title>{{ ServiceName }}{% block title %}{% endblock %}</title>
+<title>{{ GlobalConfig.serviceName }}{% block title %}{% endblock %}</title>
 </head>
 <body{% if request.vocabid == '' and request.page != 'feedback' and request.page != 'about' and request.page != 'search' %} class="bg-light frontpage-logo"{% else %} class="bg-medium vocab-{{ request.vocabid }}"{% endif %}>
   <header>

--- a/src/view/concept.twig
+++ b/src/view/concept.twig
@@ -1,6 +1,6 @@
 {% set pageType = 'concept' %}
 {% extends "base-template.twig" %}
-{% block title %}: {{ vocab.shortName }}: {{ concept_label }}{% endblock %}
+{% block title %}{{ concept.label }} - {{ vocab.shortName }} - {{ GlobalConfig.serviceName }}{% endblock %}
 
 {% block content %}
   {% include "sidebar.inc" %}

--- a/src/view/error.twig
+++ b/src/view/error.twig
@@ -1,6 +1,6 @@
 {% set pageType = 'error' %}
 {% extends "base-template.twig" %}
-{% block title %}: "Error"{% endblock %}
+{% block title %}{{ "Error"| trans }} - {{ GlobalConfig.serviceName }}{% endblock %}
 {% block content %}
 {% set pageError = request.vocabid != '' and request.page == 'page' %}
 {% if pageError %}

--- a/src/view/feedback.twig
+++ b/src/view/feedback.twig
@@ -1,7 +1,7 @@
 {% set pageType = 'feedback' %}
 {% extends "base-template.twig" %}
 
-{% block title %}: "Feedback"{% endblock %}
+{% block title %}{{ "Feedback"|trans }} - {{GlobalConfig.serviceName}}{% endblock %}
 {% block content %}
 
   {% if feedback_sent %}

--- a/src/view/vocab-home.twig
+++ b/src/view/vocab-home.twig
@@ -1,6 +1,6 @@
 {% set pageType = 'vocab-home' %}
 {% extends "base-template.twig" %}
-{% block title %}: {{ vocab.title(request.contentLang) }}{% endblock %}
+{% block title %}{{ vocab.title(request.contentLang) }} - {{ GlobalConfig.serviceName }}{% endblock %}
 
 
 {% block content %}

--- a/src/view/vocab-search.twig
+++ b/src/view/vocab-search.twig
@@ -1,6 +1,6 @@
 {% set pageType = 'vocab-search' %}
 {% extends "base-template.twig" %}
-{% block title %}: {{ vocab.shortName(request.contentLang) }} '{{ term }}'{% endblock %}
+{% block title %}'{{ term }}' - {{ vocab.shortName(request.contentLang) }} - {{ GlobalConfig.serviceName }}{% endblock %}
 {% block content %}
 <main class="searchpage py-5" id="main-container" >
   <div class="container">

--- a/tests/cypress/template/about.cy.js
+++ b/tests/cypress/template/about.cy.js
@@ -1,4 +1,16 @@
 describe('About page', () => {
+  it('Contains title and title metadata', () => {
+    // go to the Skosmos about page
+    cy.visit('/en/about')
+
+    const expectedTitle = 'About - Skosmos being tested'
+    // check that the page has a HTML title
+    cy.get('title').invoke('text').should('equal', expectedTitle)
+    // check that the page has title metadata
+    cy.get('head meta[name="title"]').should('have.attr', 'content', expectedTitle);
+    cy.get('head meta[name="twitter:title"]').should('have.attr', 'content', expectedTitle);
+    cy.get('head meta[property="og:title"]').should('have.attr', 'content', expectedTitle);
+  })
   it('Contains version number information', () => {
     // go to the Skosmos about page
     cy.visit('/en/about')

--- a/tests/cypress/template/concept.cy.js
+++ b/tests/cypress/template/concept.cy.js
@@ -130,6 +130,17 @@ describe('Concept page', () => {
 
   // tests that only need to be executed with full page load
 
+  it('Contains title and title metadata', () => {
+    cy.visit('/yso/en/page/p1265') // go to "archaeology" concept page
+
+    const expectedTitle = 'archaeology - YSO - Skosmos being tested'
+    // check that the page has a HTML title
+    cy.get('title').invoke('text').should('equal', expectedTitle)
+    // check that the page has title metadata
+    cy.get('head meta[name="title"]').should('have.attr', 'content', expectedTitle);
+    cy.get('head meta[name="twitter:title"]').should('have.attr', 'content', expectedTitle);
+    cy.get('head meta[property="og:title"]').should('have.attr', 'content', expectedTitle);
+  })
   it("doesn't contain breadcrumbs for top concepts", () => {
     cy.visit('/yso/en/page/p4762') // go to "objects" concept page
 

--- a/tests/cypress/template/error.cy.js
+++ b/tests/cypress/template/error.cy.js
@@ -1,4 +1,16 @@
 describe('Error page', () => {
+  it('Contains title and title metadata', () => {
+    // go to a non-existing page
+    cy.visit('/404', {failOnStatusCode: false})
+
+    const expectedTitle = 'Error - Skosmos being tested'
+    // check that the page has a HTML title
+    cy.get('title').invoke('text').should('equal', expectedTitle)
+    // check that the page has title metadata
+    cy.get('head meta[name="title"]').should('have.attr', 'content', expectedTitle);
+    cy.get('head meta[name="twitter:title"]').should('have.attr', 'content', expectedTitle);
+    cy.get('head meta[property="og:title"]').should('have.attr', 'content', expectedTitle);
+  })
   it('Contains 404 error code', () => {
     // check that HTTP code is 404 when accessing a non-existing page
     cy.request({url: '/404', failOnStatusCode: false}).its('status').should('equal', 404)

--- a/tests/cypress/template/feedback.cy.js
+++ b/tests/cypress/template/feedback.cy.js
@@ -1,4 +1,16 @@
 describe('Feedback page', () => {
+  it('Contains title and title metadata', () => {
+    // go to the general feedback page
+    cy.visit('/en/feedback')
+
+    const expectedTitle = 'Feedback - Skosmos being tested'
+    // check that the page has a HTML title
+    cy.get('title').invoke('text').should('equal', expectedTitle)
+    // check that the page has title metadata
+    cy.get('head meta[name="title"]').should('have.attr', 'content', expectedTitle);
+    cy.get('head meta[name="twitter:title"]').should('have.attr', 'content', expectedTitle);
+    cy.get('head meta[property="og:title"]').should('have.attr', 'content', expectedTitle);
+  })
   it('Sends feedback', () => {
     // go to the general feedback page
     cy.visit('/en/feedback')
@@ -35,6 +47,18 @@ describe('Feedback page', () => {
 })
 
 describe('Vocab feedback page', () => {
+  it('Contains title and title metadata', () => {
+    // go to test vocab feedback page
+    cy.visit('/test/en/feedback')
+
+    const expectedTitle = 'Feedback - Skosmos being tested'
+    // check that the page has a HTML title
+    cy.get('title').invoke('text').should('equal', expectedTitle)
+    // check that the page has title metadata
+    cy.get('head meta[name="title"]').should('have.attr', 'content', expectedTitle);
+    cy.get('head meta[name="twitter:title"]').should('have.attr', 'content', expectedTitle);
+    cy.get('head meta[property="og:title"]').should('have.attr', 'content', expectedTitle);
+  })
   it('Displays correct vocab option', () => {
     // go to test vocab feedback page
     cy.visit('/test/en/feedback')

--- a/tests/cypress/template/landing.cy.js
+++ b/tests/cypress/template/landing.cy.js
@@ -1,4 +1,16 @@
 describe('Landing page', () => {
+  it('Contains title and title metadata', () => {
+    // go to the Skosmos front page
+    cy.visit('/')
+
+    const expectedTitle = 'Skosmos being tested'
+    // check that the page has a HTML title
+    cy.get('title').invoke('text').should('equal', expectedTitle)
+    // check that the page has title metadata
+    cy.get('head meta[name="title"]').should('have.attr', 'content', expectedTitle);
+    cy.get('head meta[name="twitter:title"]').should('have.attr', 'content', expectedTitle);
+    cy.get('head meta[property="og:title"]').should('have.attr', 'content', expectedTitle);
+  })
   it('links to vocabulary home', () => {
     // go to the Skosmos front page
     cy.visit('/')

--- a/tests/cypress/template/vocab-home.cy.js
+++ b/tests/cypress/template/vocab-home.cy.js
@@ -1,4 +1,15 @@
 describe('Vocabulary home page', () => {
+  it('Contains title and title metadata', () => {
+    cy.visit('/test/en') // go to the "Test ontology" home page
+
+    const expectedTitle = 'Test ontology - Skosmos being tested'
+    // check that the page has a HTML title
+    cy.get('title').invoke('text').should('equal', expectedTitle)
+    // check that the page has title metadata
+    cy.get('head meta[name="title"]').should('have.attr', 'content', expectedTitle);
+    cy.get('head meta[name="twitter:title"]').should('have.attr', 'content', expectedTitle);
+    cy.get('head meta[property="og:title"]').should('have.attr', 'content', expectedTitle);
+  })
   it('contains vocabulary title', () => {
     cy.visit('/test/en') // go to the "Test ontology" home page
 

--- a/tests/cypress/template/vocab-search.cy.js
+++ b/tests/cypress/template/vocab-search.cy.js
@@ -1,6 +1,17 @@
 describe('Vocabulary search page', () => {
-      const vocab = 'test';
-      const term = 'bass';
+  const vocab = 'test';
+  const term = 'bass';
+  it('Contains title and title metadata', () => {
+      cy.visit(`/${vocab}/en/search?clang=en&q=${term}`)
+
+      const expectedTitle = "'bass' - Test short - Skosmos being tested"
+      // check that the page has a HTML title
+      cy.get('title').invoke('text').should('equal', expectedTitle)
+      // check that the page has title metadata
+      cy.get('head meta[name="title"]').should('have.attr', 'content', expectedTitle);
+      cy.get('head meta[name="twitter:title"]').should('have.attr', 'content', expectedTitle);
+      cy.get('head meta[property="og:title"]').should('have.attr', 'content', expectedTitle);
+  })
   it('Contains correct amount of search results ', () => {
       const count = 1;
       const searchCountTitle = `${count} results for \'${term}\'`;


### PR DESCRIPTION
## Reasons for creating this PR

Improve search engine optimization in Skosmos 3 by making the `<title>` values and related metadata (`title`, `twitter:title`, `og:title`) conform to the specification in https://github.com/NatLibFi/Skosmos/issues/1533#issuecomment-2063290242 .

This PR only handles the titles, not descriptions. The descriptions will have to be implemented in a subsequent PR.

## Link to relevant issue(s), if any

- Part of #1533

## Description of the changes in this PR

- refactor: pass the GlobalConfig instance to the Twig templates, instead of individual configuration settings in separate variables
- adapt the Twig templates to use the GlobalConfig instance, and set their title metadata to match the specification
- add Cypress tests to verify the title values

## Known problems or uncertainties in this PR

- this PR doesn't implement long titles (skosmos:serviceNameLong setting) for the landing page, but just uses regular serviceName for the landing page title; implementing long titles is left to another PR

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
