### PR TITLE
Sort concepts in hierarchical view by label and locale

### DIFF
--- a/resource/js/tab-hierarchy.js
+++ b/resource/js/tab-hierarchy.js
@@ -155,8 +155,9 @@ const tabHierApp = Vue.createApp({
       }
     },
     compareLabels (a, b) {
-      const labelA = a.label ? a.label : a.prefLabel
-      const labelB = b.label ? b.label : b.prefLabel
+      // Set labels as label, prefLabel or an empty string if there are no lables
+      const labelA = a.label ? a.label : (a.prefLabel ? a.prefLabel : "")
+      const labelB = b.label ? b.label : (b.prefLabel ? b.prefLabel : "")
       const lang = window.SKOSMOS.content_lang ? window.SKOSMOS.content_lang : window.SKOSMOS.lang
 
       return labelA.localeCompare(labelB, lang)

--- a/resource/js/tab-hierarchy.js
+++ b/resource/js/tab-hierarchy.js
@@ -154,9 +154,9 @@ const tabHierApp = Vue.createApp({
         width: width + 'px'
       }
     },
-    compareLabels(a, b) {
-      const labelA = a["label"] ? a["label"] : a["prefLabel"]
-      const labelB = b["label"] ? b["label"] : b["prefLabel"]
+    compareLabels (a, b) {
+      const labelA = a.label ? a.label : a.prefLabel
+      const labelB = b.label ? b.label : b.prefLabel
       const lang = window.SKOSMOS.content_lang ? window.SKOSMOS.content_lang : window.SKOSMOS.lang
 
       return labelA.localeCompare(labelB, lang)

--- a/resource/js/tab-hierarchy.js
+++ b/resource/js/tab-hierarchy.js
@@ -47,7 +47,7 @@ const tabHierApp = Vue.createApp({
 
           this.hierarchy = []
 
-          for (const c of data.topconcepts.sort((a, b) => a.label.localeCompare(b.label, window.SKOSMOS.content_lang))) {
+          for (const c of data.topconcepts.sort((a, b) => this.compareLabels(a, b))) {
             this.hierarchy.push({ uri: c.uri, label: c.label, hasChildren: c.hasChildren, children: [], isOpen: false })
           }
 
@@ -67,7 +67,7 @@ const tabHierApp = Vue.createApp({
           this.hierarchy = []
 
           // transform broaderTransitive to an array and sort it
-          const bt = Object.values(data.broaderTransitive).sort((a, b) => a.prefLabel.localeCompare(b.prefLabel, window.SKOSMOS.content_lang))
+          const bt = Object.values(data.broaderTransitive).sort((a, b) => this.compareLabels(a, b))
           const parents = [] // queue of nodes in hierarchy tree with potential missing child nodes
 
           // add top concepts to hierarchy tree
@@ -76,7 +76,7 @@ const tabHierApp = Vue.createApp({
               if (concept.narrower) {
                 // children of the current concept
                 const children = concept.narrower
-                  .sort((a, b) => a.label.localeCompare(b.label, window.SKOSMOS.content_lang))
+                  .sort((a, b) => this.compareLabels(a, b))
                   .map(c => {
                     return { uri: c.uri, label: c.label, hasChildren: c.hasChildren, children: [], isOpen: false }
                   })
@@ -112,7 +112,7 @@ const tabHierApp = Vue.createApp({
                 const conceptNode = parent.children.find(c => c.uri === concept.uri)
                 // children of current concept
                 const children = concept.narrower
-                  .sort((a, b) => a.label.localeCompare(b.label, window.SKOSMOS.content_lang))
+                  .sort((a, b) => this.compareLabels(a, b))
                   .map(c => {
                     return { uri: c.uri, label: c.label, hasChildren: c.hasChildren, children: [], isOpen: false }
                   })
@@ -139,7 +139,7 @@ const tabHierApp = Vue.createApp({
           })
           .then(data => {
             console.log('data', data)
-            for (const c of data.narrower.sort((a, b) => a.prefLabel.localeCompare(b.prefLabel, window.SKOSMOS.content_lang))) {
+            for (const c of data.narrower.sort((a, b) => this.compareLabels(a, b))) {
               concept.children.push({ uri: c.uri, label: c.prefLabel, hasChildren: c.hasChildren, children: [], isOpen: false })
             }
             console.log('hier', this.hierarchy)
@@ -153,6 +153,13 @@ const tabHierApp = Vue.createApp({
         height: 'calc( 100% - ' + height + 'px)',
         width: width + 'px'
       }
+    },
+    compareLabels(a, b) {
+      const labelA = a["label"] ? a["label"] : a["prefLabel"]
+      const labelB = b["label"] ? b["label"] : b["prefLabel"]
+      const lang = window.SKOSMOS.content_lang ? window.SKOSMOS.content_lang : window.SKOSMOS.lang
+
+      return labelA.localeCompare(labelB, lang)
     }
   },
   template: `

--- a/resource/js/tab-hierarchy.js
+++ b/resource/js/tab-hierarchy.js
@@ -38,7 +38,7 @@ const tabHierApp = Vue.createApp({
     },
     loadTopConcepts () {
       this.loading = true
-      fetch('rest/v1/' + window.SKOSMOS.vocab + '/topConcepts/?lang=' + window.SKOSMOS.lang)
+      fetch('rest/v1/' + window.SKOSMOS.vocab + '/topConcepts/?lang=' + window.SKOSMOS.content_lang)
         .then(data => {
           return data.json()
         })
@@ -47,7 +47,7 @@ const tabHierApp = Vue.createApp({
 
           this.hierarchy = []
 
-          for (const c of data.topconcepts.sort((a, b) => a.label.localeCompare(b.label, window.SKOSMOS.lang))) {
+          for (const c of data.topconcepts.sort((a, b) => a.label.localeCompare(b.label, window.SKOSMOS.content_lang))) {
             this.hierarchy.push({ uri: c.uri, label: c.label, hasChildren: c.hasChildren, children: [], isOpen: false })
           }
 
@@ -57,7 +57,7 @@ const tabHierApp = Vue.createApp({
     },
     loadConceptHierarchy () {
       this.loading = true
-      fetch('rest/v1/' + window.SKOSMOS.vocab + '/hierarchy/?uri=' + window.SKOSMOS.uri + '&lang=' + window.SKOSMOS.lang)
+      fetch('rest/v1/' + window.SKOSMOS.vocab + '/hierarchy/?uri=' + window.SKOSMOS.uri + '&lang=' + window.SKOSMOS.content_lang)
         .then(data => {
           return data.json()
         })
@@ -67,7 +67,7 @@ const tabHierApp = Vue.createApp({
           this.hierarchy = []
 
           // transform broaderTransitive to an array and sort it
-          const bt = Object.values(data.broaderTransitive).sort((a, b) => a.prefLabel.localeCompare(b.prefLabel, window.SKOSMOS.lang))
+          const bt = Object.values(data.broaderTransitive).sort((a, b) => a.prefLabel.localeCompare(b.prefLabel, window.SKOSMOS.content_lang))
           const parents = [] // queue of nodes in hierarchy tree with potential missing child nodes
 
           // add top concepts to hierarchy tree
@@ -76,7 +76,7 @@ const tabHierApp = Vue.createApp({
               if (concept.narrower) {
                 // children of the current concept
                 const children = concept.narrower
-                  .sort((a, b) => a.label.localeCompare(b.label, window.SKOSMOS.lang))
+                  .sort((a, b) => a.label.localeCompare(b.label, window.SKOSMOS.content_lang))
                   .map(c => {
                     return { uri: c.uri, label: c.label, hasChildren: c.hasChildren, children: [], isOpen: false }
                   })
@@ -112,7 +112,7 @@ const tabHierApp = Vue.createApp({
                 const conceptNode = parent.children.find(c => c.uri === concept.uri)
                 // children of current concept
                 const children = concept.narrower
-                  .sort((a, b) => a.label.localeCompare(b.label, window.SKOSMOS.lang))
+                  .sort((a, b) => a.label.localeCompare(b.label, window.SKOSMOS.content_lang))
                   .map(c => {
                     return { uri: c.uri, label: c.label, hasChildren: c.hasChildren, children: [], isOpen: false }
                   })
@@ -133,13 +133,13 @@ const tabHierApp = Vue.createApp({
     loadChildren (concept) {
       // load children only if concept has children but they have not been loaded yet
       if (concept.children.length === 0 && concept.hasChildren) {
-        fetch('rest/v1/' + window.SKOSMOS.vocab + '/children?uri=' + concept.uri + '&lang=' + window.SKOSMOS.lang)
+        fetch('rest/v1/' + window.SKOSMOS.vocab + '/children?uri=' + concept.uri + '&lang=' + window.SKOSMOS.content_lang)
           .then(data => {
             return data.json()
           })
           .then(data => {
             console.log('data', data)
-            for (const c of data.narrower.sort((a, b) => a.prefLabel.localeCompare(b.prefLabel, window.SKOSMOS.lang))) {
+            for (const c of data.narrower.sort((a, b) => a.prefLabel.localeCompare(b.prefLabel, window.SKOSMOS.content_lang))) {
               concept.children.push({ uri: c.uri, label: c.prefLabel, hasChildren: c.hasChildren, children: [], isOpen: false })
             }
             console.log('hier', this.hierarchy)

--- a/resource/js/tab-hierarchy.js
+++ b/resource/js/tab-hierarchy.js
@@ -156,8 +156,8 @@ const tabHierApp = Vue.createApp({
     },
     compareLabels (a, b) {
       // Set labels as label, prefLabel or an empty string if there are no lables
-      const labelA = a.label ? a.label : (a.prefLabel ? a.prefLabel : "")
-      const labelB = b.label ? b.label : (b.prefLabel ? b.prefLabel : "")
+      const labelA = a.label ? a.label : (a.prefLabel ? a.prefLabel : '')
+      const labelB = b.label ? b.label : (b.prefLabel ? b.prefLabel : '')
       const lang = window.SKOSMOS.content_lang ? window.SKOSMOS.content_lang : window.SKOSMOS.lang
 
       return labelA.localeCompare(labelB, lang)

--- a/resource/js/tab-hierarchy.js
+++ b/resource/js/tab-hierarchy.js
@@ -190,7 +190,7 @@ tabHierApp.component('tab-hier-wrapper', {
   mounted () {
     // scroll automatically to selected concept after the whole hierarchy tree has been mounted
     if (this.selectedConcept) {
-      const selected = document.querySelectorAll('.list-group-item .selected')[0]
+      const selected = document.querySelectorAll('#hierarchy-list .list-group-item .selected')[0]
       const list = document.querySelector('#hierarchy-list')
 
       // distances to the top of the page

--- a/resource/js/tab-hierarchy.js
+++ b/resource/js/tab-hierarchy.js
@@ -156,8 +156,8 @@ const tabHierApp = Vue.createApp({
     },
     compareLabels (a, b) {
       // Set labels as label, prefLabel or an empty string if there are no lables
-      const labelA = a.label ? a.label : (a.prefLabel ? a.prefLabel : '')
-      const labelB = b.label ? b.label : (b.prefLabel ? b.prefLabel : '')
+      const labelA = a.label || a.prefLabel || ''
+      const labelB = b.label || b.prefLabel || ''
       const lang = window.SKOSMOS.content_lang ? window.SKOSMOS.content_lang : window.SKOSMOS.lang
 
       return labelA.localeCompare(labelB, lang)

--- a/tests/cypress/template/vocab-home.cy.js
+++ b/tests/cypress/template/vocab-home.cy.js
@@ -61,7 +61,7 @@ describe('Vocabulary home page', () => {
     cy.get('#tab-alphabetical').contains('a', 'care institutions').click()
 
     // check the concept prefLabel
-    cy.get('#concept-heading h1').invoke('text').should('equal', 'care institutions')
+    cy.get('#concept-heading h1', {'timeout': 15000}).invoke('text').should('equal', 'care institutions')
 
     // check that the SKOSMOS object matches the newly loaded concept
     cy.window().then((win) => {

--- a/tests/cypress/template/vocab-home.cy.js
+++ b/tests/cypress/template/vocab-home.cy.js
@@ -61,7 +61,7 @@ describe('Vocabulary home page', () => {
     cy.get('#tab-alphabetical').contains('a', 'care institutions').click()
 
     // check the concept prefLabel
-    cy.get('#concept-heading h1', {'timeout': 15000}).invoke('text').should('equal', 'care institutions')
+    cy.get('#concept-heading h1').invoke('text').should('equal', 'care institutions')
 
     // check that the SKOSMOS object matches the newly loaded concept
     cy.window().then((win) => {


### PR DESCRIPTION
## Reasons for creating this PR

Concepts in hierarchical view are not currently sorted. This PR add functionality to sort concepts by their label according to locale.

## Link to relevant issue(s), if any

- Part of #1521 

## Description of the changes in this PR

Sort concepts in hierarchy by label and locale when they are added to hierarchy tree

Addresses requirement 6d in #1521 

## Known problems or uncertainties in this PR

Concepts are only sorted by label and locale, not notation codes or notation sorting style

## Checklist

- [ ] phpUnit tests pass locally with my changes
- [ ] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [ ] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [ ] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
