### PR TITLE
Redesign initialization of Model and GlobalConfig to avoid chicken-and-egg situation

### DIFF
--- a/src/entity.php
+++ b/src/entity.php
@@ -8,8 +8,7 @@ require_once '../vendor/autoload.php';
 header("Access-Control-Allow-Origin: *"); // enable CORS
 
 try {
-    $config = new GlobalConfig();
-    $model = new Model($config);
+    $model = new Model();
     $controller = new EntityController($model);
     $request = new Request($model);
 

--- a/src/index.php
+++ b/src/index.php
@@ -13,8 +13,7 @@ try {
     return;
 }
 
-$config = new GlobalConfig();
-$model = new Model($config);
+$model = new Model();
 $controller = new WebController($model);
 $request = new Request($model);
 
@@ -29,7 +28,7 @@ if (sizeof($parts) <= 2) {
     $lang = sizeof($parts) == 2 && $parts[1] !== '' ? $parts[1] : $controller->guessLanguage($request);
     header("Location: " . $lang . "/");
 } else {
-    if (array_key_exists($parts[1], $config->getLanguages())) { // global pages
+    if (array_key_exists($parts[1], $model->getConfig()->getLanguages())) { // global pages
         $request->setLang($parts[1]);
         $model->setLocale($parts[1]);
         $content_lang = $request->getQueryParam('clang');
@@ -60,7 +59,7 @@ if (sizeof($parts) <= 2) {
             $newurl = $controller->getBaseHref() . $vocab . "/" . $lang . "/";
             header("Location: " . $newurl);
         } else {
-            if (array_key_exists($parts[2], $config->getLanguages())) {
+            if (array_key_exists($parts[2], $model->getConfig()->getLanguages())) {
                 $lang = $parts[2];
                 $content_lang = $request->getQueryParam('clang') ? $request->getQueryParam('clang') : $lang;
                 $request->setContentLang($content_lang);

--- a/src/index.php
+++ b/src/index.php
@@ -13,7 +13,14 @@ try {
     return;
 }
 
-$model = new Model();
+try {
+    $model = new Model();
+} catch (Exception $e) {
+    header("HTTP/1.1 500 Internal Server Error");
+    echo "Error: " . $e->getMessage();
+    exit(1);
+}
+
 $controller = new WebController($model);
 $request = new Request($model);
 

--- a/src/model/DataObject.php
+++ b/src/model/DataObject.php
@@ -24,12 +24,8 @@ class DataObject
      * @param EasyRdf\Resource $resource
      * @throws Exception
      */
-    public function __construct($model, $resource)
+    public function __construct(Model $model, EasyRdf\Resource $resource)
     {
-        if (!($model instanceof Model) || !($resource instanceof EasyRdf\Resource)) {
-            throw new InvalidArgumentException('Invalid constructor parameter given to DataObject.');
-        }
-
         $this->model = $model;
         $this->resource = $resource;
         $this->order = array();

--- a/src/model/GlobalConfig.php
+++ b/src/model/GlobalConfig.php
@@ -33,16 +33,11 @@ class GlobalConfig extends BaseConfig
     public function __construct(Model $model, $config_name='../../config.ttl')
     {
         $this->cache = new Cache();
-        try {
-            $this->filePath = realpath(dirname(__FILE__) . "/" . $config_name);
-            if (!file_exists($this->filePath)) {
-                throw new Exception('config.ttl file is missing, please provide one.');
-            }
-            $resource = $this->initializeConfig();
-        } catch (Exception $e) {
-            echo "Error: " . $e->getMessage();
-            return;
+        $this->filePath = realpath(dirname(__FILE__) . "/" . $config_name);
+        if (!file_exists($this->filePath)) {
+            throw new Exception('config.ttl file is missing, please provide one.');
         }
+        $resource = $this->initializeConfig();
         parent::__construct($model, $resource);
     }
 
@@ -66,39 +61,34 @@ class GlobalConfig extends BaseConfig
      */
     private function initializeConfig()
     {
-        try {
-            // retrieve last modified time for config file (filemtime returns int|bool!)
-            $configModifiedTime = filemtime($this->filePath);
-            if (!is_bool($configModifiedTime)) {
-                $this->configModifiedTime = $configModifiedTime;
-            }
-            // use APC user cache to store parsed config.ttl configuration
-            if ($this->cache->isAvailable() && !is_null($this->configModifiedTime)) {
-                // @codeCoverageIgnoreStart
-                $key = realpath($this->filePath) . ", " . $this->configModifiedTime;
-                $nskey = "namespaces of " . $key;
-                $this->graph = $this->cache->fetch($key);
-                $this->namespaces = $this->cache->fetch($nskey);
-                if ($this->graph === false || $this->namespaces === false) { // was not found in cache
-                    $this->parseConfig($this->filePath);
-                    $this->cache->store($key, $this->graph);
-                    $this->cache->store($nskey, $this->namespaces);
-                }
-            // @codeCoverageIgnoreEnd
-            } else { // APC not available, parse on every request
-                $this->parseConfig($this->filePath);
-            }
-            $this->initializeNamespaces();
-
-            $configResources = $this->graph->allOfType("skosmos:Configuration");
-            if (is_null($configResources) || !is_array($configResources) || count($configResources) !== 1) {
-                throw new Exception("config.ttl must have exactly one skosmos:Configuration");
-            }
-            return $configResources[0];
-        } catch (Exception $e) {
-            echo "Error: " . $e->getMessage();
+        // retrieve last modified time for config file (filemtime returns int|bool!)
+        $configModifiedTime = filemtime($this->filePath);
+        if (!is_bool($configModifiedTime)) {
+            $this->configModifiedTime = $configModifiedTime;
         }
-        return null;
+        // use APC user cache to store parsed config.ttl configuration
+        if ($this->cache->isAvailable() && !is_null($this->configModifiedTime)) {
+            // @codeCoverageIgnoreStart
+            $key = realpath($this->filePath) . ", " . $this->configModifiedTime;
+            $nskey = "namespaces of " . $key;
+            $this->graph = $this->cache->fetch($key);
+            $this->namespaces = $this->cache->fetch($nskey);
+            if ($this->graph === false || $this->namespaces === false) { // was not found in cache
+                $this->parseConfig($this->filePath);
+                $this->cache->store($key, $this->graph);
+                $this->cache->store($nskey, $this->namespaces);
+            }
+        // @codeCoverageIgnoreEnd
+        } else { // APC not available, parse on every request
+            $this->parseConfig($this->filePath);
+        }
+        $this->initializeNamespaces();
+
+        $configResources = $this->graph->allOfType("skosmos:Configuration");
+        if (is_null($configResources) || !is_array($configResources) || count($configResources) !== 1) {
+            throw new Exception("config.ttl must have exactly one skosmos:Configuration");
+        }
+        return $configResources[0];
     }
 
     /**

--- a/src/model/GlobalConfig.php
+++ b/src/model/GlobalConfig.php
@@ -30,7 +30,7 @@ class GlobalConfig extends BaseConfig
      */
     private $configModifiedTime = null;
 
-    public function __construct(Model $model, $config_name='../../config.ttl')
+    public function __construct(Model $model, string $config_name='../../config.ttl')
     {
         $this->cache = new Cache();
         $this->filePath = realpath(dirname(__FILE__) . "/" . $config_name);
@@ -59,7 +59,7 @@ class GlobalConfig extends BaseConfig
      * and creating the graph and resources objects. Uses a cache if available,
      * in order to avoid re-loading the complete configuration on each request.
      */
-    private function initializeConfig()
+    private function initializeConfig(): EasyRdf\Resource
     {
         // retrieve last modified time for config file (filemtime returns int|bool!)
         $configModifiedTime = filemtime($this->filePath);

--- a/src/model/GlobalConfig.php
+++ b/src/model/GlobalConfig.php
@@ -30,7 +30,7 @@ class GlobalConfig extends BaseConfig
      */
     private $configModifiedTime = null;
 
-    public function __construct($config_name='../../config.ttl')
+    public function __construct(Model $model, $config_name='../../config.ttl')
     {
         $this->cache = new Cache();
         try {
@@ -38,11 +38,12 @@ class GlobalConfig extends BaseConfig
             if (!file_exists($this->filePath)) {
                 throw new Exception('config.ttl file is missing, please provide one.');
             }
-            $this->initializeConfig();
+            $resource = $this->initializeConfig();
         } catch (Exception $e) {
             echo "Error: " . $e->getMessage();
             return;
         }
+        parent::__construct($model, $resource);
     }
 
     public function getCache()
@@ -87,17 +88,17 @@ class GlobalConfig extends BaseConfig
             } else { // APC not available, parse on every request
                 $this->parseConfig($this->filePath);
             }
+            $this->initializeNamespaces();
 
             $configResources = $this->graph->allOfType("skosmos:Configuration");
             if (is_null($configResources) || !is_array($configResources) || count($configResources) !== 1) {
                 throw new Exception("config.ttl must have exactly one skosmos:Configuration");
             }
-
-            $this->resource = $configResources[0];
-            $this->initializeNamespaces();
+            return $configResources[0];
         } catch (Exception $e) {
             echo "Error: " . $e->getMessage();
         }
+        return null;
     }
 
     /**

--- a/src/model/Model.php
+++ b/src/model/Model.php
@@ -29,19 +29,20 @@ class Model
     /**
      * Initializes the Model object
      */
-    public function __construct($config)
+    public function __construct(string $config_filename="../../config.ttl")
     {
-        $this->globalConfig = $config;
-        $this->initializeLogging();
         $this->resolver = new Resolver($this);
-
-        foreach ($this->getConfig()->getLanguages() as $langcode => $locale) {
+        $this->globalConfig = new GlobalConfig($this, $config_filename);
+        $this->translator = null;
+        foreach ($this->globalConfig->getLanguages() as $langcode => $locale) {
             if (is_null($this->translator)) {
+                // use the first configured language as default language
                 $this->translator = new Translator($langcode);
             }
             $this->translator->addLoader('po', new PoFileLoader());
             $this->translator->addResource('po', __DIR__.'/../../resource/translations/skosmos_' . $langcode . '.po', $langcode);
         }
+        $this->initializeLogging();
     }
 
     /**

--- a/src/model/Vocabulary.php
+++ b/src/model/Vocabulary.php
@@ -12,7 +12,7 @@ class Vocabulary extends DataObject implements Modifiable
     public function __construct($model, $resource)
     {
         parent::__construct($model, $resource);
-        $this->config = new VocabularyConfig($resource, $model->getConfig()->getGlobalPlugins());
+        $this->config = new VocabularyConfig($model, $resource, $model->getConfig()->getGlobalPlugins());
     }
 
     /**

--- a/src/model/VocabularyConfig.php
+++ b/src/model/VocabularyConfig.php
@@ -30,7 +30,7 @@ class VocabularyConfig extends BaseConfig
     "skos:related", "skos:historyNote", "skosmos:memberOf",
     "skosmos:memberOfArray");
 
-    public function __construct(Model $model, $resource, $globalPlugins=array())
+    public function __construct(Model $model, EasyRdf\Resource $resource, array $globalPlugins=array())
     {
         parent::__construct($model, $resource);
         $this->globalPlugins = $globalPlugins;

--- a/src/model/VocabularyConfig.php
+++ b/src/model/VocabularyConfig.php
@@ -30,9 +30,9 @@ class VocabularyConfig extends BaseConfig
     "skos:related", "skos:historyNote", "skosmos:memberOf",
     "skosmos:memberOfArray");
 
-    public function __construct($resource, $globalPlugins=array())
+    public function __construct(Model $model, $resource, $globalPlugins=array())
     {
-        $this->resource = $resource;
+        parent::__construct($model, $resource);
         $this->globalPlugins = $globalPlugins;
         $this->setPropertyLabelOverrides();
         $pluginArray = $this->getPluginArray();

--- a/src/rest.php
+++ b/src/rest.php
@@ -8,8 +8,7 @@ require_once '../vendor/autoload.php';
 header("Access-Control-Allow-Origin: *"); // enable CORS for the whole REST API
 
 try {
-    $config = new GlobalConfig();
-    $model = new Model($config);
+    $model = new Model();
     $controller = new RestController($model);
     $request = new Request($model);
     $path = $request->getServerConstant('PATH_INFO') ? $request->getServerConstant('PATH_INFO') : ''; // eg. "/search"

--- a/tests/ConceptMappingPropertyValueTest.php
+++ b/tests/ConceptMappingPropertyValueTest.php
@@ -9,7 +9,7 @@ class ConceptMappingPropertyValueTest extends PHPUnit\Framework\TestCase
 
     protected function setUp(): void
     {
-        $this->model = new Model(new GlobalConfig('/../../tests/testconfig.ttl'));
+        $this->model = new Model('/../../tests/testconfig.ttl');
         $this->vocab = $this->model->getVocabulary('mapping');
         $this->concept = $this->vocab->getConceptInfo('http://www.skosmos.skos/mapping/m1', 'en');
         $this->props = $this->concept->getMappingProperties();

--- a/tests/ConceptPropertyTest.php
+++ b/tests/ConceptPropertyTest.php
@@ -6,7 +6,7 @@ class ConceptPropertyTest extends PHPUnit\Framework\TestCase
 
     protected function setUp(): void
     {
-        $this->model = new Model(new GlobalConfig('/../../tests/testconfig.ttl'));
+        $this->model = new Model('/../../tests/testconfig.ttl');
     }
 
     /**

--- a/tests/ConceptPropertyValueLiteralTest.php
+++ b/tests/ConceptPropertyValueLiteralTest.php
@@ -8,7 +8,7 @@ class ConceptPropertyValueLiteralTest extends PHPUnit\Framework\TestCase
 
     protected function setUp(): void
     {
-        $this->model = new Model(new GlobalConfig('/../../tests/testconfig.ttl'));
+        $this->model = new Model('/../../tests/testconfig.ttl');
         $this->vocab = $this->model->getVocabulary('test');
         $this->concept = $this->vocab->getConceptInfo('http://www.skosmos.skos/test/ta112', 'en');
     }

--- a/tests/ConceptPropertyValueTest.php
+++ b/tests/ConceptPropertyValueTest.php
@@ -8,7 +8,7 @@ class ConceptPropertyValueTest extends PHPUnit\Framework\TestCase
 
     protected function setUp(): void
     {
-        $this->model = new Model(new GlobalConfig('/../../tests/testconfig.ttl'));
+        $this->model = new Model('/../../tests/testconfig.ttl');
         $this->vocab = $this->model->getVocabulary('test');
         $this->concept = $this->vocab->getConceptInfo('http://www.skosmos.skos/test/ta112', 'en');
     }

--- a/tests/ConceptSearchParametersTest.php
+++ b/tests/ConceptSearchParametersTest.php
@@ -11,7 +11,7 @@ class ConceptSearchParametersTest extends PHPUnit\Framework\TestCase
         putenv("LC_ALL=en_GB.utf8");
         setlocale(LC_ALL, 'en_GB.utf8');
         $this->request = $this->getMockBuilder('Request')->disableOriginalConstructor()->getMock();
-        $this->model = new Model(new GlobalConfig('/../../tests/testconfig.ttl'));
+        $this->model = new Model('/../../tests/testconfig.ttl');
     }
 
     /**
@@ -20,7 +20,7 @@ class ConceptSearchParametersTest extends PHPUnit\Framework\TestCase
      */
     public function testConstructorAndSearchLimit()
     {
-        $params = new ConceptSearchParameters($this->request, new GlobalConfig('/../../tests/testconfig.ttl'), true);
+        $params = new ConceptSearchParameters($this->request, $this->model->getConfig(), true);
         $this->assertEquals(0, $params->getSearchLimit());
     }
 
@@ -30,7 +30,7 @@ class ConceptSearchParametersTest extends PHPUnit\Framework\TestCase
     public function testGetLang()
     {
         $this->request->method('getLang')->will($this->returnValue('en'));
-        $params = new ConceptSearchParameters($this->request, new GlobalConfig('/../../tests/testconfig.ttl'), true);
+        $params = new ConceptSearchParameters($this->request, $this->model->getConfig(), true);
         $this->assertEquals('en', $params->getLang());
         $this->request->method('getQueryParam')->will($this->returnValue('sv'));
         $this->assertEquals('sv', $params->getLang());
@@ -42,7 +42,7 @@ class ConceptSearchParametersTest extends PHPUnit\Framework\TestCase
      */
     public function testGetVocabs()
     {
-        $params = new ConceptSearchParameters($this->request, new GlobalConfig('/../../tests/testconfig.ttl'));
+        $params = new ConceptSearchParameters($this->request, $this->model->getConfig());
         $this->assertEquals(array(), $params->getVocabs());
         $this->request->method('getVocab')->will($this->returnValue('vocfromrequest'));
         $this->assertEquals(array('vocfromrequest'), $params->getVocabs());
@@ -55,11 +55,11 @@ class ConceptSearchParametersTest extends PHPUnit\Framework\TestCase
      */
     public function testGetVocabids()
     {
-        $params = new ConceptSearchParameters($this->request, new GlobalConfig('/../../tests/testconfig.ttl'));
+        $params = new ConceptSearchParameters($this->request, $this->model->getConfig());
         $this->assertEquals(null, $params->getVocabids());
         $params->setVocabularies(array($this->model->getVocabulary('test')));
         $this->assertEquals(array('test'), $params->getVocabids());
-        $params = new ConceptSearchParameters($this->request, new GlobalConfig('/../../tests/testconfig.ttl'), true);
+        $params = new ConceptSearchParameters($this->request, $this->model->getConfig(), true);
         $this->assertEquals(null, $params->getVocabids());
         $mockreq = $this->getMockBuilder('Request')->disableOriginalConstructor()->getMock();
         $qparams = array(
@@ -67,9 +67,9 @@ class ConceptSearchParametersTest extends PHPUnit\Framework\TestCase
             array('vocabs', 'test dates')
         );
         $mockreq->method('getQueryParam')->will($this->returnValueMap($qparams));
-        $params = new ConceptSearchParameters($mockreq, new GlobalConfig('/../../tests/testconfig.ttl'));
+        $params = new ConceptSearchParameters($mockreq, $this->model->getConfig());
         $this->assertEquals(array('test', 'dates'), $params->getVocabids());
-        $params = new ConceptSearchParameters($mockreq, new GlobalConfig('/../../tests/testconfig.ttl'), true);
+        $params = new ConceptSearchParameters($mockreq, $this->model->getConfig(), true);
         $this->assertEquals(array('test'), $params->getVocabids());
     }
 
@@ -78,11 +78,11 @@ class ConceptSearchParametersTest extends PHPUnit\Framework\TestCase
      */
     public function testGetSearchTerm()
     {
-        $params = new ConceptSearchParameters($this->request, new GlobalConfig('/../../tests/testconfig.ttl'));
+        $params = new ConceptSearchParameters($this->request, $this->model->getConfig());
         $this->assertEquals('*', $params->getSearchTerm());
         $this->request->method('getQueryParamRaw')->will($this->returnValue('test'));
         $this->assertEquals('test*', $params->getSearchTerm());
-        $params = new ConceptSearchParameters($this->request, new GlobalConfig('/../../tests/testconfig.ttl'), true);
+        $params = new ConceptSearchParameters($this->request, $this->model->getConfig(), true);
         $this->assertEquals('test', $params->getSearchTerm());
     }
 
@@ -92,7 +92,7 @@ class ConceptSearchParametersTest extends PHPUnit\Framework\TestCase
      */
     public function testSearchTermWithoutRest()
     {
-        $params = new ConceptSearchParameters($this->request, new GlobalConfig('/../../tests/testconfig.ttl'), false);
+        $params = new ConceptSearchParameters($this->request, $this->model->getConfig(), false);
         $this->request->method('getQueryParamRaw')->will($this->returnValue('0'));
         $this->assertEquals('0*', $params->getSearchTerm());
     }
@@ -106,7 +106,7 @@ class ConceptSearchParametersTest extends PHPUnit\Framework\TestCase
      */
     public function testGetSearchTermZeroes()
     {
-        $params = new ConceptSearchParameters($this->request, new GlobalConfig('/../../tests/testconfig.ttl'), true);
+        $params = new ConceptSearchParameters($this->request, $this->model->getConfig(), true);
         $this->assertEquals('', $params->getSearchTerm());
         $this->request->method('getQueryParamRaw')->will(
             $this->returnValueMap([
@@ -126,7 +126,7 @@ class ConceptSearchParametersTest extends PHPUnit\Framework\TestCase
     {
         $mockreq = $this->getMockBuilder('Request')->disableOriginalConstructor()->getMock();
         $mockreq->method('getVocab')->will($this->returnValue($this->model->getVocabulary('test')));
-        $params = new ConceptSearchParameters($mockreq, new GlobalConfig('/../../tests/testconfig.ttl'));
+        $params = new ConceptSearchParameters($mockreq, $this->model->getConfig());
         $this->assertEquals(array('skos:Concept', 'http://purl.org/iso25964/skos-thes#ThesaurusArray', 'http://www.w3.org/2004/02/skos/core#Collection'), $params->getTypeLimit());
     }
 
@@ -136,7 +136,7 @@ class ConceptSearchParametersTest extends PHPUnit\Framework\TestCase
      */
     public function testGetTypeLimit()
     {
-        $params = new ConceptSearchParameters($this->request, new GlobalConfig('/../../tests/testconfig.ttl'));
+        $params = new ConceptSearchParameters($this->request, $this->model->getConfig());
         $this->assertEquals(array('skos:Concept'), $params->getTypeLimit());
         $this->request->method('getQueryParam')->will($this->returnValue('isothes:ThesaurusArray+skos:Collection'));
         $this->assertEquals(array('isothes:ThesaurusArray', 'skos:Collection'), $params->getTypeLimit());
@@ -148,7 +148,7 @@ class ConceptSearchParametersTest extends PHPUnit\Framework\TestCase
      */
     public function testGetTypeLimitOnlyOne()
     {
-        $params = new ConceptSearchParameters($this->request, new GlobalConfig('/../../tests/testconfig.ttl'));
+        $params = new ConceptSearchParameters($this->request, $this->model->getConfig());
         $this->request->method('getQueryParam')->will($this->returnValue('skos:Collection'));
         $this->assertEquals(array('skos:Collection'), $params->getTypeLimit());
     }
@@ -159,7 +159,7 @@ class ConceptSearchParametersTest extends PHPUnit\Framework\TestCase
      */
     public function testGetAndSetUnique()
     {
-        $params = new ConceptSearchParameters($this->request, new GlobalConfig('/../../tests/testconfig.ttl'));
+        $params = new ConceptSearchParameters($this->request, $this->model->getConfig());
         $this->assertEquals(false, $params->getUnique());
         $params->setUnique(true);
         $this->assertEquals(true, $params->getUnique());
@@ -171,7 +171,7 @@ class ConceptSearchParametersTest extends PHPUnit\Framework\TestCase
      */
     public function testGetAndSetHidden()
     {
-        $params = new ConceptSearchParameters($this->request, new GlobalConfig('/../../tests/testconfig.ttl'));
+        $params = new ConceptSearchParameters($this->request, $this->model->getConfig());
         $this->assertEquals(true, $params->getHidden());
         $params->setHidden(false);
         $this->assertEquals(false, $params->getHidden());
@@ -182,7 +182,7 @@ class ConceptSearchParametersTest extends PHPUnit\Framework\TestCase
      */
     public function testGetArrayClassWithoutVocabulary()
     {
-        $params = new ConceptSearchParameters($this->request, new GlobalConfig('/../../tests/testconfig.ttl'));
+        $params = new ConceptSearchParameters($this->request, $this->model->getConfig());
         $this->assertEquals(null, $params->getArrayClass());
     }
 
@@ -191,7 +191,7 @@ class ConceptSearchParametersTest extends PHPUnit\Framework\TestCase
      */
     public function testGetArrayClass()
     {
-        $params = new ConceptSearchParameters($this->request, new GlobalConfig('/../../tests/testconfig.ttl'));
+        $params = new ConceptSearchParameters($this->request, $this->model->getConfig());
         $params->setVocabularies(array($this->model->getVocabulary('test')));
         $this->assertEquals('http://purl.org/iso25964/skos-thes#ThesaurusArray', $params->getArrayClass());
     }
@@ -202,7 +202,7 @@ class ConceptSearchParametersTest extends PHPUnit\Framework\TestCase
      */
     public function testGetSchemeLimit()
     {
-        $params = new ConceptSearchParameters($this->request, new GlobalConfig('/../../tests/testconfig.ttl'));
+        $params = new ConceptSearchParameters($this->request, $this->model->getConfig());
         $this->assertEquals([], $params->getSchemeLimit());
         $this->request->method('getQueryParam')->will($this->returnValue('http://www.skosmos.skos/test/ http://www.skosmos.skos/date/'));
         $this->assertEquals(array(0 => 'http://www.skosmos.skos/test/', 1 => 'http://www.skosmos.skos/date/'), $params->getSchemeLimit());
@@ -214,7 +214,7 @@ class ConceptSearchParametersTest extends PHPUnit\Framework\TestCase
     public function testGetContentLang()
     {
         $this->request->method('getContentLang')->will($this->returnValue('de'));
-        $params = new ConceptSearchParameters($this->request, new GlobalConfig('/../../tests/testconfig.ttl'));
+        $params = new ConceptSearchParameters($this->request, $this->model->getConfig());
         $this->assertEquals('de', $params->getContentLang());
     }
 
@@ -223,9 +223,9 @@ class ConceptSearchParametersTest extends PHPUnit\Framework\TestCase
      */
     public function testGetSearchLang()
     {
-        $params = new ConceptSearchParameters($this->request, new GlobalConfig('/../../tests/testconfig.ttl'));
+        $params = new ConceptSearchParameters($this->request, $this->model->getConfig());
         $this->assertEquals(null, $params->getSearchLang());
-        $params = new ConceptSearchParameters($this->request, new GlobalConfig('/../../tests/testconfig.ttl'));
+        $params = new ConceptSearchParameters($this->request, $this->model->getConfig());
         $this->request->method('getContentLang')->will($this->returnValue('en'));
         $this->request->method('getQueryParam')->will($this->returnValue('on')); //anylang=on
         $this->assertEquals('', $params->getSearchLang());
@@ -237,7 +237,7 @@ class ConceptSearchParametersTest extends PHPUnit\Framework\TestCase
     public function testGetOffsetNonNumeric()
     {
         $this->request->method('getQueryParam')->will($this->returnValue('notvalid'));
-        $params = new ConceptSearchParameters($this->request, new GlobalConfig('/../../tests/testconfig.ttl'));
+        $params = new ConceptSearchParameters($this->request, $this->model->getConfig());
         $this->assertEquals(0, $params->getOffset());
     }
 
@@ -247,7 +247,7 @@ class ConceptSearchParametersTest extends PHPUnit\Framework\TestCase
     public function testGetOffsetValid()
     {
         $this->request->method('getQueryParam')->will($this->returnValue(25));
-        $params = new ConceptSearchParameters($this->request, new GlobalConfig('/../../tests/testconfig.ttl'));
+        $params = new ConceptSearchParameters($this->request, $this->model->getConfig());
         $this->assertEquals(25, $params->getOffset());
     }
 
@@ -260,7 +260,7 @@ class ConceptSearchParametersTest extends PHPUnit\Framework\TestCase
             array('fields', 'broader')
         );
         $this->request->method('getQueryParam')->will($this->returnValueMap($map));
-        $params = new ConceptSearchParameters($this->request, new GlobalConfig('/../../tests/testconfig.ttl'));
+        $params = new ConceptSearchParameters($this->request, $this->model->getConfig());
         $this->assertEquals(array('broader'), $params->getAdditionalFields());
     }
 
@@ -273,7 +273,7 @@ class ConceptSearchParametersTest extends PHPUnit\Framework\TestCase
             array('fields', 'broader prefLabel')
         );
         $this->request->method('getQueryParam')->will($this->returnValueMap($map));
-        $params = new ConceptSearchParameters($this->request, new GlobalConfig('/../../tests/testconfig.ttl'));
+        $params = new ConceptSearchParameters($this->request, $this->model->getConfig());
         $this->assertEquals(array('broader', 'prefLabel'), $params->getAdditionalFields());
     }
 

--- a/tests/ConceptTest.php
+++ b/tests/ConceptTest.php
@@ -13,7 +13,7 @@ class ConceptTest extends PHPUnit\Framework\TestCase
 
     protected function setUp(): void
     {
-        $this->model = new Model(new GlobalConfig('/../../tests/testconfig.ttl'));
+        $this->model = new Model('/../../tests/testconfig.ttl');
         $this->vocab = $this->model->getVocabulary('test');
         $this->concept = $this->vocab->getConceptInfo('http://www.skosmos.skos/test/ta112', 'en');
 
@@ -365,7 +365,7 @@ class ConceptTest extends PHPUnit\Framework\TestCase
      */
     public function testGetLabelWhenNull()
     {
-        $model = new Model(new GlobalConfig('/../../tests/testconfig.ttl'));
+        $model = new Model('/../../tests/testconfig.ttl');
         $vocab = $model->getVocabulary('test');
         $concept = $vocab->getConceptInfo("http://www.skosmos.skos/test/ta120", "en");
         $this->assertEquals(null, $concept->getLabel());
@@ -390,7 +390,7 @@ class ConceptTest extends PHPUnit\Framework\TestCase
      */
     public function testGetGroupProperties()
     {
-        $model = new Model(new GlobalConfig('/../../tests/testconfig.ttl'));
+        $model = new Model('/../../tests/testconfig.ttl');
         $vocab = $model->getVocabulary('groups');
         $concept = $vocab->getConceptInfo("http://www.skosmos.skos/groups/ta111", "en");
         $arrays = $concept->getArrayProperties();
@@ -406,7 +406,7 @@ class ConceptTest extends PHPUnit\Framework\TestCase
      */
     public function testGetGroupPropertiesWithDuplicatedInformationFilteredOut()
     {
-        $model = new Model(new GlobalConfig('/../../tests/testconfig.ttl'));
+        $model = new Model('/../../tests/testconfig.ttl');
         $vocab = $model->getVocabulary('dupgroup');
         $concept = $vocab->getConceptInfo("http://www.skosmos.skos/dupgroup/c1", "en");
         $groups = $concept->getGroupProperties();
@@ -419,7 +419,7 @@ class ConceptTest extends PHPUnit\Framework\TestCase
      */
     public function testGetGroupPropertiesWithHierarchy()
     {
-        $model = new Model(new GlobalConfig('/../../tests/testconfig.ttl'));
+        $model = new Model('/../../tests/testconfig.ttl');
         $vocab = $model->getVocabulary('dupgroup');
         $concept = $vocab->getConceptInfo("http://www.skosmos.skos/dupgroup/ta111", "en");
         $groups = $concept->getGroupProperties();
@@ -437,7 +437,7 @@ class ConceptTest extends PHPUnit\Framework\TestCase
      */
     public function testGetPropertiesWithNarrowersPartOfACollection()
     {
-        $model = new Model(new GlobalConfig('/../../tests/testconfig.ttl'));
+        $model = new Model('/../../tests/testconfig.ttl');
         $vocab = $model->getVocabulary('groups');
         $concept = $vocab->getConceptInfo("http://www.skosmos.skos/groups/ta1", "en");
         $props = $concept->getProperties();

--- a/tests/DataObjectTest.php
+++ b/tests/DataObjectTest.php
@@ -9,8 +9,7 @@ class DataObjectTest extends PHPUnit\Framework\TestCase
      */
     public function testConstructorNoArguments()
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage("Invalid constructor parameter given to DataObject");
+        $this->expectException(TypeError::class);
         $obj = new DataObject(null, null);
         $this->assertNotNull($obj);
     }

--- a/tests/FeedbackTest.php
+++ b/tests/FeedbackTest.php
@@ -10,8 +10,7 @@ class FeedbackTest extends PHPUnit\Framework\TestCase
 
     protected function setUp(): void
     {
-        $config = new GlobalConfig('/../../tests/testconfig-fordefaults.ttl');
-        $this->model = new Model($config);
+        $this->model = new Model('/../../tests/testconfig-fordefaults.ttl');
         $this->request = \Mockery::mock('Request', array($this->model))->makePartial();
         $this->request->setLang('en');
         $this->controller = \Mockery::mock('WebController[sendFeedback]', array($this->model))->makePartial();

--- a/tests/GenericSparqlTest.php
+++ b/tests/GenericSparqlTest.php
@@ -14,7 +14,7 @@ class GenericSparqlTest extends PHPUnit\Framework\TestCase
         putenv("LANGUAGE=en_GB.utf8");
         putenv("LC_ALL=en_GB.utf8");
         setlocale(LC_ALL, 'en_GB.utf8');
-        $this->model = new Model(new GlobalConfig('/../../tests/testconfig.ttl'));
+        $this->model = new Model('/../../tests/testconfig.ttl');
         $this->vocab = $this->model->getVocabulary('test');
         $this->graph = $this->vocab->getGraph();
         $this->params = $this->getMockBuilder('ConceptSearchParameters')->disableOriginalConstructor()->getMock();

--- a/tests/GlobalConfigTest.php
+++ b/tests/GlobalConfigTest.php
@@ -138,18 +138,16 @@ class GlobalConfigTest extends PHPUnit\Framework\TestCase
 
     public function testInitializeConfigWithoutGraph()
     {
-        $this->markTestSkipped("disabled because exception handling is currently broken");
-        $this->expectOutputString('Error: config.ttl must have exactly one skosmos:Configuration');
-        $conf = (new Model('/../../tests/testconfig-nograph.ttl'))->getConfig();
-        $this->assertNotNull($conf);
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('config.ttl must have exactly one skosmos:Configuration');
+        $model = new Model('/../../tests/testconfig-nograph.ttl');
     }
 
     public function testNonexistentFile()
     {
-        $this->markTestSkipped("disabled because exception handling is currently broken");
-        $this->expectOutputString('Error: config.ttl file is missing, please provide one.');
-        $conf = new GlobalConfig('/../../tests/testconfig-idonotexist.ttl');
-        $this->assertNotNull($conf);
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('config.ttl file is missing, please provide one.');
+        $model = new Model('/../../tests/testconfig-idonotexist.ttl');
     }
 
     // --- tests for some default values

--- a/tests/GlobalConfigTest.php
+++ b/tests/GlobalConfigTest.php
@@ -141,6 +141,7 @@ class GlobalConfigTest extends PHPUnit\Framework\TestCase
         $this->expectException(Exception::class);
         $this->expectExceptionMessage('config.ttl must have exactly one skosmos:Configuration');
         $model = new Model('/../../tests/testconfig-nograph.ttl');
+        $this->assertNotNull($model);
     }
 
     public function testNonexistentFile()
@@ -148,6 +149,7 @@ class GlobalConfigTest extends PHPUnit\Framework\TestCase
         $this->expectException(Exception::class);
         $this->expectExceptionMessage('config.ttl file is missing, please provide one.');
         $model = new Model('/../../tests/testconfig-idonotexist.ttl');
+        $this->assertNotNull($model);
     }
 
     // --- tests for some default values

--- a/tests/GlobalConfigTest.php
+++ b/tests/GlobalConfigTest.php
@@ -15,11 +15,11 @@ class GlobalConfigTest extends PHPUnit\Framework\TestCase
 
     protected function setUp(): void
     {
-        $this->config = new GlobalConfig('/../../tests/testconfig.ttl');
+        $this->config = (new Model('/../../tests/testconfig.ttl'))->getConfig();
         $this->assertNotNull($this->config->getCache());
         $this->assertNotNull($this->config->getGraph());
-        $this->configWithDefaults = new GlobalConfig('/../../tests/testconfig-fordefaults.ttl');
-        $this->configWithBaseHref = new GlobalConfig('/../../tests/testconfig-basehref.ttl');
+        $this->configWithDefaults = (new Model('/../../tests/testconfig-fordefaults.ttl'))->getConfig();
+        $this->configWithBaseHref = (new Model('/../../tests/testconfig-basehref.ttl'))->getConfig();
     }
 
     // --- tests for values that are overriding default values
@@ -138,13 +138,15 @@ class GlobalConfigTest extends PHPUnit\Framework\TestCase
 
     public function testInitializeConfigWithoutGraph()
     {
+        $this->markTestSkipped("disabled because exception handling is currently broken");
         $this->expectOutputString('Error: config.ttl must have exactly one skosmos:Configuration');
-        $conf = new GlobalConfig('/../../tests/testconfig-nograph.ttl');
+        $conf = (new Model('/../../tests/testconfig-nograph.ttl'))->getConfig();
         $this->assertNotNull($conf);
     }
 
-    public function testInexistentFile()
+    public function testNonexistentFile()
     {
+        $this->markTestSkipped("disabled because exception handling is currently broken");
         $this->expectOutputString('Error: config.ttl file is missing, please provide one.');
         $conf = new GlobalConfig('/../../tests/testconfig-idonotexist.ttl');
         $this->assertNotNull($conf);

--- a/tests/Http304Test.php
+++ b/tests/Http304Test.php
@@ -33,7 +33,7 @@ class Http304Test extends TestCase
      */
     public function initObjects(string $vocabularyName)
     {
-        $this->model = Mockery::mock(new Model(new GlobalConfig('/../../tests/testconfig.ttl')))->makePartial();
+        $this->model = Mockery::mock(new Model('/../../tests/testconfig.ttl'))->makePartial();
         $this->vocab = Mockery::mock($this->model->getVocabulary($vocabularyName))->makePartial();
         $this->controller = Mockery::mock('WebController')
             ->shouldAllowMockingProtectedMethods()

--- a/tests/JenaTextSparqlTest.php
+++ b/tests/JenaTextSparqlTest.php
@@ -14,7 +14,7 @@ class JenaTextSparqlTest extends PHPUnit\Framework\TestCase
         putenv("LANGUAGE=en_GB.utf8");
         putenv("LC_ALL=en_GB.utf8");
         setlocale(LC_ALL, 'en_GB.utf8');
-        $this->model = new Model(new GlobalConfig('/../../tests/jenatestconfig.ttl'));
+        $this->model = new Model('/../../tests/jenatestconfig.ttl');
         $this->vocab = $this->model->getVocabulary('test');
         $this->graph = $this->vocab->getGraph();
         $this->params = $this->getMockBuilder('ConceptSearchParameters')->disableOriginalConstructor()->getMock();

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -10,7 +10,7 @@ class ModelTest extends PHPUnit\Framework\TestCase
         putenv("LANGUAGE=en_GB.utf8");
         putenv("LC_ALL=en_GB.utf8");
         setlocale(LC_ALL, 'en_GB.utf8');
-        $this->model = new Model(new GlobalConfig('/../../tests/testconfig.ttl'));
+        $this->model = new Model('/../../tests/testconfig.ttl');
         $this->params = $this->getMockBuilder('ConceptSearchParameters')->disableOriginalConstructor()->getMock();
         $this->params->method('getVocabIds')->will($this->returnValue(array('test')));
         $this->params->method('getVocabs')->will($this->returnValue(array($this->model->getVocabulary('test'))));
@@ -24,10 +24,11 @@ class ModelTest extends PHPUnit\Framework\TestCase
     /**
      * @covers Model::__construct
      */
-    public function testConstructorWithConfig()
+    public function testConstructor()
     {
-        $model = new Model(new GlobalConfig('/../../tests/testconfig.ttl'));
+        $model = new Model('/../../tests/testconfig.ttl');
         $this->assertNotNull($model);
+        $this->assertNotNull($model->getConfig());
     }
 
     /**
@@ -510,7 +511,6 @@ test:ta116
 
     /**
      * @covers Model::getRDF
-     * @depends testConstructorWithConfig
      */
     public function testGetRDFShouldIncludeLists()
     {
@@ -547,13 +547,11 @@ test:ta126
 
     /**
      * @covers Model::getRDF
-     * @depends testConstructorWithConfig
      * Issue: https://github.com/NatLibFi/Skosmos/pull/419
      */
     public function testGetRDFShouldNotIncludeExtraBlankNodesFromLists()
     {
-        $model = new Model(new GlobalConfig('/../../tests/testconfig.ttl'));
-        $result = $model->getRDF('test', 'http://www.skosmos.skos/test/ta125', 'text/turtle');
+        $result = $this->model->getRDF('test', 'http://www.skosmos.skos/test/ta125', 'text/turtle');
         $resultGraph = new EasyRdf\Graph();
         $resultGraph->parse($result, "turtle");
 

--- a/tests/PluginRegisterTest.php
+++ b/tests/PluginRegisterTest.php
@@ -48,7 +48,7 @@ class PluginRegisterTest extends PHPUnit\Framework\TestCase
                             'global-plugin-charlie' => array('js' => array('charlie.js'),
                                                       'callback' => array( 0 => 'charlie')));
         $this->mockpr->method('getPlugins')->will($this->returnValue($this->stubplugs));
-        $this->model = new Model(new GlobalConfig('/../../tests/testconfig.ttl'));
+        $this->model = new Model('/../../tests/testconfig.ttl');
         $this->vocab = $this->model->getVocabulary('test');
     }
 

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -7,8 +7,7 @@ class RequestTest extends PHPUnit\Framework\TestCase
 
     protected function setUp(): void
     {
-        $config = new GlobalConfig('/../../tests/testconfig.ttl');
-        $this->model = new Model($config);
+        $this->model = new Model('/../../tests/testconfig.ttl');
         $this->request = new Request($this->model);
     }
 

--- a/tests/ResolverTest.php
+++ b/tests/ResolverTest.php
@@ -6,7 +6,7 @@ class ResolverTest extends PHPUnit\Framework\TestCase
 
     protected function setUp(): void
     {
-        $model = new Model(new GlobalConfig('/../../tests/testconfig.ttl'));
+        $model = new Model('/../../tests/testconfig.ttl');
         $this->resolver = new Resolver($model);
     }
 

--- a/tests/RestControllerTest.php
+++ b/tests/RestControllerTest.php
@@ -12,8 +12,7 @@ class RestControllerTest extends \PHPUnit\Framework\TestCase
     private $controller;
     protected function setUp(): void
     {
-        $globalConfig = new GlobalConfig('/../../tests/testconfig.ttl');
-        $this->model = Mockery::mock(new Model($globalConfig));
+        $this->model = Mockery::mock(new Model('/../../tests/testconfig.ttl'));
         $this->controller = new RestController($this->model);
     }
 

--- a/tests/VocabularyCategoryTest.php
+++ b/tests/VocabularyCategoryTest.php
@@ -10,7 +10,7 @@ class VocabularyCategoryTest extends PHPUnit\Framework\TestCase
         putenv("LANGUAGE=en_GB.utf8");
         putenv("LC_ALL=en_GB.utf8");
         setlocale(LC_ALL, 'en_GB.utf8');
-        $this->model = new Model(new GlobalConfig('/../../tests/testconfig.ttl'));
+        $this->model = new Model('/../../tests/testconfig.ttl');
         $this->mockres = $this->getMockBuilder('EasyRdf\Resource')->disableOriginalConstructor()->getMock();
         $this->mockres->method('localName')->will($this->returnValue('local name'));
     }

--- a/tests/VocabularyConfigTest.php
+++ b/tests/VocabularyConfigTest.php
@@ -15,7 +15,7 @@ class VocabularyConfigTest extends PHPUnit\Framework\TestCase
         putenv("LANGUAGE=en_GB.utf8");
         putenv("LC_ALL=en_GB.utf8");
         setlocale(LC_ALL, 'en_GB.utf8');
-        $this->model = new Model(new GlobalConfig('/../../tests/testconfig.ttl'));
+        $this->model = new Model('/../../tests/testconfig.ttl');
         $this->assertNotNull($this->model->getVocabulary('test')->getConfig()->getPluginRegister(), "The PluginRegister of the model was not initialized!");
     }
 
@@ -460,7 +460,7 @@ class VocabularyConfigTest extends PHPUnit\Framework\TestCase
     {
         $mockres = $this->getMockBuilder('EasyRdf\Resource')->disableOriginalConstructor()->getMock();
         $mockres->method('getUri')->will($this->returnValue('http://www.skosmos.skos/onto/test'));
-        $conf = new VocabularyConfig($mockres);
+        $conf = new VocabularyConfig($this->model, $mockres);
         $this->assertEquals('test', $conf->getId());
     }
 

--- a/tests/VocabularyTest.php
+++ b/tests/VocabularyTest.php
@@ -13,8 +13,8 @@ class VocabularyTest extends \PHPUnit\Framework\TestCase
         putenv("LANGUAGE=en_GB.utf8");
         putenv("LC_ALL=en_GB.utf8");
         setlocale(LC_ALL, 'en_GB.utf8');
-        $this->model = new Model(new GlobalConfig('/../../tests/testconfig.ttl'));
-        $this->jenamodel = new Model(new GlobalConfig('/../../tests/jenatestconfig.ttl'));
+        $this->model = new Model('/../../tests/testconfig.ttl');
+        $this->jenamodel = new Model('/../../tests/jenatestconfig.ttl');
     }
 
     /**
@@ -422,9 +422,8 @@ class VocabularyTest extends \PHPUnit\Framework\TestCase
      */
     public function testGetBreadCrumbs()
     {
-        $model = new Model(new GlobalConfig('/../../tests/testconfig.ttl'));
         $resource = $this->getMockBuilder('EasyRdf\Resource')->disableOriginalConstructor()->getMock();
-        $vocabstub = $this->getMockBuilder('Vocabulary')->onlyMethods(array('getConceptTransitiveBroaders'))->setConstructorArgs(array($model, $resource))->getMock();
+        $vocabstub = $this->getMockBuilder('Vocabulary')->onlyMethods(array('getConceptTransitiveBroaders'))->setConstructorArgs(array($this->model, $resource))->getMock();
         $vocabstub->method('getConceptTransitiveBroaders')->willReturn(array( 'http://www.yso.fi/onto/yso/p4762' => array( 'label' => 'objects', ), 'http://www.yso.fi/onto/yso/p1674' => array( 'label' => 'physical whole', 'direct' => array( 0 => 'http://www.yso.fi/onto/yso/p4762', ), ), 'http://www.yso.fi/onto/yso/p14606' => array( 'label' => 'layers', 'direct' => array( 0 => 'http://www.yso.fi/onto/yso/p1674', ), ), ));
         $result = $vocabstub->getBreadCrumbs('en', 'http://www.yso.fi/onto/yso/p14606');
         foreach($result['breadcrumbs'][0] as $crumb) {
@@ -439,9 +438,8 @@ class VocabularyTest extends \PHPUnit\Framework\TestCase
      */
     public function testGetBreadCrumbsShortening()
     {
-        $model = new Model(new GlobalConfig('/../../tests/testconfig.ttl'));
         $resource = $this->getMockBuilder('EasyRdf\Resource')->disableOriginalConstructor()->getMock();
-        $vocabstub = $this->getMockBuilder('Vocabulary')->onlyMethods(array('getConceptTransitiveBroaders'))->setConstructorArgs(array($model, $resource))->getMock();
+        $vocabstub = $this->getMockBuilder('Vocabulary')->onlyMethods(array('getConceptTransitiveBroaders'))->setConstructorArgs(array($this->model, $resource))->getMock();
         $vocabstub->method('getConceptTransitiveBroaders')->willReturn(array( 'http://www.yso.fi/onto/yso/p4762' => array( 'label' => 'objects', ), 'http://www.yso.fi/onto/yso/p13871' => array( 'label' => 'thai language', 'direct' => array( 0 => 'http://www.yso.fi/onto/yso/p10834', ), ), 'http://www.yso.fi/onto/yso/p556' => array( 'label' => 'languages', 'direct' => array( 0 => 'http://www.yso.fi/onto/yso/p2881', ), ), 'http://www.yso.fi/onto/yso/p8965' => array( 'label' => 'Sino-Tibetan languages', 'direct' => array( 0 => 'http://www.yso.fi/onto/yso/p556', ), ), 'http://www.yso.fi/onto/yso/p3358' => array( 'label' => 'systems', 'direct' => array( 0 => 'http://www.yso.fi/onto/yso/p4762', ), ), 'http://www.yso.fi/onto/yso/p10834' => array( 'label' => 'Tai languages', 'direct' => array( 0 => 'http://www.yso.fi/onto/yso/p8965', ), ), 'http://www.yso.fi/onto/yso/p2881' => array( 'label' => 'cultural systems', 'direct' => array( 0 => 'http://www.yso.fi/onto/yso/p3358', ), ), ));
         $result = $vocabstub->getBreadCrumbs('en', 'http://www.yso.fi/onto/yso/p13871');
         $this->assertEquals(6, sizeof($result['breadcrumbs'][0]));
@@ -454,8 +452,7 @@ class VocabularyTest extends \PHPUnit\Framework\TestCase
      */
     public function testGetBreadCrumbsCycle()
     {
-        $model = new Model(new GlobalConfig('/../../tests/testconfig.ttl'));
-        $vocab = $model->getVocabulary('cycle');
+        $vocab = $this->model->getVocabulary('cycle');
         $result = $vocab->getBreadCrumbs('en', 'http://www.skosmos.skos/cycle/ta4');
         foreach ($result['breadcrumbs'][0] as $crumb) {
             $this->assertInstanceOf('Breadcrumb', $crumb);
@@ -500,6 +497,16 @@ class VocabularyTest extends \PHPUnit\Framework\TestCase
     {
         $vocab = $this->model->getVocabulary('test');
         $this->assertEquals('Test short', $vocab->getShortName());
+    }
+
+    /**
+     * @covers Vocabulary::getShortName
+     */
+    public function testGetShortNameLang()
+    {
+        $this->model->setLocale('fi');
+        $vocab = $this->model->getVocabulary('test');
+        $this->assertEquals('Testi lyhyt', $vocab->getShortName());
     }
 
     /**

--- a/tests/WebControllerTest.php
+++ b/tests/WebControllerTest.php
@@ -9,8 +9,7 @@ class WebControllerTest extends TestCase
 
     protected function setUp(): void
     {
-        $globalConfig = new GlobalConfig('/../../tests/testconfig.ttl');
-        $this->model = Mockery::mock(new Model($globalConfig));
+        $this->model = Mockery::mock(new Model('/../../tests/testconfig.ttl'));
         $this->webController = new WebController($this->model);
     }
 

--- a/tests/cypress/e2e/fp-lang-yso-clang-result-vocab.cy.js
+++ b/tests/cypress/e2e/fp-lang-yso-clang-result-vocab.cy.js
@@ -7,8 +7,8 @@ describe('Front page -> lang -> vocab -> cLang -> search -> concept page', () =>
     // Click on the language "button" to switch UI lang to English
     cy.get('#language-en').click();
 
-    // Select "YSO - Yleinen suomalainen ontologia (arkeologia)" from the vocabulary list and go to the vocab page
-    cy.contains('.list-group-item a', 'YSO - Yleinen suomalainen ontologia (arkeologia)').click();
+    // Select "YSO - General Finnish ontology (archaeology)" from the vocabulary list and go to the vocab page
+    cy.contains('.list-group-item a', 'YSO - General Finnish ontology (archaeology)').click();
 
     // Confirm that we are on the correct page (yso)
     cy.url().should('include', '/yso/en/');

--- a/tests/cypress/e2e/linked-data-entity.cy.js
+++ b/tests/cypress/e2e/linked-data-entity.cy.js
@@ -1,0 +1,53 @@
+describe('HTTP content negotiation for linked data', () => {
+  it('Default entity representation: HTML', () => {
+    // visit the URI for "archaeology" concept via the entity controller
+    cy.request('/entity?uri=http://www.yso.fi/onto/yso/p1265').then((response) => {
+      // Check that the Content-Type header contains 'text/html'
+      expect(response.headers['content-type']).to.include('text/html');
+      // Check that the response body is not empty
+      expect(response.body).to.not.be.empty;
+    })
+  });
+  it('Negotiated entity representation: Turtle', () => {
+    // visit the URI for "archaeology" concept via the entity controller
+    cy.request({
+      url: '/entity?uri=http://www.yso.fi/onto/yso/p1265',
+      headers: {
+        Accept: 'text/turtle'
+      }
+    }).then((response) => {
+      // Check that the Content-Type header contains 'text/turtle'
+      expect(response.headers['content-type']).to.include('text/turtle');
+      // Check that the response body is not empty
+      expect(response.body).to.not.be.empty;
+    })
+  });
+  it('Negotiated entity representation: JSON-LD', () => {
+    // visit the URI for "archaeology" concept via the entity controller
+    cy.request({
+      url: '/entity?uri=http://www.yso.fi/onto/yso/p1265',
+      headers: {
+        Accept: 'application/ld+json'
+      }
+    }).then((response) => {
+      // Check that the Content-Type header contains 'application/ld+json'
+      expect(response.headers['content-type']).to.include('application/ld+json');
+      // Check that the response body is not empty
+      expect(response.body).to.not.be.empty;
+    })
+  });
+  it('Negotiated entity representation: RDF/XML', () => {
+    // visit the URI for "archaeology" concept via the entity controller
+    cy.request({
+      url: '/entity?uri=http://www.yso.fi/onto/yso/p1265',
+      headers: {
+        Accept: 'application/rdf+xml'
+      }
+    }).then((response) => {
+      // Check that the Content-Type header contains 'application/rdf+xml'
+      expect(response.headers['content-type']).to.include('application/rdf+xml');
+      // Check that the response body is not empty
+      expect(response.body).to.not.be.empty;
+    })
+  });
+});

--- a/tests/jenatestconfig.ttl
+++ b/tests/jenatestconfig.ttl
@@ -34,7 +34,7 @@
     # customize the base element. Set this if the automatic base url detection doesn't work. For example setups behind a proxy.
     # skosmos:baseHref "http://localhost/Skosmos/" ;
     # interface languages available, and the corresponding system locales
-    skosmos:languages ( [ :name "en" ; :value "en_GB.utf8" ] ) ;
+    skosmos:languages ( [ rdfs:label "en" ; rdf:value "en_GB.utf8" ] ) ;
     # how many results (maximum) to load at a time on the search results page
     skosmos:searchResultsSize 20 ;
     # how many items (maximum) to retrieve in transitive property queries


### PR DESCRIPTION
## Reasons for creating this PR

There is a chicken-and-egg problem in initializing the Model and GlobalConfig objects that are fundamental to the Skosmos application (see #1627). This PR changes the way these are initialized to avoid the circular dependency.

Previously, GlobalConfig was created first (with optionally a path to the configuration file); then Model was created, giving it the GlobalConfig object as a constructor parameter. But this meant that GlobalConfig didn't have access to the Model even though it should, since it's a subclass of DataObject and DataObjects are expected to know the current Model. A similar problem affects VocabularyConfig that also needs to be aware of the Model as it is also a DataObject.

This PR changes the situation:

- Model is always created first, and its constructor (which is optionally given a path to the configuration file) creates the GlobalConfig object. This way both objects are aware of each other from the beginning. It also means that they always go hand-in-hand; it's not possible to create one without the other.
- VocabularyConfig is now given the Model as a constructor parameter.

These changes are not very big, but since many PHPUnit tests initialize one or more of these objects, a lot of changes had to be made to the test suite.

Also, the exception handling was a bit broken/misplaced, so this PR changes the way exceptional situations are handled. Exceptions are thrown by GlobalConfig but they are no longer immediately caught within GlobalConfig. Instead the exception is allowed to propagate to the outermost calling code. `index.php` catches and reports these exceptions to the user because this helps to diagnose common problems encountered when Skosmos is being installed. (This matches the old behavior, but the catching code has been moved.)

In the initial version of this PR, I forgot to fix entity.php; it was not covered by any PHPUnit or Cypress tests. So I added a few simple Cypress tests to verify that entity.php is working.

## Link to relevant issue(s), if any

- Closes #1627

## Description of the changes in this PR

* change the constructors of Model, GlobalConfig and VocabularyConfig for the new initialization style
* modify the Skosmos application code to use the new initialization style
* adapt the PHPUnit tests to the changes in the initialization
* add a new unit test VocabularyTest.testGetShortNameLang that verifies that GlobalConfig can access current language information from the Model (this was not possible until this PR)
* add a new Cypress E2E test for serving linked data via entity.php

## Known problems or uncertainties in this PR

none

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
