### PR TITLE
Setting the language in the search bar

### DIFF
--- a/resource/js/vocab-search.js
+++ b/resource/js/vocab-search.js
@@ -74,7 +74,7 @@ const vocabSearch = Vue.createApp({
       const paramLang = urlParams.get('clang')
       const anyLang = urlParams.get('anylang')
       if (anyLang) {
-        document.cookie = `SKOSMOS_SEARCH_LANG=${'all'};path=/`
+        this.setSearchLangCookie('all')
         return 'all'
       }
       if (paramLang) {
@@ -186,13 +186,7 @@ const vocabSearch = Vue.createApp({
     },
     changeLang (lang) {
       this.selectedLanguage = lang
-      // Setting the cookie path to be the relative part of the baseHref if it is provided
-      let cookiePath = '/'
-      if (window.SKOSMOS.baseHref && window.SKOSMOS.baseHref.replace(window.origin, '')) {
-        cookiePath = window.SKOSMOS.baseHref.replace(window.origin, '')
-      }
-      document.cookie = `SKOSMOS_SEARCH_LANG=${this.selectedLanguage};path=${cookiePath}`
-
+      this.setSearchLangCookie(lang)
       this.resetSearchTermAndHideDropdown()
     },
     changeContentLangAndReload (lang) {
@@ -218,6 +212,14 @@ const vocabSearch = Vue.createApp({
     showAutoComplete () {
       this.showDropdown = true
       this.$forceUpdate()
+    },
+    setSearchLangCookie (lang) {
+      // The cookie path should be relative if the baseHref is known
+      let cookiePath = '/'
+      if (window.SKOSMOS.baseHref && window.SKOSMOS.baseHref.replace(window.origin, '')) {
+        cookiePath = window.SKOSMOS.baseHref.replace(window.origin, '')
+      }
+      document.cookie = `SKOSMOS_SEARCH_LANG=${this.selectedLanguage};path=${cookiePath}`
     }
   },
   template: `

--- a/resource/js/vocab-search.js
+++ b/resource/js/vocab-search.js
@@ -74,7 +74,7 @@ const vocabSearch = Vue.createApp({
       const paramLang = urlParams.get('clang')
       const anyLang = urlParams.get('anylang')
       if (anyLang) {
-        this.setSearchLangCookie('all')
+        this.changeLang('all')
         return 'all'
       }
       if (paramLang) {

--- a/resource/js/vocab-search.js
+++ b/resource/js/vocab-search.js
@@ -74,7 +74,7 @@ const vocabSearch = Vue.createApp({
       const paramLang = urlParams.get('clang')
       const anyLang = urlParams.get('anylang')
       if (anyLang) {
-        document.cookie = `SKOSMOS_SEARCH_LANG=${'all'}`
+        document.cookie = `SKOSMOS_SEARCH_LANG=${'all'};path=/`
         return 'all'
       }
       if (paramLang) {
@@ -186,7 +186,7 @@ const vocabSearch = Vue.createApp({
     },
     changeLang (lang) {
       this.selectedLanguage = lang
-      document.cookie = `SKOSMOS_SEARCH_LANG=${this.selectedLanguage}`
+      document.cookie = `SKOSMOS_SEARCH_LANG=${this.selectedLanguage};path=/`
       this.resetSearchTermAndHideDropdown()
     },
     changeContentLangAndReload (lang) {

--- a/resource/js/vocab-search.js
+++ b/resource/js/vocab-search.js
@@ -187,7 +187,7 @@ const vocabSearch = Vue.createApp({
     changeLang (lang) {
       this.selectedLanguage = lang
       // Setting the cookie path to be the relative part of the baseHref if it is provided
-      const cookiePath = "/"
+      let cookiePath = '/'
       if (window.SKOSMOS.baseHref && window.SKOSMOS.baseHref.replace(window.origin, '')) {
         cookiePath = window.SKOSMOS.baseHref.replace(window.origin, '')
       }

--- a/resource/js/vocab-search.js
+++ b/resource/js/vocab-search.js
@@ -45,7 +45,8 @@ const vocabSearch = Vue.createApp({
       const mySearchCounter = this.searchCounter + 1 // make sure we can identify this search later in case of several ongoing searches
       this.searchCounter = mySearchCounter
       let skosmosSearchUrl = 'rest/v1/' + window.SKOSMOS.vocab + '/search?'
-      const skosmosSearchUrlParams = new URLSearchParams({ query: this.formatSearchTerm(), lang: window.SKOSMOS.lang, unique: true })
+      const skosmosSearchUrlParams = new URLSearchParams({ query: this.formatSearchTerm(), unique: true })
+      if (this.selectedLanguage !== 'all') skosmosSearchUrlParams.set('lang', this.selectedLanguage)
       skosmosSearchUrl += skosmosSearchUrlParams.toString()
 
       fetch(skosmosSearchUrl)
@@ -148,8 +149,10 @@ const vocabSearch = Vue.createApp({
       const searchUrl = vocabHref + 'search?' + searchUrlParams.toString()
       window.location.href = searchUrl
     },
-    changeLang () {
+    changeLang (changeEvent) {
+      this.selectedLanguage = changeEvent.target.value
       window.SKOSMOS.content_lang = this.selectedLanguage
+      this.resetSearchTermAndHideDropdown()
       // TODO: Implement (a normal) page load to change content according to the new content language
     },
     resetSearchTermAndHideDropdown () {
@@ -170,7 +173,7 @@ const vocabSearch = Vue.createApp({
       <div class="d-flex justify-content-end input-group ms-auto" id="search-wrapper">
         <select class="btn btn-outline-secondary dropdown-toggle" data-bs-toggle="dropdown-item"
           v-model="selectedLanguage"
-          @change="changeLang()"
+          @change="changeLang($event)"
           aria-label="Select search language">
           <option class="dropdown-item" v-for="(value, key) in languageStrings" :value="key">{{ value }}</option>
         </select>

--- a/resource/js/vocab-search.js
+++ b/resource/js/vocab-search.js
@@ -186,7 +186,13 @@ const vocabSearch = Vue.createApp({
     },
     changeLang (lang) {
       this.selectedLanguage = lang
-      document.cookie = `SKOSMOS_SEARCH_LANG=${this.selectedLanguage};path=/`
+      // Setting the cookie path to be the relative part of the baseHref if it is provided
+      const cookiePath = "/"
+      if (window.SKOSMOS.baseHref && window.SKOSMOS.baseHref.replace(window.origin, '')) {
+        cookiePath = window.SKOSMOS.baseHref.replace(window.origin, '')
+      }
+      document.cookie = `SKOSMOS_SEARCH_LANG=${this.selectedLanguage};path=${cookiePath}`
+
       this.resetSearchTermAndHideDropdown()
     },
     changeContentLangAndReload (lang) {

--- a/src/view/scripts.inc
+++ b/src/view/scripts.inc
@@ -24,6 +24,7 @@ window.SKOSMOS = {
   {%- if request.plugins.callbacks ~%}
   "pluginCallbacks": [{% for function in request.plugins.callbacks %}{% if not loop.first %}, {% endif %}"{{ function }}"{% endfor %}],
   {%- endif ~%}
+  "baseHref": "{{ BaseHref }}",
   "language_strings": { "fi": { "fi": "suomi",
                                 "en": "englanti",
                                 "se": "pohjoissaame",

--- a/tests/cypress/template/vocab-search-bar.cy.js
+++ b/tests/cypress/template/vocab-search-bar.cy.js
@@ -1,157 +1,183 @@
 describe('Vocab search bar', () => {
-  it('search can be done with a chosen content language', () => {
-    // go to YSO vocab front page
-    cy.visit('/yso/fi/')
 
-    // Select an option from the dropdown
-    cy.get('#search-wrapper select').select('sv');
+  describe('Search Language', () => {
+    it('search can be done with a chosen content language', () => {
+      // go to YSO vocab front page
+      cy.visit('/yso/fi/')
 
-    // Enter a search term
-    cy.get('#search-wrapper input').type('Katt');
+      // Select an option from the dropdown
+      cy.get('#search-wrapper select').select('sv');
 
-    // Click the search button
-    cy.get('#search-button').click();
+      // Enter a search term
+      cy.get('#search-wrapper input').type('Katt');
 
-    //Verify the search page url (search result page tests are elsewhere)
-    cy.url().should('include', 'q=Katt').and('include', 'clang=sv');
+      // Click the search button
+      cy.get('#search-button').click();
 
-  })
+      // Verify the search page url (search result page tests are elsewhere)
+      cy.url().should('include', 'q=Katt').and('include', 'clang=sv');
+    })
 
-  it('search can be done with all languages', () => {
-    // go to YSO vocab front page
-    cy.visit('/yso/fi/')
+    it('search can be done with all languages', () => {
+      // go to YSO vocab front page
+      cy.visit('/yso/fi/')
 
-    // Choose 'all' languages
-    cy.get('#search-wrapper select').select('all');
+      // Choose 'all' languages
+      cy.get('#search-wrapper select').select('all');
 
-    // Enter a search term
-    cy.get('#search-wrapper input').type('Katt');
+      // Enter a search term
+      cy.get('#search-wrapper input').type('Katt');
 
-    // Click the search button
-    cy.get('#search-button').click();
+      // Click the search button
+      cy.get('#search-button').click();
 
-    //Verify the search page url (search result page tests are elsewhere)
-    cy.url().should('include', 'q=Katt').and('include', 'anylang=true');
-  })
+      // Verify the search page url (search result page tests are elsewhere)
+      cy.url().should('include', 'q=Katt').and('include', 'anylang=true');
+    })
+  });
 
-  it('Writing in the text field triggers the autocomplete results list', () => {
-    // go to YSO vocab front page
-    cy.visit('/yso/fi/')
+  describe('Autocomplete', () => {
+    it('Writing in the text field triggers the autocomplete results list', () => {
+      // go to YSO vocab front page
+      cy.visit('/yso/fi/')
 
-    cy.get('#search-field').type('kas'); // perform autocomplete search
-    cy.get('#search-autocomplete-results', { timeout: 20000 }).should('be.visible').children().should('have.length.greaterThan', 2);
-  })
+      cy.get('#search-field').type('kas'); // perform autocomplete search
+      cy.get('#search-autocomplete-results', { timeout: 20000 }).should('be.visible').children().should('have.length.greaterThan', 2);
+    })
 
-  it('No results message is displayed if no results are found', () => {
-    // go to YSO vocab front page
-    cy.visit('/yso/en/')
+    it('Special characters can be used in the search', () => {
+      // go to YSO vocab front page
+      cy.visit('/yso/fi/')
 
-    cy.get('#search-field').type('kissa'); // even if the search yields no results, there shoulde a single line in the result list
-    cy.get('#search-autocomplete-results', { timeout: 20000 }).should('be.visible').children().should('have.length.greaterThan', 0);
-    cy.get('#search-autocomplete-results').within(() => {
+      cy.get('#search-field').type('*tus (*');
+      cy.get('#search-autocomplete-results', { timeout: 20000 }).should('be.visible'); // the autocomplete should appear
+
+      cy.get('#search-autocomplete-results').within(() => { // the first result should have text ajoitus (historia)
+        cy.get('li').first().should('contain', 'ajoitus (historia)')
+      })
+    })
+
+    it('No results message is displayed if no results are found', () => {
+      // go to YSO vocab front page
+      cy.visit('/yso/en/')
+
+      cy.get('#search-field').type('kissa'); // even if the search yields no results, there shoulde a single line in the result list
+      cy.get('#search-autocomplete-results', { timeout: 20000 }).should('be.visible').children().should('have.length.greaterThan', 0);
+      cy.get('#search-autocomplete-results').within(() => {
         cy.get('li').eq(0).invoke('text').should('contain', 'No results') // the single result should display a no results message
       })
-  })
-
-  it('No results are displayed for autocomplete if there is not at leas two charecters in the search term', () => {
-    // go to YSO vocab front page
-    cy.visit('/yso/en/')
-
-    cy.get('#search-field').type('k'); // even if the search yields no results, there shoulde a single line in the result list
-    cy.get('#search-autocomplete-results', { timeout: 20000 }).should('not.be.visible');
-  })
-
-  it('The autocomplete list should not change due to previous searches completing', () => {
-    // go to YSO vocab front page
-    cy.visit('/yso/fi/')
-
-    cy.get('#search-field').type('ka');
-    cy.wait(300);
-    cy.get('#search-field').type('i');
-    cy.get('#search-autocomplete-results', { timeout: 20000 }).should('be.visible'); // the autocomplete should appear
-    cy.get('#search-autocomplete-results').children().should('have.length', 1)
-    cy.wait(10000); // wait extra 10 seconds to see if the 'ka' search adds results to the list
-    cy.get('#search-autocomplete-results').children().should('have.length', 1)
-  })
-
-  it('Clear button should hide the autocomplete list', () => {
-    // go to YSO vocab front page
-    cy.visit('/yso/en/')
-
-    cy.get('#search-field').type('kas');
-    cy.get('#search-autocomplete-results', { timeout: 20000 }).should('be.visible'); // the autocomplete should appear
-
-    cy.get('#clear-button').click()
-    cy.get('#search-autocomplete-results').should('not.be.visible'); // the autocomplete should disappear
-  })
-
-  it('Emptying the text search field hides the autocomplete list', () => {
-    // go to YSO vocab front page
-    cy.visit('/yso/en/')
-
-    cy.get('#search-field').type('kis');
-    cy.get('#search-autocomplete-results', { timeout: 20000 }).should('be.visible'); // the autocomplete should appear
-
-    cy.get('#search-field').clear();
-    cy.get('#search-autocomplete-results').should('not.be.visible'); // the autocomplete should disappear
-  })
-
-  it('Clicking outside of the autocomplete list hides the autocomplete list', () => {
-    // go to YSO vocab front page
-    cy.visit('/yso/en/')
-
-    cy.get('#search-field').type('kas');
-    cy.get('#search-autocomplete-results', { timeout: 20000 }).should('be.visible'); // the autocomplete should appear
-
-    cy.get('#main-container').click({ force: true }); // using force true to click on elements not considered actionable
-    cy.get('#search-autocomplete-results').should('not.be.visible'); // the autocomplete should disappear
-  })
-
-  it('AltLabel search results should bold the matching parts of altLabel', () => {
-    // go to YSO vocab front page
-    cy.visit('/yso/fi/')
-
-    cy.get('#search-field').type('assyro');
-    cy.get('#search-autocomplete-results', { timeout: 20000 }).should('be.visible'); // the autocomplete should appear
-
-    cy.get('#search-autocomplete-results').within(() => { // the first result should have matching part of text 'assyrologia' appearing in bold
-      cy.get('li').last().find('b').eq(0).should('have.text', 'assyro')
     })
-  })
 
-  it('AltLabel search results should be displayed in italics', () => {
-    // go to YSO vocab front page
-    cy.visit('/yso/fi/')
+    it('No results are displayed for autocomplete if there is not at leas two charecters in the search term', () => {
+      // go to YSO vocab front page
+      cy.visit('/yso/en/')
 
-    cy.get('#search-field').type('assyro');
-    cy.get('#search-autocomplete-results', { timeout: 20000 }).should('be.visible'); // the autocomplete should appear
-
-    cy.get('#search-autocomplete-results').within(() => { // the first result should have text 'assyrologia' appearing in italics
-      cy.get('li').last().find('i').eq(0).should('contain.text', 'assyrologia')
+      cy.get('#search-field').type('k'); // even if the search yields no results, there shoulde a single line in the result list
+      cy.get('#search-autocomplete-results', { timeout: 20000 }).should('not.be.visible');
     })
-  })
 
-  it('Notation search results should bold the matching parts of the notation', () => {
-    // go to YSO vocab front page
-    cy.visit('/yso/fi/')
+    it('The autocomplete list should not change due to previous searches completing', () => {
+      // go to YSO vocab front page
+      cy.visit('/yso/fi/')
 
-    cy.get('#search-field').type('51');
-    cy.get('#search-autocomplete-results', { timeout: 20000 }).should('be.visible'); // the autocomplete should appear
-
-    cy.get('#search-autocomplete-results').within(() => { // the first result should have text '51' appearing in bold
-      cy.get('li').last().find('b').eq(0).should('have.text', '51')
+      cy.get('#search-field').type('ka');
+      cy.wait(300);
+      cy.get('#search-field').type('i');
+      cy.get('#search-autocomplete-results', { timeout: 20000 }).should('be.visible'); // the autocomplete should appear
+      cy.get('#search-autocomplete-results').children().should('have.length', 1)
+      cy.wait(5000); // wait extra 5 seconds to see if the 'ka' search adds results to the list
+      cy.get('#search-autocomplete-results').children().should('have.length', 1)
     })
-  })
 
-  it('Special characters can be used in the search', () => {
-    // go to YSO vocab front page
-    cy.visit('/yso/fi/')
+    it('Clear button should hide the autocomplete list', () => {
+      // go to YSO vocab front page
+      cy.visit('/yso/en/')
 
-    cy.get('#search-field').type('*tus (*');
-    cy.get('#search-autocomplete-results', { timeout: 20000 }).should('be.visible'); // the autocomplete should appear
+      cy.get('#search-field').type('kas');
+      cy.get('#search-autocomplete-results', { timeout: 20000 }).should('be.visible'); // the autocomplete should appear
 
-    cy.get('#search-autocomplete-results').within(() => { // the first result should have text ajoitus (historia)
-      cy.get('li').first().should('contain', 'ajoitus (historia)')
+      cy.get('#clear-button').click()
+      cy.get('#search-autocomplete-results').should('not.be.visible'); // the autocomplete should disappear
     })
-  })
+
+    it('Emptying the text search field hides the autocomplete list', () => {
+      // go to YSO vocab front page
+      cy.visit('/yso/en/')
+
+      cy.get('#search-field').type('kis');
+      cy.get('#search-autocomplete-results', { timeout: 20000 }).should('be.visible'); // the autocomplete should appear
+
+      cy.get('#search-field').clear();
+      cy.get('#search-autocomplete-results').should('not.be.visible'); // the autocomplete should disappear
+    })
+
+    it('Clicking outside of the autocomplete list hides the autocomplete list', () => {
+      // go to YSO vocab front page
+      cy.visit('/yso/en/')
+
+      cy.get('#search-field').type('kas');
+      cy.get('#search-autocomplete-results', { timeout: 20000 }).should('be.visible'); // the autocomplete should appear
+
+      cy.get('#main-container').click({ force: true }); // using force true to click on elements not considered actionable
+      cy.get('#search-autocomplete-results').should('not.be.visible'); // the autocomplete should disappear
+    })
+  });
+
+  describe('Search Result Rendering', () => {
+    it('AltLabel search results should bold the matching parts of altLabel', () => {
+      // go to YSO vocab front page
+      cy.visit('/yso/fi/')
+
+      cy.get('#search-field').type('assyro');
+      cy.get('#search-autocomplete-results', { timeout: 20000 }).should('be.visible'); // the autocomplete should appear
+
+      cy.get('#search-autocomplete-results').within(() => { // the first result should have matching part of text 'assyrologia' appearing in bold
+        cy.get('li').last().find('b').eq(0).should('have.text', 'assyro')
+      })
+    })
+
+    it('AltLabel search results should be displayed in italics', () => {
+      // go to YSO vocab front page
+      cy.visit('/yso/fi/')
+
+      cy.get('#search-field').type('assyro');
+      cy.get('#search-autocomplete-results', { timeout: 20000 }).should('be.visible'); // the autocomplete should appear
+
+      cy.get('#search-autocomplete-results').within(() => { // the first result should have text 'assyrologia' appearing in italics
+        cy.get('li').last().find('i').eq(0).should('contain.text', 'assyrologia')
+      })
+    })
+
+    it('Notation search results should bold the matching parts of the notation', () => {
+      // go to YSO vocab front page
+      cy.visit('/yso/fi/')
+
+      cy.get('#search-field').type('51');
+      cy.get('#search-autocomplete-results', { timeout: 20000 }).should('be.visible'); // the autocomplete should appear
+
+      cy.get('#search-autocomplete-results').within(() => { // the first result should have text '51' appearing in bold
+        cy.get('li').last().find('b').eq(0).should('have.text', '51')
+      })
+    })
+  });
+
+  describe('Cookie Management', () => {
+    it('The search language cookie is set', () => {
+      cy.visit('/yso/fi/');
+
+      // Select an option from the dropdown to set the search language
+      cy.get('#search-wrapper select').select('sv');
+
+      // Test that the cookie has been set correctly
+      cy.getCookie('SKOSMOS_SEARCH_LANG').should('have.property', 'value', 'sv');
+    });
+
+    it('The search language cookie is read', () => {
+      cy.setCookie('SKOSMOS_SEARCH_LANG', 'en');
+      cy.visit('/yso/fi/');
+
+      // Test that the cookie value has been read and used to initialize the language selector
+      cy.get('#search-wrapper select').should('have.value', 'en');
+    });
+  });
 })

--- a/tests/cypress/template/vocab-search-bar.cy.js
+++ b/tests/cypress/template/vocab-search-bar.cy.js
@@ -34,6 +34,21 @@ describe('Vocab search bar', () => {
       // Verify the search page url (search result page tests are elsewhere)
       cy.url().should('include', 'q=Katt').and('include', 'anylang=true');
     })
+
+    it('search with all languages retains the previously chosen content language', () => {
+      // go to YSO vocab front page
+      cy.visit('/yso/fi/')
+
+      // Choose 'sv' for search & content language
+      cy.get('#search-wrapper select').select('sv');
+
+      // Choose 'all' for search language
+      cy.get('#search-wrapper select').select('all');
+
+      // Verify the search page url has the previously chosen language as the content language
+      cy.url().should('include', 'clang=sv');
+    })
+
   });
 
   describe('Autocomplete', () => {

--- a/tests/cypress/template/vocab-search-bar.cy.js
+++ b/tests/cypress/template/vocab-search-bar.cy.js
@@ -173,6 +173,7 @@ describe('Vocab search bar', () => {
     });
 
     it('The search language cookie is read', () => {
+      cy.visit('/'); // setting the cookie at the front page to make sure the cookies are set globally
       cy.setCookie('SKOSMOS_SEARCH_LANG', 'en');
       cy.visit('/yso/fi/');
 

--- a/tests/cypress/template/vocab-search-bar.cy.js
+++ b/tests/cypress/template/vocab-search-bar.cy.js
@@ -31,7 +31,7 @@ describe('Vocab search bar', () => {
     cy.get('#search-button').click();
 
     //Verify the search page url (search result page tests are elsewhere)
-    cy.url().should('include', 'q=Katt').and('include', 'anylang=on');
+    cy.url().should('include', 'q=Katt').and('include', 'anylang=true');
   })
 
   it('Writing in the text field triggers the autocomplete results list', () => {


### PR DESCRIPTION
## Link to relevant issue(s), if any

#1514 

## Description of the changes in this PR

- Rendering the search results when "All languages" is chosen
- Choosing the correct search language
  - First from the url clang parameter
  - Second from cookie
  - If all else fails, from the SKOSMOS object

## Known problems or uncertainties in this PR
Needs more cypress tests

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
