### PR TITLE
Fetch letters and concepts based on content language

### DIFF
--- a/resource/js/tab-alpha.js
+++ b/resource/js/tab-alpha.js
@@ -42,7 +42,7 @@ const tabAlphaApp = Vue.createApp({
       this.loadingLetters = true
       // Remove scrolling event listener while letters are loaded
       this.$refs.tabAlpha.$refs.list.removeEventListener('scroll', this.handleScrollEvent)
-      fetch('rest/v1/' + window.SKOSMOS.vocab + '/index/?lang=' + window.SKOSMOS.lang)
+      fetch('rest/v1/' + window.SKOSMOS.vocab + '/index/?lang=' + window.SKOSMOS.content_lang)
         .then(data => {
           return data.json()
         })
@@ -58,7 +58,7 @@ const tabAlphaApp = Vue.createApp({
       this.currentOffset = 0
       // Remove scrolling event listener while concepts are loaded
       this.$refs.tabAlpha.$refs.list.removeEventListener('scroll', this.handleScrollEvent)
-      const url = 'rest/v1/' + window.SKOSMOS.vocab + '/index/' + letter + '?lang=' + window.SKOSMOS.lang + '&limit=250'
+      const url = 'rest/v1/' + window.SKOSMOS.vocab + '/index/' + letter + '?lang=' + window.SKOSMOS.content_lang + '&limit=250'
       fetchWithAbort(url, 'alpha')
         .then(data => {
           return data.json()
@@ -83,7 +83,7 @@ const tabAlphaApp = Vue.createApp({
       this.loadingMoreConcepts = true
       // Remove scrolling event listener while new concepts are loaded
       this.$refs.tabAlpha.$refs.list.removeEventListener('scroll', this.handleScrollEvent)
-      const url = 'rest/v1/' + window.SKOSMOS.vocab + '/index/' + this.selectedLetter + '?lang=' + window.SKOSMOS.lang + '&limit=250&offset=' + this.currentOffset
+      const url = 'rest/v1/' + window.SKOSMOS.vocab + '/index/' + this.selectedLetter + '?lang=' + window.SKOSMOS.content_lang + '&limit=250&offset=' + this.currentOffset
       fetchWithAbort(url, 'alpha')
         .then(data => {
           return data.json()

--- a/tests/cypress/template/sidebar.cy.js
+++ b/tests/cypress/template/sidebar.cy.js
@@ -12,4 +12,12 @@ describe('Sidebar', () => {
     cy.get('#sidebar-tabs').find('.active').should('have.length', 1)
     cy.get('.tab-content').find('.active').should('have.length', 1)
   })
+  it('Concepts and letters in alphabetical index are displayed in the correct language', () => {
+    // go to YSO vocab from page with UI language in English and content language in Finnish
+    cy.visit('/yso/en/?clang=fi')
+    // check that first item in the list is in the correct language
+    cy.get('#tab-alphabetical .sidebar-list a').first().invoke('text').should('contain', 'aarrelöydöt')
+    // check that letters contain Y and not C
+    cy.get('#tab-alphabetical .pagination a').invoke('text').should('contain', 'Y').should('not.contain', 'C')
+  })
 })

--- a/tests/cypress/template/sidebar.cy.js
+++ b/tests/cypress/template/sidebar.cy.js
@@ -13,9 +13,9 @@ describe('Sidebar', () => {
     cy.get('.tab-content').find('.active').should('have.length', 1)
   })
   it('Concepts and letters in alphabetical index are displayed in the correct language', () => {
-    // go to YSO vocab from page with UI language in English and content language in Finnish
+    // go to YSO vocab from page with UI language set to English and content language set to Finnish
     cy.visit('/yso/en/?clang=fi')
-    // check that first item in the list is in the correct language
+    // check that the first item in the list is in the correct language
     cy.get('#tab-alphabetical .sidebar-list a').first().invoke('text').should('contain', 'aarrelöydöt')
     // check that letters contain Y and not C
     cy.get('#tab-alphabetical .pagination a').invoke('text').should('contain', 'Y').should('not.contain', 'C')


### PR DESCRIPTION
## Reasons for creating this PR

Alphabetical index shows concepts and letters in UI language instead of content language.

## Link to relevant issue(s), if any

- Part of #1563

## Description of the changes in this PR

Fetch letters and concepts based on content languge, addresses requirement 3 in #1563

## Known problems or uncertainties in this PR

## Checklist

- [ ] phpUnit tests pass locally with my changes
- [ ] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [ ] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [ ] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
