### PR TITLE
Concept type translations for autocomplete search

### DIFF
--- a/resource/js/vocab-search.js
+++ b/resource/js/vocab-search.js
@@ -117,7 +117,7 @@ const vocabSearch = Vue.createApp({
       return null
     },
     translateType (type) {
-      return window.SKOSMOS.msgs[window.SKOSMOS.lang][type]
+      return window.SKOSMOS.typeTranslations[type]
     },
     /*
      * renderResults is used when the search string has been indexed in the cache

--- a/src/controller/WebController.php
+++ b/src/controller/WebController.php
@@ -539,7 +539,9 @@ class WebController extends Controller
         $types = array();
 
         foreach ($queriedtypes as $uri => $typedata) {
-            $types[$uri] = $typedata['label'];
+            if ($typedata['label']) {
+                $types[$uri] = $typedata['label'];
+            }
         }
         return json_encode($types, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
     }

--- a/src/view/scripts.inc
+++ b/src/view/scripts.inc
@@ -25,6 +25,9 @@ window.SKOSMOS = {
   "pluginCallbacks": [{% for function in request.plugins.callbacks %}{% if not loop.first %}, {% endif %}"{{ function }}"{% endfor %}],
   {%- endif ~%}
   "baseHref": "{{ BaseHref }}",
+  {%~ if conceptTypeTranslations %}
+  "typeTranslations": {{ conceptTypeTranslations|raw }},
+  {%- endif ~%}
   "language_strings": { "fi": { "fi": "suomi",
                                 "en": "englanti",
                                 "se": "pohjoissaame",


### PR DESCRIPTION
## Link to relevant issue(s), if any

#1514

## Description of the changes in this PR

This PR produces translation strings in WebController for different class URIs. Autocomplete result list can then present human readable labels for the types of search results.

## Known problems or uncertainties in this PR

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
