### PR TITLE
Add loading spinners to Vue components

### DIFF
--- a/resource/js/concept-mappings.js
+++ b/resource/js/concept-mappings.js
@@ -58,7 +58,8 @@ const conceptMappingsApp = Vue.createApp({
         </template>
         <template v-else>
           <i class="fa-solid fa-spinner fa-spin-pulse"></i>
-        </div>
+        </template>
+      </div>
     </div>
   `
 })

--- a/resource/js/concept-mappings.js
+++ b/resource/js/concept-mappings.js
@@ -52,9 +52,13 @@ const conceptMappingsApp = Vue.createApp({
   },
   template: `
     <div v-load-concept-page="loadMappings">
-      <div v-if="hasMappings" class="main-content-section p-5">
-        <concept-mappings :mappings="mappings"></concept-mappings>
-      </div>
+      <div class="main-content-section p-5">
+        <template v-if="hasMappings">
+          <concept-mappings :mappings="mappings"></concept-mappings>
+        </template>
+        <template v-else>
+          <i class="fa-solid fa-spinner fa-spin-pulse"></i>
+        </div>
     </div>
   `
 })

--- a/resource/js/concept-mappings.js
+++ b/resource/js/concept-mappings.js
@@ -4,7 +4,8 @@
 const conceptMappingsApp = Vue.createApp({
   data () {
     return {
-      mappings: {}
+      mappings: {},
+      loading: false
     }
   },
   provide: {
@@ -18,6 +19,7 @@ const conceptMappingsApp = Vue.createApp({
   methods: {
     loadMappings () {
       this.mappings = {} // clear mappings before starting to load new ones
+      this.loading = true
       const url = 'rest/v1/' + window.SKOSMOS.vocab + '/mappings?uri=' + window.SKOSMOS.uri + '&external=true&clang=' + window.SKOSMOS.lang + '&lang=' + window.SKOSMOS.content_lang
       fetchWithAbort(url, 'concept')
         .then(data => {
@@ -25,6 +27,7 @@ const conceptMappingsApp = Vue.createApp({
         })
         .then(data => {
           this.mappings = this.group_by(data.mappings, 'typeLabel')
+          this.loading = false
         })
         .catch(error => {
           if (error.name === 'AbortError') {
@@ -32,6 +35,7 @@ const conceptMappingsApp = Vue.createApp({
           } else {
             throw error
           }
+          this.loading = false
         })
     },
     // from https://stackoverflow.com/a/71505541
@@ -52,14 +56,16 @@ const conceptMappingsApp = Vue.createApp({
   },
   template: `
     <div v-load-concept-page="loadMappings">
-      <div class="main-content-section p-5">
-        <template v-if="hasMappings">
-          <concept-mappings :mappings="mappings"></concept-mappings>
-        </template>
-        <template v-else>
+      <template v-if="loading">
+        <div class="main-content-section p-5">
           <i class="fa-solid fa-spinner fa-spin-pulse"></i>
-        </template>
-      </div>
+        </div>
+      </template>
+      <template v-else-if="hasMappings">
+        <div class="main-content-section p-5">
+          <concept-mappings :mappings="mappings"></concept-mappings>
+        </div>
+      </template>
     </div>
   `
 })

--- a/resource/js/tab-hierarchy.js
+++ b/resource/js/tab-hierarchy.js
@@ -174,7 +174,9 @@ const tabHierApp = Vue.createApp({
             @select-concept="selectedConcept = $event"
           ></tab-hier-wrapper>
         </ul>
-        <template v-else>Loading...</template><!-- Add a spinner or equivalent -->
+        <template v-else>
+          <i class="fa-solid fa-spinner fa-spin-pulse"></i>
+        </template>
       </div>
     </div>
   `

--- a/resource/js/term-counts.js
+++ b/resource/js/term-counts.js
@@ -9,37 +9,46 @@ const termCountsApp = Vue.createApp({
   mounted () {
     fetch('rest/v1/' + window.SKOSMOS.vocab + '/labelStatistics?lang=' + window.SKOSMOS.lang)
       .then(data => {
+        console.log('a')
         return data.json()
       })
       .then(data => {
+        console.log('b')
         this.languages = data.languages
       })
   },
   template: `
     <h3 class="fw-bold py-3">Term counts by language</h3>
-    <table class="table" id="term-stats">
-      <tbody>
-        <tr>
-          <th class="main-table-label fw-bold">Concept language</th>
-          <th class="main-table-label fw-bold">Preferred terms</th>
-          <th class="main-table-label fw-bold">Alternate terms</th>
-          <th class="main-table-label fw-bold">Hidden terms</th>
-        </tr>
-        <term-counts :languages="languages"></term-counts>
-      </tbody>
-    </table>
+    
+      <table class="table" id="term-stats">
+        <tbody>
+          <tr>
+            <th class="main-table-label fw-bold">Concept language</th>
+            <th class="main-table-label fw-bold">Preferred terms</th>
+            <th class="main-table-label fw-bold">Alternate terms</th>
+            <th class="main-table-label fw-bold">Hidden terms</th>
+          </tr>
+          <term-counts :languages="languages"></term-counts>
+        </tbody>
+      </table>
+    
   `
 })
 
 termCountsApp.component('term-counts', {
   props: ['languages'],
   template: `
-    <tr v-for="l in languages">
-      <td>{{ l.literal }}</td>
-      <td>{{ l.properties.find(a => a.property === 'skos:prefLabel').labels }}</td>
-      <td>{{ l.properties.find(a => a.property === 'skos:altLabel').labels }}</td>
-      <td>{{ l.properties.find(a => a.property === 'skos:hiddenLabel').labels }}</td>
-    </tr>
+    <template v-if="languages.length">
+      <tr v-for="l in languages">
+        <td>{{ l.literal }}</td>
+        <td>{{ l.properties.find(a => a.property === 'skos:prefLabel').labels }}</td>
+        <td>{{ l.properties.find(a => a.property === 'skos:altLabel').labels }}</td>
+        <td>{{ l.properties.find(a => a.property === 'skos:hiddenLabel').labels }}</td>
+      </tr>
+    </template>
+    <template v-else >
+      <i class="fa-solid fa-spinner fa-spin-pulse"></i>
+    </template>
   `
 })
 

--- a/resource/js/term-counts.js
+++ b/resource/js/term-counts.js
@@ -9,34 +9,30 @@ const termCountsApp = Vue.createApp({
   mounted () {
     fetch('rest/v1/' + window.SKOSMOS.vocab + '/labelStatistics?lang=' + window.SKOSMOS.lang)
       .then(data => {
-        console.log('a')
         return data.json()
       })
       .then(data => {
-        console.log('b')
         this.languages = data.languages
       })
   },
   template: `
     <h3 class="fw-bold py-3">Term counts by language</h3>
-    
-      <table class="table" id="term-stats">
-        <tbody>
-          <tr>
-            <th class="main-table-label fw-bold">Concept language</th>
-            <th class="main-table-label fw-bold">Preferred terms</th>
-            <th class="main-table-label fw-bold">Alternate terms</th>
-            <th class="main-table-label fw-bold">Hidden terms</th>
-          </tr>
-          <template v-if="languages.length">
-            <term-counts :languages="languages"></term-counts>
-          </template>
-          <template v-else >
-            <i class="fa-solid fa-spinner fa-spin-pulse"></i>
-          </template>
-        </tbody>
-      </table>
-    
+    <table class="table" id="term-stats">
+      <tbody>
+        <tr>
+          <th class="main-table-label fw-bold">Concept language</th>
+          <th class="main-table-label fw-bold">Preferred terms</th>
+          <th class="main-table-label fw-bold">Alternate terms</th>
+          <th class="main-table-label fw-bold">Hidden terms</th>
+        </tr>
+        <template v-if="languages.length">
+          <term-counts :languages="languages"></term-counts>
+        </template>
+        <template v-else >
+          <i class="fa-solid fa-spinner fa-spin-pulse"></i>
+        </template>
+      </tbody>
+    </table>
   `
 })
 

--- a/resource/js/term-counts.js
+++ b/resource/js/term-counts.js
@@ -28,7 +28,12 @@ const termCountsApp = Vue.createApp({
             <th class="main-table-label fw-bold">Alternate terms</th>
             <th class="main-table-label fw-bold">Hidden terms</th>
           </tr>
-          <term-counts :languages="languages"></term-counts>
+          <template v-if="languages.length">
+            <term-counts :languages="languages"></term-counts>
+          </template>
+          <template v-else >
+            <i class="fa-solid fa-spinner fa-spin-pulse"></i>
+          </template>
         </tbody>
       </table>
     
@@ -38,17 +43,12 @@ const termCountsApp = Vue.createApp({
 termCountsApp.component('term-counts', {
   props: ['languages'],
   template: `
-    <template v-if="languages.length">
-      <tr v-for="l in languages">
-        <td>{{ l.literal }}</td>
-        <td>{{ l.properties.find(a => a.property === 'skos:prefLabel').labels }}</td>
-        <td>{{ l.properties.find(a => a.property === 'skos:altLabel').labels }}</td>
-        <td>{{ l.properties.find(a => a.property === 'skos:hiddenLabel').labels }}</td>
-      </tr>
-    </template>
-    <template v-else >
-      <i class="fa-solid fa-spinner fa-spin-pulse"></i>
-    </template>
+    <tr v-for="l in languages">
+      <td>{{ l.literal }}</td>
+      <td>{{ l.properties.find(a => a.property === 'skos:prefLabel').labels }}</td>
+      <td>{{ l.properties.find(a => a.property === 'skos:altLabel').labels }}</td>
+      <td>{{ l.properties.find(a => a.property === 'skos:hiddenLabel').labels }}</td>
+    </tr>
   `
 })
 

--- a/resource/js/vocab-counts.js
+++ b/resource/js/vocab-counts.js
@@ -8,6 +8,11 @@ const resourceCountsApp = Vue.createApp({
       conceptGroups: {}
     }
   },
+  computed: {
+    hasCounts () {
+      return Object.keys(this.concepts).length > 0
+    }
+  },
   mounted () {
     fetch('rest/v1/' + window.SKOSMOS.vocab + '/vocabularyStatistics?lang=' + window.SKOSMOS.lang)
       .then(data => {
@@ -24,7 +29,12 @@ const resourceCountsApp = Vue.createApp({
     <table class="table" id="resource-stats">
       <tbody>
         <tr><th class="versal">Type</th><th class="versal">Count</th></tr>
-        <resource-counts :concepts="concepts" :subTypes="subTypes" :conceptGroups="conceptGroups"></resource-counts>
+        <template v-if="hasCounts">
+          <resource-counts :concepts="concepts" :subTypes="subTypes" :conceptGroups="conceptGroups" :hasCounts="hasCounts"></resource-counts>
+        </template>
+        <template v-else >
+          <i class="fa-solid fa-spinner fa-spin-pulse"></i>
+        </template>
       </tbody>
     </table>
   `

--- a/resource/js/vocab-counts.js
+++ b/resource/js/vocab-counts.js
@@ -30,7 +30,7 @@ const resourceCountsApp = Vue.createApp({
       <tbody>
         <tr><th class="versal">Type</th><th class="versal">Count</th></tr>
         <template v-if="hasCounts">
-          <resource-counts :concepts="concepts" :subTypes="subTypes" :conceptGroups="conceptGroups" :hasCounts="hasCounts"></resource-counts>
+          <resource-counts :concepts="concepts" :subTypes="subTypes" :conceptGroups="conceptGroups"></resource-counts>
         </template>
         <template v-else >
           <i class="fa-solid fa-spinner fa-spin-pulse"></i>

--- a/tests/cypress/template/concept.cy.js
+++ b/tests/cypress/template/concept.cy.js
@@ -99,6 +99,8 @@ describe('Concept page', () => {
 
       // check that we have some mappings
       cy.get('#concept-mappings').should('not.be.empty')
+      // check that spinner does not exist after load
+      cy.get('#concept-mappings i.fa-spinner').should('not.exist')
 
       // check the first mapping property name
       // NOTE: we need to increase the timeout as the mappings can take a long time to load

--- a/tests/cypress/template/concept.cy.js
+++ b/tests/cypress/template/concept.cy.js
@@ -100,7 +100,7 @@ describe('Concept page', () => {
       // check that we have some mappings
       cy.get('#concept-mappings').should('not.be.empty')
       // check that spinner does not exist after load
-      cy.get('#concept-mappings i.fa-spinner').should('not.exist')
+      cy.get('#concept-mappings i.fa-spinner', {'timeout': 15000}).should('not.exist')
 
       // check the first mapping property name
       // NOTE: we need to increase the timeout as the mappings can take a long time to load

--- a/tests/cypress/template/vocab-home.cy.js
+++ b/tests/cypress/template/vocab-home.cy.js
@@ -81,7 +81,7 @@ describe('Vocabulary home page', () => {
     // check that we have some mappings
     cy.get('#concept-mappings').should('not.be.empty')
     // check that loading spinner does not exist
-    cy.get('#concept-mappings i.fa-spinner').should('not.exist')
+    cy.get('#concept-mappings i.fa-spinner', {'timeout': 15000}).should('not.exist')
 
     // check the second mapping property name
     cy.get('.prop-mapping h2', {'timeout': 15000}).eq(0).contains('Exactly matching concepts')
@@ -119,7 +119,7 @@ describe('Vocabulary home page', () => {
     // check that we have some mappings
     cy.get('#concept-mappings').should('not.be.empty')
     // check that loading spinner does not exist
-    cy.get('#concept-mappings i.fa-spinner').should('not.exist')
+    cy.get('#concept-mappings i.fa-spinner', {'timeout': 15000}).should('not.exist')
 
     // check the second mapping property name
     cy.get('.prop-mapping h2', {'timeout': 15000}).eq(0).contains('Exactly matching concepts')

--- a/tests/cypress/template/vocab-home.cy.js
+++ b/tests/cypress/template/vocab-home.cy.js
@@ -15,6 +15,9 @@ describe('Vocabulary home page', () => {
 
     // check that the first letter is B
     letters.first().invoke('text').should('equal', 'B')
+
+    // Check that loading spinner does not exist
+    cy.get('#tab-alphabetical .sidebar-list i.fa-spinner').should('not.exist')
   })
   it('shows alphabetical index entries', () => {
     cy.visit('/test/en') // go to the "Test ontology" home page
@@ -26,6 +29,9 @@ describe('Vocabulary home page', () => {
 
     // check that the first entry is Bass
     entries.first().invoke('text').should('equal', 'Bass')
+
+    // Check that loading spinner does not exist
+    cy.get('#tab-alphabetical .sidebar-list i.fa-spinner').should('not.exist')
   })
   it('alphabetical index letters are clickable', () => {
     cy.visit('/test/en') // go to the "Test ontology" home page
@@ -38,6 +44,9 @@ describe('Vocabulary home page', () => {
 
     // check that the first entry is Carp
     cy.get('#tab-alphabetical .sidebar-list .list-group').children().first().invoke('text').should('equal', 'Carp')
+
+    // Check that loading spinner does not exist
+    cy.get('#tab-alphabetical .sidebar-list i.fa-spinner').should('not.exist')
   })
   it('alphabetical index diacritic letters are clickable', () => {
     cy.visit('/yso/sv/') // go to the YSO home page in Swedish language
@@ -61,7 +70,7 @@ describe('Vocabulary home page', () => {
     cy.get('#tab-alphabetical').contains('a', 'care institutions').click()
 
     // check the concept prefLabel
-    cy.get('#concept-heading h1').invoke('text').should('equal', 'care institutions')
+    cy.get('#concept-heading h1', {'timeout': 15000}).invoke('text').should('equal', 'care institutions')
 
     // check that the SKOSMOS object matches the newly loaded concept
     cy.window().then((win) => {
@@ -71,6 +80,8 @@ describe('Vocabulary home page', () => {
 
     // check that we have some mappings
     cy.get('#concept-mappings').should('not.be.empty')
+    // check that loading spinner does not exist
+    cy.get('#concept-mappings i.fa-spinner').should('not.exist')
 
     // check the second mapping property name
     cy.get('.prop-mapping h2', {'timeout': 15000}).eq(0).contains('Exactly matching concepts')
@@ -97,7 +108,7 @@ describe('Vocabulary home page', () => {
     cy.get('#tab-hierarchy').contains('a', 'Fish').click()
 
     // check the concept prefLabel
-    cy.get('#concept-heading h1').invoke('text').should('equal', 'Fish')
+    cy.get('#concept-heading h1', {'timeout': 15000}).invoke('text').should('equal', 'Fish')
 
     // check that the SKOSMOS object matches the newly loaded concept
     cy.window().then((win) => {
@@ -107,6 +118,8 @@ describe('Vocabulary home page', () => {
 
     // check that we have some mappings
     cy.get('#concept-mappings').should('not.be.empty')
+    // check that loading spinner does not exist
+    cy.get('#concept-mappings i.fa-spinner').should('not.exist')
 
     // check the second mapping property name
     cy.get('.prop-mapping h2', {'timeout': 15000}).eq(0).contains('Exactly matching concepts')


### PR DESCRIPTION
## Reasons for creating this PR

Many Vue components do not currently have loading spinners, this PR adds them.

## Link to relevant issue(s), if any

- Part of #1521 and #1484

## Description of the changes in this PR

Adds Font Awesome spinner icons for loading:
- concept mappings
- hierarchical tree
- new concepts into hierarchical tree
- vocab and term counts on vocab page

Addresses requirement 3j in #1521

## Known problems or uncertainties in this PR

No loading texts are added in this PR

## Checklist

- [ ] phpUnit tests pass locally with my changes
- [ ] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [ ] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [ ] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
