### PR TITLE
Add notation codes to sidebar

### DIFF
--- a/resource/css/skosmos.css
+++ b/resource/css/skosmos.css
@@ -560,7 +560,7 @@ body {
     border: none;
   }
 
-  #tab-hierarchy .sidebar-list .list-group-item span {
+  #tab-hierarchy .sidebar-list .list-group-item .concept-label {
     display: inline-block;
     border-left: 1px dashed var(--vocab-text);
     margin-left: 16px;
@@ -568,7 +568,7 @@ body {
   }
 
   /* horizontal line before concept */
-  #tab-hierarchy .sidebar-list .list-group-item span::before {
+  #tab-hierarchy .sidebar-list .list-group-item .concept-label::before {
     content: '';
     position: absolute;
     left: 16px;
@@ -579,7 +579,7 @@ body {
   }
 
   /* hiding bottom of vertical line on last concept of list */
-  #tab-hierarchy .sidebar-list .list-group-item span.last::before {
+  #tab-hierarchy .sidebar-list .list-group-item .concept-label.last::before {
     top: auto;
     bottom: 0;
     height: calc(100% - 13px);
@@ -590,6 +590,15 @@ body {
 
   #tab-hierarchy .sidebar-list .list-group-item a.selected {
     color: var(--vocab-text) !important;
+  }
+
+  #tab-hierarchy .sidebar-list .list-group-item .concept-notation {
+    color: var(--dark-color);
+    font-weight: normal;
+  }
+
+  #tab-hierarchy .sidebar-list .list-group-item a.selected .concept-notation {
+    font-weight: bold;
   }
 
   .hierarchy-button {

--- a/resource/css/skosmos.css
+++ b/resource/css/skosmos.css
@@ -594,7 +594,6 @@ body {
 
   #tab-hierarchy .sidebar-list .list-group-item .concept-notation {
     color: var(--dark-color);
-    font-weight: normal;
   }
 
   #tab-hierarchy .sidebar-list .list-group-item a.selected .concept-notation {

--- a/resource/js/tab-alpha.js
+++ b/resource/js/tab-alpha.js
@@ -198,8 +198,7 @@ tabAlphaApp.component('tab-alpha', {
               :href="getConceptURL(concept.uri)" @click="loadConcept($event, concept.uri)"
               aria-label="Go to the concept page"
             >
-              {{ concept.prefLabel }}
-              {{ showNotation && concept.qualifier ? ' (' + concept.qualifier + ')' : '' }}
+              {{ concept.prefLabel }}{{ showNotation && concept.qualifier ? ' (' + concept.qualifier + ')' : '' }}
             </a>
           </li>
           <template v-if="loadingMoreConcepts">

--- a/resource/js/tab-alpha.js
+++ b/resource/js/tab-alpha.js
@@ -18,7 +18,8 @@ const tabAlphaApp = Vue.createApp({
   provide () {
     return {
       partialPageLoad,
-      getConceptURL
+      getConceptURL,
+      showNotation: window.SKOSMOS.showNotation
     }
   },
   mounted () {
@@ -146,7 +147,7 @@ tabAlphaApp.directive('click-tab-alphabetical', {
 tabAlphaApp.component('tab-alpha', {
   props: ['indexLetters', 'indexConcepts', 'selectedConcept', 'loadingLetters', 'loadingConcepts', 'loadingMoreConcepts', 'loadingMessage'],
   emits: ['loadConcepts', 'selectConcept'],
-  inject: ['partialPageLoad', 'getConceptURL'],
+  inject: ['partialPageLoad', 'getConceptURL', 'showNotation'],
   methods: {
     loadConcepts (event, letter) {
       event.preventDefault()
@@ -195,7 +196,11 @@ tabAlphaApp.component('tab-alpha', {
             </template>
             <a :class="{ 'selected': selectedConcept === concept.uri }"
               :href="getConceptURL(concept.uri)" @click="loadConcept($event, concept.uri)"
-              aria-label="Go to the concept page">{{ concept.prefLabel }}</a>
+              aria-label="Go to the concept page"
+            >
+              {{ concept.prefLabel }}
+              {{ showNotation && concept.qualifier ? ' (' + concept.qualifier + ')' : '' }}
+            </a>
           </li>
           <template v-if="loadingMoreConcepts">
             <li class="list-group-item py-1 px-2">

--- a/resource/js/tab-hierarchy.js
+++ b/resource/js/tab-hierarchy.js
@@ -12,7 +12,8 @@ const tabHierApp = Vue.createApp({
   provide () {
     return {
       partialPageLoad,
-      getConceptURL
+      getConceptURL,
+      showNotation: window.SKOSMOS.showNotation
     }
   },
   mounted () {
@@ -48,7 +49,7 @@ const tabHierApp = Vue.createApp({
           this.hierarchy = []
 
           for (const c of data.topconcepts.sort((a, b) => this.compareLabels(a, b))) {
-            this.hierarchy.push({ uri: c.uri, label: c.label, hasChildren: c.hasChildren, children: [], isOpen: false })
+            this.hierarchy.push({ uri: c.uri, label: c.label, hasChildren: c.hasChildren, children: [], isOpen: false, notation: c.notation })
           }
 
           this.loading = false
@@ -78,17 +79,17 @@ const tabHierApp = Vue.createApp({
                 const children = concept.narrower
                   .sort((a, b) => this.compareLabels(a, b))
                   .map(c => {
-                    return { uri: c.uri, label: c.label, hasChildren: c.hasChildren, children: [], isOpen: false }
+                    return { uri: c.uri, label: c.label, hasChildren: c.hasChildren, children: [], isOpen: false, notation: c.notation }
                   })
                 // new concept node to be added to hierarchy tree
-                const conceptNode = { uri: concept.uri, label: concept.prefLabel, hasChildren: true, children, isOpen: true }
+                const conceptNode = { uri: concept.uri, label: concept.prefLabel, hasChildren: true, children, isOpen: true, notation: concept.notation }
                 // push new concept to hierarchy tree
                 this.hierarchy.push(conceptNode)
                 // push new concept to parent queue
                 parents.push(conceptNode)
               } else {
                 // push new concept node to hierarchy tree
-                this.hierarchy.push({ uri: concept.uri, label: concept.prefLabel, hasChildren: concept.hasChildren, children: [], isOpen: false })
+                this.hierarchy.push({ uri: concept.uri, label: concept.prefLabel, hasChildren: concept.hasChildren, children: [], isOpen: false, notation: concept.notation })
               }
             }
           }
@@ -114,7 +115,7 @@ const tabHierApp = Vue.createApp({
                 const children = concept.narrower
                   .sort((a, b) => this.compareLabels(a, b))
                   .map(c => {
-                    return { uri: c.uri, label: c.label, hasChildren: c.hasChildren, children: [], isOpen: false }
+                    return { uri: c.uri, label: c.label, hasChildren: c.hasChildren, children: [], isOpen: false, notation: c.notation }
                   })
                 // set children of current concept as children of concept node
                 conceptNode.children = children
@@ -140,7 +141,7 @@ const tabHierApp = Vue.createApp({
           .then(data => {
             console.log('data', data)
             for (const c of data.narrower.sort((a, b) => this.compareLabels(a, b))) {
-              concept.children.push({ uri: c.uri, label: c.prefLabel, hasChildren: c.hasChildren, children: [], isOpen: false })
+              concept.children.push({ uri: c.uri, label: c.prefLabel, hasChildren: c.hasChildren, children: [], isOpen: false, notation: c.notation })
             }
             console.log('hier', this.hierarchy)
           })
@@ -241,7 +242,7 @@ tabHierApp.component('tab-hier-wrapper', {
 tabHierApp.component('tab-hier', {
   props: ['concept', 'selectedConcept', 'isTopConcept', 'isLast'],
   emits: ['loadChildren', 'selectConcept'],
-  inject: ['partialPageLoad', 'getConceptURL'],
+  inject: ['partialPageLoad', 'getConceptURL', 'showNotation'],
   methods: {
     handleClickOpenEvent (concept) {
       concept.isOpen = !concept.isOpen
@@ -269,11 +270,15 @@ tabHierApp.component('tab-hier', {
       >
         <i>{{ concept.isOpen ? '&#x25E2;' : '&#x25FF;' }}</i>
       </button>
-      <span :class="{ 'last': isLast }">
+      <span class="concept-label" :class="{ 'last': isLast }">
         <a :class="{ 'selected': selectedConcept === concept.uri }"
           :href="getConceptURL(concept.uri)"
           @click="handleClickConceptEvent($event, concept)"
-          aria-label="Go to the concept page">{{ concept.label }}</a>
+          aria-label="Go to the concept page"
+        >
+          <span v-if="showNotation && concept.notation" class="concept-notation">{{ concept.notation }} </span>
+          {{ concept.label }}
+        </a>
       </span>
       <ul class="list-group px-3" v-if="concept.children.length !== 0 && concept.isOpen">
         <template v-for="(c, i) in concept.children">

--- a/tests/cypress/template/concept.cy.js
+++ b/tests/cypress/template/concept.cy.js
@@ -102,7 +102,7 @@ describe('Concept page', () => {
 
       // check the first mapping property name
       // NOTE: we need to increase the timeout as the mappings can take a long time to load
-      cy.get('.prop-mapping h2', {'timeout': 15000}).eq(0).contains('Closely matching concepts')
+      cy.get('.prop-mapping h2', {'timeout': 20000}).eq(0).contains('Closely matching concepts')
       // check the first mapping property values
       cy.get('.prop-mapping').eq(0).find('.prop-mapping-label').eq(0).contains('Labyrinths')
       cy.get('.prop-mapping').eq(0).find('.prop-mapping-label').eq(0).find('a').should('have.attr', 'href', 'http://id.loc.gov/authorities/subjects/sh85073793')

--- a/tests/cypress/template/vocab-home.cy.js
+++ b/tests/cypress/template/vocab-home.cy.js
@@ -61,7 +61,7 @@ describe('Vocabulary home page', () => {
     cy.get('#tab-alphabetical').contains('a', 'care institutions').click()
 
     // check the concept prefLabel
-    cy.get('#concept-heading h1').invoke('text').should('equal', 'care institutions')
+    cy.get('#concept-heading h1', {'timeout': 15000}).invoke('text').should('equal', 'care institutions')
 
     // check that the SKOSMOS object matches the newly loaded concept
     cy.window().then((win) => {
@@ -97,7 +97,7 @@ describe('Vocabulary home page', () => {
     cy.get('#tab-hierarchy').contains('a', 'Fish').click()
 
     // check the concept prefLabel
-    cy.get('#concept-heading h1').invoke('text').should('equal', 'Fish')
+    cy.get('#concept-heading h1', {'timeout': 15000}).invoke('text').should('equal', 'Fish')
 
     // check that the SKOSMOS object matches the newly loaded concept
     cy.window().then((win) => {

--- a/tests/cypress/template/vocab-home.cy.js
+++ b/tests/cypress/template/vocab-home.cy.js
@@ -73,7 +73,7 @@ describe('Vocabulary home page', () => {
     cy.get('#concept-mappings').should('not.be.empty')
 
     // check the second mapping property name
-    cy.get('.prop-mapping h2', {'timeout': 15000}).eq(0).contains('Exactly matching concepts')
+    cy.get('.prop-mapping h2', {'timeout': 20000}).eq(0).contains('Exactly matching concepts')
     // check the second mapping property values
     cy.get('.prop-mapping').eq(0).find('.prop-mapping-label').eq(0).contains('vårdinrättningar (sv)')
     cy.get('.prop-mapping').eq(0).find('.prop-mapping-label').eq(0).find('a').invoke('text').should('equal', 'vårdinrättningar')


### PR DESCRIPTION
## Reasons for creating this PR

Notations codes are not currently displayed in alphabetical or hierarchical views, this PR adds them.

## Link to relevant issue(s), if any

- Part of #1521 and #1563

## Description of the changes in this PR

Add notation codes with proper styling to alphabetical and hierarchical views.

Addresses requirement 6c in #1521 and 5a in #1563

## Known problems or uncertainties in this PR

## Checklist

- [ ] phpUnit tests pass locally with my changes
- [ ] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [ ] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [ ] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
