### PR TITLE
Fix sidebar width on window resize

### DIFF
--- a/resource/css/skosmos.css
+++ b/resource/css/skosmos.css
@@ -554,6 +554,7 @@ body {
   #tab-hierarchy .sidebar-list .list-group-item {
     border-left: 1px dashed var(--vocab-text);
     border-radius: 0;
+    white-space: nowrap;
   }
 
   #tab-hierarchy .sidebar-list .list-group-item.top-concept {
@@ -565,6 +566,7 @@ body {
     border-left: 1px dashed var(--vocab-text);
     margin-left: 16px;
     padding-left: 14px;
+    white-space: wrap;
   }
 
   /* horizontal line before concept */

--- a/resource/js/tab-alpha.js
+++ b/resource/js/tab-alpha.js
@@ -27,7 +27,7 @@ const tabAlphaApp = Vue.createApp({
     if (document.querySelector('#alphabetical > a').classList.contains('active')) {
       this.loadLetters()
     }
-    
+
     this.loadingMessage = window.SKOSMOS.msgs[window.SKOSMOS.lang]['Loading more items'] ?? window.SKOSMOS.msgs.en['Loading more items']
     this.setListStyle()
   },

--- a/resource/js/tab-hierarchy.js
+++ b/resource/js/tab-hierarchy.js
@@ -21,7 +21,7 @@ const tabHierApp = Vue.createApp({
     if (document.querySelector('#hierarchy > a').classList.contains('active')) {
       this.loadHierarchy()
     }
-    
+
     this.setListStyle()
   },
   methods: {

--- a/resource/js/tab-hierarchy.js
+++ b/resource/js/tab-hierarchy.js
@@ -6,7 +6,8 @@ const tabHierApp = Vue.createApp({
     return {
       hierarchy: [],
       loading: true,
-      selectedConcept: ''
+      selectedConcept: '',
+      listStyle: {}
     }
   },
   provide () {
@@ -20,6 +21,8 @@ const tabHierApp = Vue.createApp({
     if (document.querySelector('#hierarchy > a').classList.contains('active')) {
       this.loadHierarchy()
     }
+    
+    this.setListStyle()
   },
   methods: {
     handleClickHierarchyEvent () {
@@ -146,10 +149,10 @@ const tabHierApp = Vue.createApp({
           })
       }
     },
-    getListStyle () {
+    setListStyle () {
       const height = document.getElementById('sidebar-tabs').clientHeight
       const width = document.getElementById('sidebar-tabs').clientWidth
-      return {
+      this.listStyle = {
         height: 'calc( 100% - ' + height + 'px)',
         width: width + 'px'
       }
@@ -164,8 +167,8 @@ const tabHierApp = Vue.createApp({
     }
   },
   template: `
-    <div v-click-tab-hierarchy="handleClickHierarchyEvent">
-      <div id="hierarchy-list" class="sidebar-list p-0" :style="getListStyle()">
+    <div v-click-tab-hierarchy="handleClickHierarchyEvent" v-resize-window="setListStyle">
+      <div id="hierarchy-list" class="sidebar-list p-0" :style="listStyle">
         <ul class="list-group" v-if="!loading">
           <tab-hier-wrapper
             :hierarchy="hierarchy"
@@ -180,6 +183,7 @@ const tabHierApp = Vue.createApp({
   `
 })
 
+/* Custom directive used to add an event listener on clicks on the hierarchy nav-item element */
 tabHierApp.directive('click-tab-hierarchy', {
   beforeMount: (el, binding) => {
     el.clickTabEvent = event => {
@@ -189,6 +193,19 @@ tabHierApp.directive('click-tab-hierarchy', {
   },
   unmounted: el => {
     document.querySelector('#hierarchy').removeEventListener('click', el.clickTabEvent)
+  }
+})
+
+/* Custom directive used to add an event listener on resizing the window */
+tabHierApp.directive('resize-window', {
+  beforeMount: (el, binding) => {
+    el.resizeWindowEvent = event => {
+      binding.value() // calling the method given as the attribute value (setListStyle)
+    }
+    window.addEventListener('resize', el.resizeWindowEvent) // registering an event listener on resizing the window
+  },
+  unmounted: el => {
+    window.removeEventListener('resize', el.resizeWindowEvent)
   }
 })
 


### PR DESCRIPTION
## Reasons for creating this PR

Sidebar Vue components do not currently resize correctly with window resizing, this PR fixes that.

## Link to relevant issue(s), if any

- Part of #1521 and #1563

## Description of the changes in this PR

- Adds an event listener for window resizing in alphabetical and hierarchical components
- Change the width of the components on window resize event

Addresses requirement 3i in #1521 and 1d in #1563

## Known problems or uncertainties in this PR

## Checklist

- [ ] phpUnit tests pass locally with my changes
- [ ] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [ ] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [ ] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
