### PR TITLE
SEO: long title on landing page (skosmos:serviceNameLong configuration setting)

### DIFF
--- a/src/model/BaseConfig.php
+++ b/src/model/BaseConfig.php
@@ -54,7 +54,14 @@ abstract class BaseConfig extends DataObject
             return $literal->getValue();
         }
 
-        // not found with selected language, try any language
+        // not found with selected language, try to find one without a language tag
+        foreach ($this->getResource()->allLiterals($property) as $literal) {
+            if ($literal->getLang() === null) {
+                return $literal->getValue();
+            }
+        }
+
+        // not found with selected language or no language tag, try any language
         $literal = $this->getResource()->getLiteral($property);
         if ($literal) {
             return $literal->getValue();

--- a/src/model/BaseConfig.php
+++ b/src/model/BaseConfig.php
@@ -61,12 +61,7 @@ abstract class BaseConfig extends DataObject
             }
         }
 
-        // not found with selected language or no language tag, try any language
-        $literal = $this->getResource()->getLiteral($property);
-        if ($literal) {
-            return $literal->getValue();
-        }
-
+        // not found, return the default value
         return $default;
     }
 

--- a/src/model/GlobalConfig.php
+++ b/src/model/GlobalConfig.php
@@ -290,6 +290,22 @@ class GlobalConfig extends BaseConfig
     }
 
     /**
+     * Returns the long version of the service name in the requested language.
+     * @return string the long name of the service
+     */
+    public function getServiceNameLong($lang)
+    {
+        $val = $this->getLiteral('skosmos:serviceNameLong', false, $lang);
+
+        if ($val === false) {
+            // fall back to short service name if not configured
+            return $this->getServiceName();
+        }
+
+        return $val;
+    }
+
+    /**
      * @return string
      */
     public function getCustomCss()

--- a/src/view/base-template.twig
+++ b/src/view/base-template.twig
@@ -11,7 +11,6 @@
 <meta name="generator" content="Skosmos {{ request.version }}">
 <meta name="title" content="{{ block('title') }}">
 <meta property="og:title" content="{{ block('title') }}">
-<meta name="twitter:title" content="{{ block('title') }}">
 <meta name="twitter:card" content="summary">
 <link href="node_modules/bootstrap/dist/css/bootstrap.min.css" media="screen, print" rel="stylesheet" type="text/css">
 <link href="resource/css/fonts.css" media="screen, print" rel="stylesheet" type="text/css">

--- a/src/view/landing.twig
+++ b/src/view/landing.twig
@@ -1,5 +1,6 @@
 {% set pageType = 'landing' %}
 {% extends "base-template.twig" %}
+{% block title %}{{ GlobalConfig.serviceNameLong(request.lang) }}{% endblock %}
 
 {% block content %}
 <div class="col-md-7">

--- a/tests/GlobalConfigTest.php
+++ b/tests/GlobalConfigTest.php
@@ -54,6 +54,21 @@ class GlobalConfigTest extends PHPUnit\Framework\TestCase
         $this->assertEquals("Skosmos being tested", $this->config->getServiceName());
     }
 
+    public function testGetServiceNameLongEn()
+    {
+        $this->assertEquals("Skosmos being tested, long title", $this->config->getServiceNameLong('en'));
+    }
+
+    public function testGetServiceNameLongNoLanguageFallback()
+    {
+        $this->assertEquals("Skosmos-long", $this->config->getServiceNameLong('fr'));
+    }
+
+    public function testGetServiceNameLongNotSetFallback()
+    {
+        $this->assertEquals("Skosmos", $this->configWithDefaults->getServiceNameLong('en'));
+    }
+
     public function testGetBaseHref()
     {
         $this->assertEquals("http://tests.localhost/Skosmos/", $this->configWithBaseHref->getBaseHref());

--- a/tests/cypress/template/about.cy.js
+++ b/tests/cypress/template/about.cy.js
@@ -8,7 +8,6 @@ describe('About page', () => {
     cy.get('title').invoke('text').should('equal', expectedTitle)
     // check that the page has title metadata
     cy.get('head meta[name="title"]').should('have.attr', 'content', expectedTitle);
-    cy.get('head meta[name="twitter:title"]').should('have.attr', 'content', expectedTitle);
     cy.get('head meta[property="og:title"]').should('have.attr', 'content', expectedTitle);
   })
   it('Contains version number information', () => {

--- a/tests/cypress/template/concept.cy.js
+++ b/tests/cypress/template/concept.cy.js
@@ -140,7 +140,6 @@ describe('Concept page', () => {
     cy.get('title').invoke('text').should('equal', expectedTitle)
     // check that the page has title metadata
     cy.get('head meta[name="title"]').should('have.attr', 'content', expectedTitle);
-    cy.get('head meta[name="twitter:title"]').should('have.attr', 'content', expectedTitle);
     cy.get('head meta[property="og:title"]').should('have.attr', 'content', expectedTitle);
   })
   it("doesn't contain breadcrumbs for top concepts", () => {

--- a/tests/cypress/template/error.cy.js
+++ b/tests/cypress/template/error.cy.js
@@ -8,7 +8,6 @@ describe('Error page', () => {
     cy.get('title').invoke('text').should('equal', expectedTitle)
     // check that the page has title metadata
     cy.get('head meta[name="title"]').should('have.attr', 'content', expectedTitle);
-    cy.get('head meta[name="twitter:title"]').should('have.attr', 'content', expectedTitle);
     cy.get('head meta[property="og:title"]').should('have.attr', 'content', expectedTitle);
   })
   it('Contains 404 error code', () => {

--- a/tests/cypress/template/feedback.cy.js
+++ b/tests/cypress/template/feedback.cy.js
@@ -8,7 +8,6 @@ describe('Feedback page', () => {
     cy.get('title').invoke('text').should('equal', expectedTitle)
     // check that the page has title metadata
     cy.get('head meta[name="title"]').should('have.attr', 'content', expectedTitle);
-    cy.get('head meta[name="twitter:title"]').should('have.attr', 'content', expectedTitle);
     cy.get('head meta[property="og:title"]').should('have.attr', 'content', expectedTitle);
   })
   it('Sends feedback', () => {
@@ -56,7 +55,6 @@ describe('Vocab feedback page', () => {
     cy.get('title').invoke('text').should('equal', expectedTitle)
     // check that the page has title metadata
     cy.get('head meta[name="title"]').should('have.attr', 'content', expectedTitle);
-    cy.get('head meta[name="twitter:title"]').should('have.attr', 'content', expectedTitle);
     cy.get('head meta[property="og:title"]').should('have.attr', 'content', expectedTitle);
   })
   it('Displays correct vocab option', () => {

--- a/tests/cypress/template/landing.cy.js
+++ b/tests/cypress/template/landing.cy.js
@@ -3,7 +3,7 @@ describe('Landing page', () => {
     // go to the Skosmos front page
     cy.visit('/')
 
-    const expectedTitle = 'Skosmos being tested'
+    const expectedTitle = 'Skosmos being tested, long title'
     // check that the page has a HTML title
     cy.get('title').invoke('text').should('equal', expectedTitle)
     // check that the page has title metadata

--- a/tests/cypress/template/landing.cy.js
+++ b/tests/cypress/template/landing.cy.js
@@ -8,7 +8,6 @@ describe('Landing page', () => {
     cy.get('title').invoke('text').should('equal', expectedTitle)
     // check that the page has title metadata
     cy.get('head meta[name="title"]').should('have.attr', 'content', expectedTitle);
-    cy.get('head meta[name="twitter:title"]').should('have.attr', 'content', expectedTitle);
     cy.get('head meta[property="og:title"]').should('have.attr', 'content', expectedTitle);
   })
   it('links to vocabulary home', () => {

--- a/tests/cypress/template/vocab-home.cy.js
+++ b/tests/cypress/template/vocab-home.cy.js
@@ -7,7 +7,6 @@ describe('Vocabulary home page', () => {
     cy.get('title').invoke('text').should('equal', expectedTitle)
     // check that the page has title metadata
     cy.get('head meta[name="title"]').should('have.attr', 'content', expectedTitle);
-    cy.get('head meta[name="twitter:title"]').should('have.attr', 'content', expectedTitle);
     cy.get('head meta[property="og:title"]').should('have.attr', 'content', expectedTitle);
   })
   it('contains vocabulary title', () => {

--- a/tests/cypress/template/vocab-search.cy.js
+++ b/tests/cypress/template/vocab-search.cy.js
@@ -9,7 +9,6 @@ describe('Vocabulary search page', () => {
       cy.get('title').invoke('text').should('equal', expectedTitle)
       // check that the page has title metadata
       cy.get('head meta[name="title"]').should('have.attr', 'content', expectedTitle);
-      cy.get('head meta[name="twitter:title"]').should('have.attr', 'content', expectedTitle);
       cy.get('head meta[property="og:title"]').should('have.attr', 'content', expectedTitle);
   })
   it('Contains correct amount of search results ', () => {

--- a/tests/testconfig.ttl
+++ b/tests/testconfig.ttl
@@ -33,6 +33,7 @@
     skosmos:httpTimeout 2 ;
     # customize the service name
     skosmos:serviceName "Skosmos being tested" ;
+    skosmos:serviceNameLong "Skosmos being tested, long title"@en, "Skosmos-long" ;
     # customize the base element. Set this if the automatic base url detection doesn't work. For example setups behind a proxy.
     #skosmos:baseHref "http://localhost/Skosmos/" ;
     # interface languages available, and the corresponding system locales


### PR DESCRIPTION
## Reasons for creating this PR

This PR makes it possible to set a long name for the service using a new setting `skosmos:serviceNameLong`. This name will be used as the `<title>` (and related metadata elements important for SEO) on the landing page. The setting is multilingual, so it is possible to set different names for different UI languages. If not set, the value of the `skosmos:serviceName` setting is used as a fallback.

I also adjusted the `BaseConfig.getLiteral()` fallback mechanism in case there is no configuration value in the requested language. In that case it picked an arbitrary value that could be in any other language. I adjusted the mechanism so it only falls back to a value without a language tag, but not to another language which could be surprising.

There's also a small change to drop `twitter:title` metadata because it turns out it's completely redundant according to [Twitter/X developer docs](https://developer.x.com/en/docs/twitter-for-websites/cards/guides/getting-started#opengraph) when we already have `og:title`.

## Link to relevant issue(s), if any

- Part of #1533 

## Description of the changes in this PR

- add support for skosmos:serviceNameSetting in GlobalConfig
- adjust BaseConfig.getLiteral so it uses a better fallback mechanism for multilingual values
- PhpUnit tests for the above
- use the serviceNameLong value in the Twig template of the landing page
- drop use of `twitter:title` because it's redundant
- Cypress test for the above

## Known problems or uncertainties in this PR

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
