### PR TITLE
Fix sidebar Vue component sizing

### DIFF
--- a/resource/js/tab-alpha.js
+++ b/resource/js/tab-alpha.js
@@ -31,7 +31,7 @@ const tabAlphaApp = Vue.createApp({
 
     this.loadingMessage = window.SKOSMOS.msgs[window.SKOSMOS.lang]['Loading more items'] ?? window.SKOSMOS.msgs.en['Loading more items']
   },
-  beforeUpdate() {
+  beforeUpdate () {
     this.setListStyle()
   },
   methods: {

--- a/resource/js/tab-alpha.js
+++ b/resource/js/tab-alpha.js
@@ -30,6 +30,8 @@ const tabAlphaApp = Vue.createApp({
     }
 
     this.loadingMessage = window.SKOSMOS.msgs[window.SKOSMOS.lang]['Loading more items'] ?? window.SKOSMOS.msgs.en['Loading more items']
+  },
+  beforeUpdate() {
     this.setListStyle()
   },
   methods: {

--- a/resource/js/tab-hierarchy.js
+++ b/resource/js/tab-hierarchy.js
@@ -23,7 +23,8 @@ const tabHierApp = Vue.createApp({
     if (document.querySelector('#hierarchy > a').classList.contains('active')) {
       this.loadHierarchy()
     }
-
+  },
+  beforeUpdate() {
     this.setListStyle()
   },
   methods: {

--- a/resource/js/tab-hierarchy.js
+++ b/resource/js/tab-hierarchy.js
@@ -24,7 +24,7 @@ const tabHierApp = Vue.createApp({
       this.loadHierarchy()
     }
   },
-  beforeUpdate() {
+  beforeUpdate () {
     this.setListStyle()
   },
   methods: {


### PR DESCRIPTION
## Reasons for creating this PR

Setting the height and width of sidebar Vue components is broken and needs to be fixed.

## Link to relevant issue(s), if any

## Description of the changes in this PR

Set the height and width of sidebar-list on `beforeUpdate` lifecycle hook instead of `mounted`. This sets the components to the correct size.

## Known problems or uncertainties in this PR

## Checklist

- [ ] phpUnit tests pass locally with my changes
- [ ] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [ ] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [ ] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
