### PR TITLE
use PUT for initialising Fuseki to ensure existing vocabularies are overwritten before running tests

### DIFF
--- a/tests/init_containers.sh
+++ b/tests/init_containers.sh
@@ -17,6 +17,6 @@ done
 for fn in ../tests/test-vocab-data/*.ttl; do
     name=$(basename "${fn}" .ttl)
     echo "Loading test vocabulary $name"
-    curl -I -X POST -H Content-Type:text/turtle -T "$fn" -G http://localhost:9030/skosmos/data --data-urlencode graph="http://www.skosmos.skos/$name/"
+    curl -I -X PUT -H Content-Type:text/turtle -T "$fn" -G http://localhost:9030/skosmos/data --data-urlencode graph="http://www.skosmos.skos/$name/"
     echo
 done


### PR DESCRIPTION
## Reasons for creating this PR

When running PHPUnit and/or Cypress tests repeatedly during Skosmos development, it may happen that the Fuseki container is already running when it is being reinitialized. In that case Fuseki isn't a blank slate but will contain previously loaded versions of vocabularies.

There was a bug in the script that loads vocabularies to Fuseki. It used POST requests, which will not overwrite existing vocabularies (graphs) but instead will add new triples without removing existing ones. This could cause mysterious test failures especially in the case of blank nodes (that exist in one of the test vocabularies) but also if the vocabulary data files had been recently changed.

This one-line PR simply changes to PUT so that any preexisting vocabularies will be completely overwritten. This ensures that tests are run against a known state.

## Link to relevant issue(s), if any

- n/a

## Description of the changes in this PR

- use PUT instead of POST for loading vocabularies into Fuseki (that will be used for running tests)

## Known problems or uncertainties in this PR

none

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
