### PR TITLE
SEO: descriptions on landing, about and feedback pages

### DIFF
--- a/src/model/GlobalConfig.php
+++ b/src/model/GlobalConfig.php
@@ -306,6 +306,33 @@ class GlobalConfig extends BaseConfig
     }
 
     /**
+     * Returns the service description in the requested language.
+     * @return string the description of the service
+     */
+    public function getServiceDescription($lang)
+    {
+        return $this->getLiteral('skosmos:serviceDescription', null, $lang);
+    }
+
+    /**
+     * Returns the feedback page description in the requested language.
+     * @return string the description of the feedback page
+     */
+    public function getFeedbackDescription($lang)
+    {
+        return $this->getLiteral('skosmos:feedbackDescription', null, $lang);
+    }
+
+    /**
+     * Returns the about page description in the requested language.
+     * @return string the description of the about page
+     */
+    public function getAboutDescription($lang)
+    {
+        return $this->getLiteral('skosmos:aboutDescription', null, $lang);
+    }
+
+    /**
      * @return string
      */
     public function getCustomCss()

--- a/src/view/about.twig
+++ b/src/view/about.twig
@@ -1,6 +1,8 @@
 {% set pageType = 'about' %}
 {% extends "base-template.twig" %}
 {% block title %}{{ "About" | trans}} - {{ GlobalConfig.serviceName }}{% endblock %}
+{% block description %}{{ GlobalConfig.aboutDescription(request.lang) }}{% endblock %}
+
 {% block content %}
 
 <div class="container">

--- a/src/view/base-template.twig
+++ b/src/view/base-template.twig
@@ -14,7 +14,6 @@
 {% if block('description') is defined and block('description') is not empty %}
 <meta name="description" content="{{ block('description') }}">
 <meta property="og:description" content="{{ block('description') }}">
-<meta name="twitter:description" content="{{ block('description') }}">
 {% endif %}
 <meta name="twitter:card" content="summary">
 <link href="node_modules/bootstrap/dist/css/bootstrap.min.css" media="screen, print" rel="stylesheet" type="text/css">

--- a/src/view/base-template.twig
+++ b/src/view/base-template.twig
@@ -11,6 +11,11 @@
 <meta name="generator" content="Skosmos {{ request.version }}">
 <meta name="title" content="{{ block('title') }}">
 <meta property="og:title" content="{{ block('title') }}">
+{% if block('description') is defined and block('description') is not empty %}
+<meta name="description" content="{{ block('description') }}">
+<meta property="og:description" content="{{ block('description') }}">
+<meta name="twitter:description" content="{{ block('description') }}">
+{% endif %}
 <meta name="twitter:card" content="summary">
 <link href="node_modules/bootstrap/dist/css/bootstrap.min.css" media="screen, print" rel="stylesheet" type="text/css">
 <link href="resource/css/fonts.css" media="screen, print" rel="stylesheet" type="text/css">

--- a/src/view/feedback.twig
+++ b/src/view/feedback.twig
@@ -1,7 +1,9 @@
 {% set pageType = 'feedback' %}
 {% extends "base-template.twig" %}
 
-{% block title %}{{ "Feedback"|trans }} - {{GlobalConfig.serviceName}}{% endblock %}
+{% block title %}{{ "Feedback"|trans }} - {{ GlobalConfig.serviceName }}{% endblock %}
+{% block description %}{{ GlobalConfig.feedbackDescription(request.lang) }}{% endblock %}
+
 {% block content %}
 
   {% if feedback_sent %}

--- a/src/view/landing.twig
+++ b/src/view/landing.twig
@@ -1,6 +1,7 @@
 {% set pageType = 'landing' %}
 {% extends "base-template.twig" %}
 {% block title %}{{ GlobalConfig.serviceNameLong(request.lang) }}{% endblock %}
+{% block description %}{{ GlobalConfig.serviceDescription(request.lang) }}{% endblock %}
 
 {% block content %}
 <div class="col-md-7">

--- a/tests/GlobalConfigTest.php
+++ b/tests/GlobalConfigTest.php
@@ -69,6 +69,36 @@ class GlobalConfigTest extends PHPUnit\Framework\TestCase
         $this->assertEquals("Skosmos", $this->configWithDefaults->getServiceNameLong('en'));
     }
 
+    public function testGetServiceDescription()
+    {
+        $this->assertEquals("Description of Skosmos being tested", $this->config->getServiceDescription('en'));
+    }
+
+    public function testGetServiceDescriptionNotInLanguage()
+    {
+        $this->assertNull($this->config->getServiceDescription('fr'));
+    }
+
+    public function testGetFeedbackDescription()
+    {
+        $this->assertEquals("Feedback page for Skosmos being tested", $this->config->getFeedbackDescription('en'));
+    }
+
+    public function testGetFeedbackDescriptionNotInLanguage()
+    {
+        $this->assertNull($this->config->getFeedbackDescription('fr'));
+    }
+
+    public function testGetAboutDescription()
+    {
+        $this->assertEquals("About page for Skosmos being tested", $this->config->getAboutDescription('en'));
+    }
+
+    public function testGetAboutDescriptionNotInLanguage()
+    {
+        $this->assertNull($this->config->getAboutDescription('fr'));
+    }
+
     public function testGetBaseHref()
     {
         $this->assertEquals("http://tests.localhost/Skosmos/", $this->configWithBaseHref->getBaseHref());

--- a/tests/cypress/template/about.cy.js
+++ b/tests/cypress/template/about.cy.js
@@ -1,5 +1,5 @@
 describe('About page', () => {
-  it('Contains title and title metadata', () => {
+  it('Contains title metadata', () => {
     // go to the Skosmos about page
     cy.visit('/en/about')
 
@@ -9,6 +9,16 @@ describe('About page', () => {
     // check that the page has title metadata
     cy.get('head meta[name="title"]').should('have.attr', 'content', expectedTitle);
     cy.get('head meta[property="og:title"]').should('have.attr', 'content', expectedTitle);
+  })
+  it('Contains description metadata', () => {
+    // go to the Skosmos about page
+    cy.visit('/en/about')
+
+    const expectedDescription = 'About page for Skosmos being tested'
+    // check that the page has description metadata
+    cy.get('head meta[name="description"]').should('have.attr', 'content', expectedDescription);
+    cy.get('head meta[name="twitter:description"]').should('have.attr', 'content', expectedDescription);
+    cy.get('head meta[property="og:description"]').should('have.attr', 'content', expectedDescription);
   })
   it('Contains version number information', () => {
     // go to the Skosmos about page

--- a/tests/cypress/template/about.cy.js
+++ b/tests/cypress/template/about.cy.js
@@ -17,7 +17,6 @@ describe('About page', () => {
     const expectedDescription = 'About page for Skosmos being tested'
     // check that the page has description metadata
     cy.get('head meta[name="description"]').should('have.attr', 'content', expectedDescription);
-    cy.get('head meta[name="twitter:description"]').should('have.attr', 'content', expectedDescription);
     cy.get('head meta[property="og:description"]').should('have.attr', 'content', expectedDescription);
   })
   it('Contains version number information', () => {

--- a/tests/cypress/template/feedback.cy.js
+++ b/tests/cypress/template/feedback.cy.js
@@ -1,5 +1,5 @@
 describe('Feedback page', () => {
-  it('Contains title and title metadata', () => {
+  it('Contains title metadata', () => {
     // go to the general feedback page
     cy.visit('/en/feedback')
 
@@ -9,6 +9,16 @@ describe('Feedback page', () => {
     // check that the page has title metadata
     cy.get('head meta[name="title"]').should('have.attr', 'content', expectedTitle);
     cy.get('head meta[property="og:title"]').should('have.attr', 'content', expectedTitle);
+  })
+  it('Contains description metadata', () => {
+    // go to the general feedback page
+    cy.visit('/en/feedback')
+
+    const expectedDescription = 'Feedback page for Skosmos being tested'
+    // check that the page has description metadata
+    cy.get('head meta[name="description"]').should('have.attr', 'content', expectedDescription);
+    cy.get('head meta[name="twitter:description"]').should('have.attr', 'content', expectedDescription);
+    cy.get('head meta[property="og:description"]').should('have.attr', 'content', expectedDescription);
   })
   it('Sends feedback', () => {
     // go to the general feedback page
@@ -46,7 +56,7 @@ describe('Feedback page', () => {
 })
 
 describe('Vocab feedback page', () => {
-  it('Contains title and title metadata', () => {
+  it('Contains title metadata', () => {
     // go to test vocab feedback page
     cy.visit('/test/en/feedback')
 
@@ -56,6 +66,16 @@ describe('Vocab feedback page', () => {
     // check that the page has title metadata
     cy.get('head meta[name="title"]').should('have.attr', 'content', expectedTitle);
     cy.get('head meta[property="og:title"]').should('have.attr', 'content', expectedTitle);
+  })
+  it('Contains description metadata', () => {
+    // go to test vocab feedback page
+    cy.visit('/test/en/feedback')
+
+    const expectedDescription = 'Feedback page for Skosmos being tested'
+    // check that the page has description metadata
+    cy.get('head meta[name="description"]').should('have.attr', 'content', expectedDescription);
+    cy.get('head meta[name="twitter:description"]').should('have.attr', 'content', expectedDescription);
+    cy.get('head meta[property="og:description"]').should('have.attr', 'content', expectedDescription);
   })
   it('Displays correct vocab option', () => {
     // go to test vocab feedback page

--- a/tests/cypress/template/feedback.cy.js
+++ b/tests/cypress/template/feedback.cy.js
@@ -17,7 +17,6 @@ describe('Feedback page', () => {
     const expectedDescription = 'Feedback page for Skosmos being tested'
     // check that the page has description metadata
     cy.get('head meta[name="description"]').should('have.attr', 'content', expectedDescription);
-    cy.get('head meta[name="twitter:description"]').should('have.attr', 'content', expectedDescription);
     cy.get('head meta[property="og:description"]').should('have.attr', 'content', expectedDescription);
   })
   it('Sends feedback', () => {
@@ -74,7 +73,6 @@ describe('Vocab feedback page', () => {
     const expectedDescription = 'Feedback page for Skosmos being tested'
     // check that the page has description metadata
     cy.get('head meta[name="description"]').should('have.attr', 'content', expectedDescription);
-    cy.get('head meta[name="twitter:description"]').should('have.attr', 'content', expectedDescription);
     cy.get('head meta[property="og:description"]').should('have.attr', 'content', expectedDescription);
   })
   it('Displays correct vocab option', () => {

--- a/tests/cypress/template/landing.cy.js
+++ b/tests/cypress/template/landing.cy.js
@@ -1,14 +1,26 @@
 describe('Landing page', () => {
-  it('Contains title and title metadata', () => {
+  it('Contains title metadata', () => {
     // go to the Skosmos front page
     cy.visit('/')
 
     const expectedTitle = 'Skosmos being tested, long title'
+
     // check that the page has a HTML title
     cy.get('title').invoke('text').should('equal', expectedTitle)
     // check that the page has title metadata
     cy.get('head meta[name="title"]').should('have.attr', 'content', expectedTitle);
     cy.get('head meta[property="og:title"]').should('have.attr', 'content', expectedTitle);
+  })
+  it('Contains description metadata', () => {
+    // go to the Skosmos front page
+    cy.visit('/')
+
+    const expectedDescription = 'Description of Skosmos being tested'
+
+    // check that the page has description metadata
+    cy.get('head meta[name="description"]').should('have.attr', 'content', expectedDescription);
+    cy.get('head meta[name="twitter:description"]').should('have.attr', 'content', expectedDescription);
+    cy.get('head meta[property="og:description"]').should('have.attr', 'content', expectedDescription);
   })
   it('links to vocabulary home', () => {
     // go to the Skosmos front page

--- a/tests/cypress/template/landing.cy.js
+++ b/tests/cypress/template/landing.cy.js
@@ -19,7 +19,6 @@ describe('Landing page', () => {
 
     // check that the page has description metadata
     cy.get('head meta[name="description"]').should('have.attr', 'content', expectedDescription);
-    cy.get('head meta[name="twitter:description"]').should('have.attr', 'content', expectedDescription);
     cy.get('head meta[property="og:description"]').should('have.attr', 'content', expectedDescription);
   })
   it('links to vocabulary home', () => {

--- a/tests/testconfig.ttl
+++ b/tests/testconfig.ttl
@@ -34,6 +34,9 @@
     # customize the service name
     skosmos:serviceName "Skosmos being tested" ;
     skosmos:serviceNameLong "Skosmos being tested, long title"@en, "Skosmos-long" ;
+    skosmos:serviceDescription "Description of Skosmos being tested"@en ;
+    skosmos:feedbackDescription "Feedback page for Skosmos being tested"@en ;
+    skosmos:aboutDescription "About page for Skosmos being tested"@en ;
     # customize the base element. Set this if the automatic base url detection doesn't work. For example setups behind a proxy.
     #skosmos:baseHref "http://localhost/Skosmos/" ;
     # interface languages available, and the corresponding system locales


### PR DESCRIPTION
## Reasons for creating this PR

This PR adds support for new SEO configuration options `skosmos:serviceDescription`, `skosmos:aboutDescription` and `skosmos:feedbackDescription` which make it possible to set a description for the landing, about and feedback pages, respectively. The values are multilingual. If not set, there will be no description metadata on the respective page.

## Link to relevant issue(s), if any

- Part of #1533

## Description of the changes in this PR

- add support for `skosmos:serviceDescription`, `skosmos:aboutDescription` and `skosmos:feedbackDescription`  settings in GlobalConfig
- use the settings to add description metadata to the HTML templates of the landing, about and feedback pages
- PHPUnit and Cypress tests

## Known problems or uncertainties in this PR

There is no Cypress test for the case when one of the descriptions is not set in the configuration and thus should not be displayed. Should there be? The problem here is that this would require a separately configured Skosmos instance with a different configuration that omits some or all of the description settings. We currently only use one Skosmos instance for running Cypress tests, using the `tests/testconfig.ttl` configuration file.

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
