### PR TITLE
Order hierarchy by notation

### DIFF
--- a/resource/js/tab-hierarchy.js
+++ b/resource/js/tab-hierarchy.js
@@ -52,7 +52,7 @@ const tabHierApp = Vue.createApp({
 
           this.hierarchy = []
 
-          for (const c of data.topconcepts.sort((a, b) => this.compareStrs(a, b))) {
+          for (const c of data.topconcepts.sort((a, b) => this.compareConcepts(a, b))) {
             this.hierarchy.push({ uri: c.uri, label: c.label, hasChildren: c.hasChildren, children: [], isOpen: false, notation: c.notation })
           }
 
@@ -72,7 +72,7 @@ const tabHierApp = Vue.createApp({
           this.hierarchy = []
 
           // transform broaderTransitive to an array and sort it
-          const bt = Object.values(data.broaderTransitive).sort((a, b) => this.compareStrs(a, b))
+          const bt = Object.values(data.broaderTransitive).sort((a, b) => this.compareConcepts(a, b))
           const parents = [] // queue of nodes in hierarchy tree with potential missing child nodes
 
           // add top concepts to hierarchy tree
@@ -81,7 +81,7 @@ const tabHierApp = Vue.createApp({
               if (concept.narrower) {
                 // children of the current concept
                 const children = concept.narrower
-                  .sort((a, b) => this.compareStrs(a, b))
+                  .sort((a, b) => this.compareConcepts(a, b))
                   .map(c => {
                     return { uri: c.uri, label: c.label, hasChildren: c.hasChildren, children: [], isOpen: false, notation: c.notation }
                   })
@@ -117,7 +117,7 @@ const tabHierApp = Vue.createApp({
                 const conceptNode = parent.children.find(c => c.uri === concept.uri)
                 // children of current concept
                 const children = concept.narrower
-                  .sort((a, b) => this.compareStrs(a, b))
+                  .sort((a, b) => this.compareConcepts(a, b))
                   .map(c => {
                     return { uri: c.uri, label: c.label, hasChildren: c.hasChildren, children: [], isOpen: false, notation: c.notation }
                   })
@@ -145,7 +145,7 @@ const tabHierApp = Vue.createApp({
           })
           .then(data => {
             console.log('data', data)
-            for (const c of data.narrower.sort((a, b) => this.compareStrs(a, b))) {
+            for (const c of data.narrower.sort((a, b) => this.compareConcepts(a, b))) {
               concept.children.push({ uri: c.uri, label: c.prefLabel, hasChildren: c.hasChildren, children: [], isOpen: false, notation: c.notation })
             }
             this.loadingChildren = this.loadingChildren.filter(x => x !== concept)
@@ -161,7 +161,7 @@ const tabHierApp = Vue.createApp({
         width: width + 'px'
       }
     },
-    compareStrs (a, b) {
+    compareConcepts (a, b) {
       let strA, strB
 
       if (window.SKOSMOS.sortByNotation) {

--- a/resource/js/tab-hierarchy.js
+++ b/resource/js/tab-hierarchy.js
@@ -185,7 +185,7 @@ const tabHierApp = Vue.createApp({
       // Set language and options
       const lang = window.SKOSMOS.content_lang || window.SKOSMOS.lang
       const options = {
-        numeric: window.SKOSMOS.sortByNotation == 'natural', // Set numeric to true if sort should be natural
+        numeric: window.SKOSMOS.sortByNotation === 'natural', // Set numeric to true if sort should be natural
         sensitivity: 'variant' // Strings that differ in base letters, diacritic marks, or case compare as unequal
       }
 

--- a/tests/cypress/template/sidebar.cy.js
+++ b/tests/cypress/template/sidebar.cy.js
@@ -21,3 +21,27 @@ describe('Sidebar', () => {
     cy.get('#tab-alphabetical .pagination a').invoke('text').should('contain', 'Y').should('not.contain', 'C')
   })
 })
+
+describe('Hierarchy', () => {
+  it('Sorts concepts based on labels', () => {
+    // Go to "properties" concept page in a vocab with sorting based on labels
+    cy.visit('/yso/en/page/p2742')
+    // First and second concepts in hierarchy should be sorted by label
+    cy.get('#hierarchy-list .list-group-item').eq(0).find('.concept-label').invoke('text').should('contain', 'events and action')
+    cy.get('#hierarchy-list .list-group-item').eq(1).find('.concept-label').invoke('text').should('contain', 'objects')
+  })
+  it('Sorts concepts based on notation codes in lexical order', () => {
+    // Go to "Tuna" concept page in a vocab with lexical sorting
+    cy.visit('/test-notation-sort/en/page/?uri=http%3A%2F%2Fwww.skosmos.skos%2Ftest%2Fta0111')
+    // First and second concepts in hierarchy should be sorted by notation codes in lexical order
+    cy.get('#hierarchy-list .list-group-item').eq(1).find('.concept-notation').invoke('text').should('equal', '33.01')
+    cy.get('#hierarchy-list .list-group-item').eq(2).find('.concept-notation').invoke('text').should('equal', '33.02')
+  })
+  it('Sorts concepts based on notation codes in natural order', () => {
+    // Go to "Tuna" concept page in a vocab with natural sorting
+    cy.visit('/testNotation/en/page/?uri=http%3A%2F%2Fwww.skosmos.skos%2Ftest%2Fta0111')
+    // First and second concepts in hierarchy should be sorted by notation codes in natural order
+    cy.get('#hierarchy-list .list-group-item').eq(1).find('.concept-notation').invoke('text').should('equal', '33.1')
+    cy.get('#hierarchy-list .list-group-item').eq(2).find('.concept-notation').invoke('text').should('equal', '33.01')
+  })
+})


### PR DESCRIPTION
## Reasons for creating this PR

Hierarchy is currently only ordered by labels. It should be possible to order it by notation codes as well

## Link to relevant issue(s), if any

- Part of #1521 

## Description of the changes in this PR

Sort concepts based on notation codes using both lexical and natural sorting.

Addresses requirement 6d in #1521

## Known problems or uncertainties in this PR

## Checklist

- [ ] phpUnit tests pass locally with my changes
- [ ] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [ ] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [ ] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
