### PR TITLE
Increase HTTP timeout in test configuration to fix flaky Cypress mapping tests

### DIFF
--- a/tests/GlobalConfigTest.php
+++ b/tests/GlobalConfigTest.php
@@ -46,7 +46,7 @@ class GlobalConfigTest extends PHPUnit\Framework\TestCase
 
     public function testGetHttpTimeout()
     {
-        $this->assertEquals(2, $this->config->getHttpTimeout());
+        $this->assertEquals(8, $this->config->getHttpTimeout());
     }
 
     public function testGetServiceName()

--- a/tests/testconfig.ttl
+++ b/tests/testconfig.ttl
@@ -30,7 +30,7 @@
     skosmos:sparqlCollationEnabled true ;
     # HTTP client configuration
     skosmos:sparqlTimeout 10 ;
-    skosmos:httpTimeout 2 ;
+    skosmos:httpTimeout 8 ;
     # customize the service name
     skosmos:serviceName "Skosmos being tested" ;
     skosmos:serviceNameLong "Skosmos being tested, long title"@en, "Skosmos-long" ;


### PR DESCRIPTION
## Reasons for creating this PR

Some Cypress runs were failing under GitHub Actions CI. In particular the "concept mappings / full" and/or "concept mappings / partial" tests for the concept page often failed. For example [this run](https://github.com/NatLibFi/Skosmos/actions/runs/10404988178/job/28814722532#step:6:700).

Adjusting the Cypress timeouts doesn't help, because the problem is that the underlying Skosmos resolver code (LinkedDataResolver) times out. The reason is that we've set a 2 second httpTimeout in testconfig.ttl, used to configure Skosmos for the PHPUnit and Cypress tests. This is too short to reliably resolve some of the mappings (LCSH, KOKO, YSA etc.) especially under the GitHub Actions CI environment.

The fix is simple: increase the timeout to 8 seconds. (Sidenote: this needs to be different from the default value of 5 seconds, because it is tested in a PHPUnit test that needs to verify that the non-default setting is effective. The test has been changed accordingly)

## Link to relevant issue(s), if any

- n/a, but failing tests were seen in e.g. PR #1651 

## Description of the changes in this PR

- increase httpTimeout value from 2 to 8 in testconfig.ttl
- modify GlobalConfigTest accordingly

## Known problems or uncertainties in this PR

Not sure if 8 is the ideal value here but it's better than 2 for sure.

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
