### PR TITLE
Add notation codes to concept page

### DIFF
--- a/resource/css/skosmos.css
+++ b/resource/css/skosmos.css
@@ -712,6 +712,10 @@ body {
     border: none;
   }
 
+  .property-value .property-value-notation {
+    color: var(--vocab-text);
+  }
+
   #resource-table th {
     color: var(--vocab-text);
     font-weight: bold;

--- a/src/view/concept-card.inc
+++ b/src/view/concept-card.inc
@@ -58,6 +58,9 @@
             {% if propval.uri and property.type != 'rdf:type' %} {# resources with URI #}
             <li>
               <a href="{{ propval.uri | link_url(propval.vocab, request.lang, 'page', request.contentLang) }}">
+              {%- if propval.notation -%}
+                <span class="property-value-notation">{{ propval.notation }} </span>
+              {%- endif -%}
                 {{- propval.label(request.contentLang) -}}
               </a>
             </li>

--- a/tests/cypress/template/concept.cy.js
+++ b/tests/cypress/template/concept.cy.js
@@ -281,6 +281,17 @@ describe('Concept page', () => {
     // check that we have the correct number of narrower concepts
     cy.get('.prop-skos_narrower .property-value').find('li').should('have.length', 8)
   })
+  it('contains notation codes for narrower/broader concepts', () => {
+    // Go to "Karppi" concept page
+    cy.visit('/testNotation/en/page/?uri=http%3A%2F%2Fwww.skosmos.skos%2Ftest%2Fta01')
+    // Check the notation code for narrower concept
+    cy.get('.prop-skos_narrower .property-value-notation').eq(0).invoke('text').should('contain', '33.01')
+
+    // Go to "Crucian carp" concept page
+    cy.visit('/testNotation/en/page/?uri=http%3A%2F%2Fwww.skosmos.skos%2Ftest%2Fta0121')
+    // Check the notation code for broader concept
+    cy.get('.prop-skos_broader .property-value-notation').eq(0).invoke('text').should('contain', '33.1')
+  })
   it('contains related concepts', () => {
     cy.visit('/yso/en/page/p21685') // go to "music research" concept page
 


### PR DESCRIPTION
## Reasons for creating this PR

The concept page does not show notation codes for broader/narrower/etc concepts, this PR adds them.

## Link to relevant issue(s), if any

- Part of #1484

## Description of the changes in this PR

- Showing notation codes for concepts in property value list
- CSS class for notation codes
- Cypress test

## Known problems or uncertainties in this PR

## Checklist

- [ ] phpUnit tests pass locally with my changes
- [ ] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [ ] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [ ] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
