### PR TITLE
Refactor: Convert linkUrlFilter to a Twig extension class

### DIFF
--- a/src/controller/Controller.php
+++ b/src/controller/Controller.php
@@ -98,57 +98,6 @@ class Controller
     }
 
     /**
-     * Creates Skosmos links from uris.
-     * @param string $uri
-     * @param Vocabulary $vocab
-     * @param string $lang
-     * @param string $type
-     * @param string $clang content
-     * @param string $term
-     * @throws Exception if the vocabulary ID is not found in configuration
-     * @return string containing the Skosmos link
-     */
-    public function linkUrlFilter($uri, $vocab, $lang, $type = 'page', $clang = null, $term = null)
-    {
-        // $vocab can either be null, a vocabulary id (string) or a Vocabulary object
-        if ($vocab === null) {
-            // target vocabulary is unknown, best bet is to link to the plain URI
-            return $uri;
-        } elseif (is_string($vocab)) {
-            $vocid = $vocab;
-            $vocab = $this->model->getVocabulary($vocid);
-        } else {
-            $vocid = $vocab->getId();
-        }
-
-        $params = array();
-        if (isset($clang) && $clang !== $lang) {
-            $params['clang'] = $clang;
-        }
-
-        if (isset($term)) {
-            $params['q'] = $term;
-        }
-
-        // case 1: URI within vocabulary namespace: use only local name
-        $localname = $vocab->getLocalName($uri);
-        if ($localname !== $uri && $localname === urlencode($localname)) {
-            // check that the prefix stripping worked, and there are no problematic chars in localname
-            $paramstr = count($params) > 0 ? '?' . http_build_query($params) : '';
-            if ($type && $type !== '' && $type !== 'vocab' && !($localname === '' && $type === 'page')) {
-                return "$vocid/$lang/$type/$localname" . $paramstr;
-            }
-
-            return "$vocid/$lang/$localname" . $paramstr;
-        }
-
-        // case 2: URI outside vocabulary namespace, or has problematic chars
-        // pass the full URI as parameter instead
-        $params['uri'] = $uri;
-        return "$vocid/$lang/$type/?" . http_build_query($params);
-    }
-
-    /**
      * Echos an error message when the request can't be fulfilled.
      * @param string $code
      * @param string $status

--- a/src/controller/LinkUrlExtension.php
+++ b/src/controller/LinkUrlExtension.php
@@ -1,0 +1,67 @@
+<?php
+
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+
+class LinkUrlExtension extends AbstractExtension
+{
+    private $model;
+
+    public function __construct($model)
+    {
+        $this->model = $model;
+    }
+
+    public function getFilters()
+    {
+        return [
+            new TwigFilter('link_url', [$this, 'linkUrlFilter']),
+        ];
+    }
+
+    /**
+     * Creates Skosmos links from uris.
+     * @param string $uri
+     * @param Vocabulary $vocab
+     * @param string $lang
+     * @param string $type
+     * @param string $clang content
+     * @param string $term
+     * @throws Exception if the vocabulary ID is not found in configuration
+     * @return string containing the Skosmos link
+     */
+    public function linkUrlFilter($uri, $vocab, $lang, $type = 'page', $clang = null, $term = null)
+    {
+        // $vocab can either be null, a vocabulary id (string) or a Vocabulary object
+        if ($vocab === null) {
+            return $uri;
+        } elseif (is_string($vocab)) {
+            $vocid = $vocab;
+            $vocab = $this->model->getVocabulary($vocid);
+        } else {
+            $vocid = $vocab->getId();
+        }
+
+        $params = [];
+        if (isset($clang) && $clang !== $lang) {
+            $params['clang'] = $clang;
+        }
+
+        if (isset($term)) {
+            $params['q'] = $term;
+        }
+
+        $localname = $vocab->getLocalName($uri);
+        if ($localname !== $uri && $localname === urlencode($localname)) {
+            $paramstr = count($params) > 0 ? '?' . http_build_query($params) : '';
+            if ($type && $type !== '' && $type !== 'vocab' && !($localname === '' && $type === 'page')) {
+                return "$vocid/$lang/$type/$localname" . $paramstr;
+            }
+
+            return "$vocid/$lang/$localname" . $paramstr;
+        }
+
+        $params['uri'] = $uri;
+        return "$vocid/$lang/$type/?" . http_build_query($params);
+    }
+}

--- a/src/controller/RestController.php
+++ b/src/controller/RestController.php
@@ -706,9 +706,10 @@ class RestController extends Controller
         }
 
         $mappings = [];
+        $linkUrlExtension = new LinkUrlExtension($this->model);
         foreach ($concept->getMappingProperties() as $mappingProperty) {
             foreach ($mappingProperty->getValues() as $mappingPropertyValue) {
-                $hrefLink = $this->linkUrlFilter($mappingPropertyValue->getUri(), $mappingPropertyValue->getExVocab(), $request->getLang(), 'page', $request->getContentLang());
+                $hrefLink = $linkUrlExtension->linkUrlFilter($mappingPropertyValue->getUri(), $mappingPropertyValue->getExVocab(), $request->getLang(), 'page', $request->getContentLang());
                 $mappings[] = $mappingPropertyValue->asJskos($queryExVocabs, $request->getLang(), $hrefLink);
             }
         }

--- a/src/controller/WebController.php
+++ b/src/controller/WebController.php
@@ -50,7 +50,7 @@ class WebController extends Controller
         $this->twig->addGlobal("PreferredProperties", array('skos:prefLabel', 'skos:narrower', 'skos:broader', 'skosmos:memberOf', 'skos:altLabel', 'skos:related'));
 
         // register a Twig filter for generating URLs for vocabulary resources (concepts and groups)
-        $this->twig->addFilter(new \Twig\TwigFilter('link_url', array($this, 'linkUrlFilter')));
+        $this->twig->addExtension(new LinkUrlExtension($model));
 
         // register a Twig filter for generating strings from language codes with CLDR
         $langFilter = new \Twig\TwigFilter('lang_name', function ($langcode, $lang) {


### PR DESCRIPTION
## Reasons for creating this PR

This makes the controller code a bit cleaner. It is also necessary to make it possible to extract messages from Twig templates in PR #1648 .

See #1653 

## Link to relevant issue(s), if any

- Closes #1653

## Description of the changes in this PR

- move linkUrlFilter from Controller to its own Twig extension class

## Known problems or uncertainties in this PR

n/a

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
