### PR TITLE
SEO: vocab description, site name, type, canonical URL

### DIFF
--- a/src/model/Request.php
+++ b/src/model/Request.php
@@ -210,7 +210,7 @@ class Request
      */
     public function getLangUrl($newlang=null)
     {
-        $script_name = str_replace('/index.php', '', $this->getServerConstant('SCRIPT_NAME'));
+        $script_name = str_replace('/src/index.php', '', $this->getServerConstant('SCRIPT_NAME'));
         $langurl = substr(str_replace($script_name, '', strval($this->getServerConstant('REQUEST_URI'))), 1);
         if ($newlang !== null) {
             $langurl = preg_replace("#^(.*/)?{$this->lang}/#", "$1{$newlang}/", $langurl);

--- a/src/model/VocabularyConfig.php
+++ b/src/model/VocabularyConfig.php
@@ -272,6 +272,15 @@ class VocabularyConfig extends BaseConfig
     }
 
     /**
+     * Returns the human readable vocabulary description.
+     * @return string the description of the vocabulary
+     */
+    public function getDescription($lang = null)
+    {
+        return $this->getLiteral('dc:description', false, $lang);
+    }
+
+    /**
      * Returns the sorting strategy for notation codes set in the config.ttl
      * config: either "lexical", "natural", or null if sorting by notations is
      * disabled. A "true" value in the configuration file is interpreted as

--- a/src/view/about.twig
+++ b/src/view/about.twig
@@ -2,7 +2,7 @@
 {% extends "base-template.twig" %}
 {% block title %}{{ "About" | trans}} - {{ GlobalConfig.serviceName }}{% endblock %}
 {% block description %}{{ GlobalConfig.aboutDescription(request.lang) }}{% endblock %}
-{% block url %}{{ BaseHref }}{{ request.lang }}/about{% endblock %}
+{% block url %}{{ BaseHref }}{{ request.langurl }}{% endblock %}
 
 {% block content %}
 

--- a/src/view/about.twig
+++ b/src/view/about.twig
@@ -2,6 +2,7 @@
 {% extends "base-template.twig" %}
 {% block title %}{{ "About" | trans}} - {{ GlobalConfig.serviceName }}{% endblock %}
 {% block description %}{{ GlobalConfig.aboutDescription(request.lang) }}{% endblock %}
+{% block url %}{{ BaseHref }}{{ request.lang }}/about{% endblock %}
 
 {% block content %}
 

--- a/src/view/base-template.twig
+++ b/src/view/base-template.twig
@@ -16,6 +16,7 @@
 <meta property="og:description" content="{{ block('description') }}">
 {% endif %}
 <meta name="twitter:card" content="summary">
+<meta property="og:site_name" content="{{ GlobalConfig.serviceName }}">
 <link href="node_modules/bootstrap/dist/css/bootstrap.min.css" media="screen, print" rel="stylesheet" type="text/css">
 <link href="resource/css/fonts.css" media="screen, print" rel="stylesheet" type="text/css">
 <link href="resource/css/skosmos.css" media="screen, print" rel="stylesheet" type="text/css">

--- a/src/view/base-template.twig
+++ b/src/view/base-template.twig
@@ -15,6 +15,10 @@
 <meta name="description" content="{{ block('description') }}">
 <meta property="og:description" content="{{ block('description') }}">
 {% endif %}
+{% if block('url') is defined and block('url') is not empty %}
+<link rel="canonical" href="{{ block('url') }}">
+<meta property="og:url" content="{{ block('url') }}">
+{% endif %}
 <meta property="og:type" content="website">
 <meta property="og:site_name" content="{{ GlobalConfig.serviceName }}">
 <link href="node_modules/bootstrap/dist/css/bootstrap.min.css" media="screen, print" rel="stylesheet" type="text/css">

--- a/src/view/base-template.twig
+++ b/src/view/base-template.twig
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html dir="ltr" lang="{{ request.lang }}">
+<html dir="ltr" lang="{{ request.lang }}" prefix="og: https://ogp.me/ns#">
 <head>
 <base href="{{ BaseHref }}">
 <link rel="shortcut icon" href="favicon.ico">
@@ -15,7 +15,7 @@
 <meta name="description" content="{{ block('description') }}">
 <meta property="og:description" content="{{ block('description') }}">
 {% endif %}
-<meta name="twitter:card" content="summary">
+<meta property="og:type" content="website">
 <meta property="og:site_name" content="{{ GlobalConfig.serviceName }}">
 <link href="node_modules/bootstrap/dist/css/bootstrap.min.css" media="screen, print" rel="stylesheet" type="text/css">
 <link href="resource/css/fonts.css" media="screen, print" rel="stylesheet" type="text/css">

--- a/src/view/concept.twig
+++ b/src/view/concept.twig
@@ -1,6 +1,7 @@
 {% set pageType = 'concept' %}
 {% extends "base-template.twig" %}
 {% block title %}{{ concept.label }} - {{ vocab.shortName }} - {{ GlobalConfig.serviceName }}{% endblock %}
+{% block url %}{{ BaseHref }}{{ concept.uri|link_url(vocab,request.lang,'page',request.contentLang) }}{% endblock %}
 
 {% block content %}
   {% include "sidebar.inc" %}

--- a/src/view/error.twig
+++ b/src/view/error.twig
@@ -1,6 +1,7 @@
 {% set pageType = 'error' %}
 {% extends "base-template.twig" %}
 {% block title %}{{ "Error"| trans }} - {{ GlobalConfig.serviceName }}{% endblock %}
+{% block url %}{{ BaseHref }}{{ request.langurl }}{% endblock %}
 {% block content %}
 {% set pageError = request.vocabid != '' and request.page == 'page' %}
 {% if pageError %}

--- a/src/view/feedback.twig
+++ b/src/view/feedback.twig
@@ -3,7 +3,7 @@
 
 {% block title %}{{ "Feedback"|trans }} - {{ GlobalConfig.serviceName }}{% endblock %}
 {% block description %}{{ GlobalConfig.feedbackDescription(request.lang) }}{% endblock %}
-{% block url %}{{ BaseHref }}{% if request.vocab %}{{ request.vocab.id }}/{% endif %}{{ request.lang }}/feedback{% endblock %}
+{% block url %}{{ BaseHref }}{{ request.langurl }}{% endblock %}
 
 {% block content %}
 

--- a/src/view/feedback.twig
+++ b/src/view/feedback.twig
@@ -3,6 +3,7 @@
 
 {% block title %}{{ "Feedback"|trans }} - {{ GlobalConfig.serviceName }}{% endblock %}
 {% block description %}{{ GlobalConfig.feedbackDescription(request.lang) }}{% endblock %}
+{% block url %}{{ BaseHref }}{% if request.vocab %}{{ request.vocab.id }}/{% endif %}{{ request.lang }}/feedback{% endblock %}
 
 {% block content %}
 

--- a/src/view/landing.twig
+++ b/src/view/landing.twig
@@ -2,6 +2,7 @@
 {% extends "base-template.twig" %}
 {% block title %}{{ GlobalConfig.serviceNameLong(request.lang) }}{% endblock %}
 {% block description %}{{ GlobalConfig.serviceDescription(request.lang) }}{% endblock %}
+{% block url %}{{ BaseHref }}{{ request.lang }}/{% endblock %}
 
 {% block content %}
 <div class="col-md-7">

--- a/src/view/landing.twig
+++ b/src/view/landing.twig
@@ -2,7 +2,7 @@
 {% extends "base-template.twig" %}
 {% block title %}{{ GlobalConfig.serviceNameLong(request.lang) }}{% endblock %}
 {% block description %}{{ GlobalConfig.serviceDescription(request.lang) }}{% endblock %}
-{% block url %}{{ BaseHref }}{{ request.lang }}/{% endblock %}
+{% block url %}{{ BaseHref }}{{ request.langurl }}{% endblock %}
 
 {% block content %}
 <div class="col-md-7">

--- a/src/view/vocab-home.twig
+++ b/src/view/vocab-home.twig
@@ -2,7 +2,7 @@
 {% extends "base-template.twig" %}
 {% block title %}{{ vocab.title(request.contentLang) }} - {{ GlobalConfig.serviceName }}{% endblock %}
 {% block description %}{{ vocab.config.description(request.contentLang) }}{% endblock %}
-{% block url %}{{ BaseHref }}{{ vocab.id }}/{{ request.lang }}/{% if request.contentLang != request.lang and request.contentLang != '' and request.contentLang in vocab.config.languages %}?clang={{ request.contentLang }}{% endif %}{% endblock %}
+{% block url %}{{ BaseHref }}{{ request.langurl }}{% endblock %}
 
 
 {% block content %}

--- a/src/view/vocab-home.twig
+++ b/src/view/vocab-home.twig
@@ -2,6 +2,7 @@
 {% extends "base-template.twig" %}
 {% block title %}{{ vocab.title(request.contentLang) }} - {{ GlobalConfig.serviceName }}{% endblock %}
 {% block description %}{{ vocab.config.description(request.contentLang) }}{% endblock %}
+{% block url %}{{ BaseHref }}{{ vocab.id }}/{{ request.lang }}/{% if request.contentLang != request.lang and request.contentLang != '' and request.contentLang in vocab.config.languages %}?clang={{ request.contentLang }}{% endif %}{% endblock %}
 
 
 {% block content %}

--- a/src/view/vocab-home.twig
+++ b/src/view/vocab-home.twig
@@ -1,6 +1,7 @@
 {% set pageType = 'vocab-home' %}
 {% extends "base-template.twig" %}
 {% block title %}{{ vocab.title(request.contentLang) }} - {{ GlobalConfig.serviceName }}{% endblock %}
+{% block description %}{{ vocab.config.description(request.contentLang) }}{% endblock %}
 
 
 {% block content %}

--- a/src/view/vocab-search.twig
+++ b/src/view/vocab-search.twig
@@ -1,6 +1,8 @@
 {% set pageType = 'vocab-search' %}
 {% extends "base-template.twig" %}
 {% block title %}'{{ term }}' - {{ vocab.shortName(request.contentLang) }} - {{ GlobalConfig.serviceName }}{% endblock %}
+{% block url %}{{ BaseHref }}{{ vocab.id }}/{{ request.lang }}/search?clang={{ request.contentLang}}&amp;q={{ term|url_encode }}{% endblock %}
+
 {% block content %}
 <main class="searchpage py-5" id="main-container" >
   <div class="container">

--- a/src/view/vocab-search.twig
+++ b/src/view/vocab-search.twig
@@ -1,7 +1,7 @@
 {% set pageType = 'vocab-search' %}
 {% extends "base-template.twig" %}
 {% block title %}'{{ term }}' - {{ vocab.shortName(request.contentLang) }} - {{ GlobalConfig.serviceName }}{% endblock %}
-{% block url %}{{ BaseHref }}{{ vocab.id }}/{{ request.lang }}/search?clang={{ request.contentLang}}&amp;q={{ term|url_encode }}{% endblock %}
+{% block url %}{{ BaseHref }}{{ request.langurl }}{% endblock %}
 
 {% block content %}
 <main class="searchpage py-5" id="main-container" >

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -179,7 +179,7 @@ class RequestTest extends PHPUnit\Framework\TestCase
      */
     public function testGetLangUrlNoParamRoot()
     {
-        $this->request->setServerConstant('SCRIPT_NAME', '/Skosmos/index.php');
+        $this->request->setServerConstant('SCRIPT_NAME', '/Skosmos/src/index.php');
         $this->request->setServerConstant('REQUEST_URI', '/Skosmos/en/');
         $langurl = $this->request->getLangUrl();
         $this->assertEquals("en/", $langurl);
@@ -190,7 +190,7 @@ class RequestTest extends PHPUnit\Framework\TestCase
      */
     public function testGetLangUrlNoParamVocab()
     {
-        $this->request->setServerConstant('SCRIPT_NAME', '/Skosmos/index.php');
+        $this->request->setServerConstant('SCRIPT_NAME', '/Skosmos/src/index.php');
         $this->request->setServerConstant('REQUEST_URI', '/Skosmos/myvocab/en/');
         $langurl = $this->request->getLangUrl();
         $this->assertEquals("myvocab/en/", $langurl);
@@ -201,7 +201,7 @@ class RequestTest extends PHPUnit\Framework\TestCase
      */
     public function testGetLangUrlNoParamVocabIndex()
     {
-        $this->request->setServerConstant('SCRIPT_NAME', '/Skosmos/index.php');
+        $this->request->setServerConstant('SCRIPT_NAME', '/Skosmos/src/index.php');
         $this->request->setServerConstant('REQUEST_URI', '/Skosmos/myvocab/en/index');
         $langurl = $this->request->getLangUrl();
         $this->assertEquals("myvocab/en/index", $langurl);
@@ -212,7 +212,7 @@ class RequestTest extends PHPUnit\Framework\TestCase
      */
     public function testGetLangUrlNewLangRoot()
     {
-        $this->request->setServerConstant('SCRIPT_NAME', '/Skosmos/index.php');
+        $this->request->setServerConstant('SCRIPT_NAME', '/Skosmos/src/index.php');
         $this->request->setServerConstant('REQUEST_URI', '/Skosmos/en/');
         $this->request->setLang('en');
         $langurl = $this->request->getLangUrl("sv");
@@ -224,7 +224,7 @@ class RequestTest extends PHPUnit\Framework\TestCase
      */
     public function testGetLangUrlNewLangVocab()
     {
-        $this->request->setServerConstant('SCRIPT_NAME', '/Skosmos/index.php');
+        $this->request->setServerConstant('SCRIPT_NAME', '/Skosmos/src/index.php');
         $this->request->setServerConstant('REQUEST_URI', '/Skosmos/myvocab/en/');
         $this->request->setLang('en');
         $langurl = $this->request->getLangUrl("sv");
@@ -236,7 +236,7 @@ class RequestTest extends PHPUnit\Framework\TestCase
      */
     public function testGetLangUrlNewLangVocabIndex()
     {
-        $this->request->setServerConstant('SCRIPT_NAME', '/Skosmos/index.php');
+        $this->request->setServerConstant('SCRIPT_NAME', '/Skosmos/src/index.php');
         $this->request->setServerConstant('REQUEST_URI', '/Skosmos/myvocab/en/index');
         $this->request->setLang('en');
         $langurl = $this->request->getLangUrl("sv");
@@ -248,7 +248,7 @@ class RequestTest extends PHPUnit\Framework\TestCase
      */
     public function testGetLangUrlSanitizeSpecialChars()
     {
-        $this->request->setServerConstant('SCRIPT_NAME', '/Skosmos/index.php');
+        $this->request->setServerConstant('SCRIPT_NAME', '/Skosmos/src/index.php');
         $this->request->setServerConstant('REQUEST_URI', '/Skosmos/http://example.com');
         $this->request->setLang('en');
         $langurl = $this->request->getLangUrl();

--- a/tests/VocabularyConfigTest.php
+++ b/tests/VocabularyConfigTest.php
@@ -361,6 +361,15 @@ class VocabularyConfigTest extends PHPUnit\Framework\TestCase
     }
 
     /**
+     * @covers VocabularyConfig::getDescription
+     */
+    public function testGetDesctiption()
+    {
+        $vocab = $this->model->getVocabulary('test');
+        $this->assertEquals('Description of Test ontology', $vocab->getConfig()->getDescription('en'));
+    }
+
+    /**
      * @covers VocabularyConfig::getShowDeprecatedChanges
      * @covers VocabularyConfig::getBoolean
      */

--- a/tests/VocabularyTest.php
+++ b/tests/VocabularyTest.php
@@ -225,7 +225,7 @@ class VocabularyTest extends \PHPUnit\Framework\TestCase
     {
         $vocab = $this->model->getVocabulary('test');
         $info = $vocab->getInfo();
-        $this->assertEquals(array("dc:title" => array('Test ontology'), 'dc:modified' => array('Wednesday, October 1, 2014 16:29:03'), "rdf:type" => array('http://www.w3.org/2004/02/skos/core#ConceptScheme' => 'http://www.w3.org/2004/02/skos/core#ConceptScheme'), "owl:versionInfo" => array('The latest and greatest version')), $info);
+        $this->assertEquals(array("dc:title" => array('Test ontology'), 'dc:modified' => array('Wednesday, October 1, 2014 16:29:03'), "rdf:type" => array('http://www.w3.org/2004/02/skos/core#ConceptScheme' => 'http://www.w3.org/2004/02/skos/core#ConceptScheme'), "owl:versionInfo" => array('The latest and greatest version'), "dc:description" => array('Description of Test ontology')), $info);
     }
 
     /**

--- a/tests/cypress/template/about.cy.js
+++ b/tests/cypress/template/about.cy.js
@@ -19,6 +19,14 @@ describe('About page', () => {
     cy.get('head meta[name="description"]').should('have.attr', 'content', expectedDescription);
     cy.get('head meta[property="og:description"]').should('have.attr', 'content', expectedDescription);
   })
+  it('Contains site name metadata', () => {
+    // go to the Skosmos about page
+    cy.visit('/en/about')
+
+    const expectedSiteName = 'Skosmos being tested'
+    // check that the page has site name metadata
+    cy.get('head meta[property="og:site_name"]').should('have.attr', 'content', expectedSiteName);
+  })
   it('Contains version number information', () => {
     // go to the Skosmos about page
     cy.visit('/en/about')

--- a/tests/cypress/template/about.cy.js
+++ b/tests/cypress/template/about.cy.js
@@ -27,6 +27,15 @@ describe('About page', () => {
     // check that the page has site name metadata
     cy.get('head meta[property="og:site_name"]').should('have.attr', 'content', expectedSiteName);
   })
+  it('Contains canonical URL metadata', () => {
+    // go to the Skosmos about page
+    cy.visit('/en/about')
+
+    const expectedUrl = Cypress.config('baseUrl') + 'en/about'
+    // check that the page has canonical URL metadata
+    cy.get('link[rel="canonical"]').should('have.attr', 'href', expectedUrl);
+    cy.get('head meta[property="og:url"]').should('have.attr', 'content', expectedUrl);
+  })
   it('Contains version number information', () => {
     // go to the Skosmos about page
     cy.visit('/en/about')

--- a/tests/cypress/template/concept.cy.js
+++ b/tests/cypress/template/concept.cy.js
@@ -149,6 +149,23 @@ describe('Concept page', () => {
     // check that the page has site name metadata
     cy.get('head meta[property="og:site_name"]').should('have.attr', 'content', expectedSiteName);
   })
+  it('Contains canonical URL metadata (short URL)', () => {
+    cy.visit('/yso/en/page/p1265') // go to "archaeology" concept page
+
+    const expectedUrl = Cypress.config('baseUrl') + 'yso/en/page/p1265'
+    // check that the page has canonical URL metadata
+    cy.get('link[rel="canonical"]').should('have.attr', 'href', expectedUrl);
+    cy.get('head meta[property="og:url"]').should('have.attr', 'content', expectedUrl);
+  })
+  it('Contains canonical URL metadata (long URL)', () => {
+    // go to "archaeology" concept page using long URL based on URI
+    cy.visit('/yso/en/page/?uri=http%3A%2F%2Fwww.yso.fi%2Fonto%2Fyso%2Fp1265')
+
+    const expectedUrl = Cypress.config('baseUrl') + 'yso/en/page/p1265'
+    // check that the page has canonical URL metadata
+    cy.get('link[rel="canonical"]').should('have.attr', 'href', expectedUrl);
+    cy.get('head meta[property="og:url"]').should('have.attr', 'content', expectedUrl);
+  })
   it("doesn't contain breadcrumbs for top concepts", () => {
     cy.visit('/yso/en/page/p4762') // go to "objects" concept page
 

--- a/tests/cypress/template/concept.cy.js
+++ b/tests/cypress/template/concept.cy.js
@@ -142,6 +142,13 @@ describe('Concept page', () => {
     cy.get('head meta[name="title"]').should('have.attr', 'content', expectedTitle);
     cy.get('head meta[property="og:title"]').should('have.attr', 'content', expectedTitle);
   })
+  it('Contains site name metadata', () => {
+    cy.visit('/yso/en/page/p1265') // go to "archaeology" concept page
+
+    const expectedSiteName = 'Skosmos being tested'
+    // check that the page has site name metadata
+    cy.get('head meta[property="og:site_name"]').should('have.attr', 'content', expectedSiteName);
+  })
   it("doesn't contain breadcrumbs for top concepts", () => {
     cy.visit('/yso/en/page/p4762') // go to "objects" concept page
 

--- a/tests/cypress/template/error.cy.js
+++ b/tests/cypress/template/error.cy.js
@@ -10,6 +10,14 @@ describe('Error page', () => {
     cy.get('head meta[name="title"]').should('have.attr', 'content', expectedTitle);
     cy.get('head meta[property="og:title"]').should('have.attr', 'content', expectedTitle);
   })
+  it('Contains site name metadata', () => {
+    // go to a non-existing page
+    cy.visit('/404', {failOnStatusCode: false})
+
+    const expectedSiteName = 'Skosmos being tested'
+    // check that the page has site name metadata
+    cy.get('head meta[property="og:site_name"]').should('have.attr', 'content', expectedSiteName);
+  })
   it('Contains 404 error code', () => {
     // check that HTTP code is 404 when accessing a non-existing page
     cy.request({url: '/404', failOnStatusCode: false}).its('status').should('equal', 404)

--- a/tests/cypress/template/error.cy.js
+++ b/tests/cypress/template/error.cy.js
@@ -18,6 +18,15 @@ describe('Error page', () => {
     // check that the page has site name metadata
     cy.get('head meta[property="og:site_name"]').should('have.attr', 'content', expectedSiteName);
   })
+  it('Contains canonical URL metadata', () => {
+    // go to a non-existing page
+    cy.visit('/404', {failOnStatusCode: false})
+
+    const expectedUrl = Cypress.config('baseUrl') + '404/'
+    // check that the page has canonical URL metadata
+    cy.get('link[rel="canonical"]').should('have.attr', 'href', expectedUrl);
+    cy.get('head meta[property="og:url"]').should('have.attr', 'content', expectedUrl);
+  })
   it('Contains 404 error code', () => {
     // check that HTTP code is 404 when accessing a non-existing page
     cy.request({url: '/404', failOnStatusCode: false}).its('status').should('equal', 404)

--- a/tests/cypress/template/feedback.cy.js
+++ b/tests/cypress/template/feedback.cy.js
@@ -27,6 +27,15 @@ describe('Feedback page', () => {
     // check that the page has site name metadata
     cy.get('head meta[property="og:site_name"]').should('have.attr', 'content', expectedSiteName);
   })
+  it('Contains canonical URL metadata', () => {
+    // go to the general feedback page
+    cy.visit('/en/feedback')
+
+    const expectedUrl = Cypress.config('baseUrl') + 'en/feedback'
+    // check that the page has canonical URL metadata
+    cy.get('link[rel="canonical"]').should('have.attr', 'href', expectedUrl);
+    cy.get('head meta[property="og:url"]').should('have.attr', 'content', expectedUrl);
+  })
   it('Sends feedback', () => {
     // go to the general feedback page
     cy.visit('/en/feedback')
@@ -90,6 +99,15 @@ describe('Vocab feedback page', () => {
     const expectedSiteName = 'Skosmos being tested'
     // check that the page has site name metadata
     cy.get('head meta[property="og:site_name"]').should('have.attr', 'content', expectedSiteName);
+  })
+  it('Contains canonical URL metadata', () => {
+    // go to test vocab feedback page
+    cy.visit('/test/en/feedback')
+
+    const expectedUrl = Cypress.config('baseUrl') + 'test/en/feedback'
+    // check that the page has canonical URL metadata
+    cy.get('link[rel="canonical"]').should('have.attr', 'href', expectedUrl);
+    cy.get('head meta[property="og:url"]').should('have.attr', 'content', expectedUrl);
   })
   it('Displays correct vocab option', () => {
     // go to test vocab feedback page

--- a/tests/cypress/template/feedback.cy.js
+++ b/tests/cypress/template/feedback.cy.js
@@ -19,6 +19,14 @@ describe('Feedback page', () => {
     cy.get('head meta[name="description"]').should('have.attr', 'content', expectedDescription);
     cy.get('head meta[property="og:description"]').should('have.attr', 'content', expectedDescription);
   })
+  it('Contains site name metadata', () => {
+    // go to the general feedback page
+    cy.visit('/en/feedback')
+
+    const expectedSiteName = 'Skosmos being tested'
+    // check that the page has site name metadata
+    cy.get('head meta[property="og:site_name"]').should('have.attr', 'content', expectedSiteName);
+  })
   it('Sends feedback', () => {
     // go to the general feedback page
     cy.visit('/en/feedback')
@@ -74,6 +82,14 @@ describe('Vocab feedback page', () => {
     // check that the page has description metadata
     cy.get('head meta[name="description"]').should('have.attr', 'content', expectedDescription);
     cy.get('head meta[property="og:description"]').should('have.attr', 'content', expectedDescription);
+  })
+  it('Contains site name metadata', () => {
+    // go to test vocab feedback page
+    cy.visit('/test/en/feedback')
+
+    const expectedSiteName = 'Skosmos being tested'
+    // check that the page has site name metadata
+    cy.get('head meta[property="og:site_name"]').should('have.attr', 'content', expectedSiteName);
   })
   it('Displays correct vocab option', () => {
     // go to test vocab feedback page

--- a/tests/cypress/template/landing.cy.js
+++ b/tests/cypress/template/landing.cy.js
@@ -29,6 +29,15 @@ describe('Landing page', () => {
     // check that the page has site name metadata
     cy.get('head meta[property="og:site_name"]').should('have.attr', 'content', expectedSiteName);
   })
+  it('Contains canonical URL metadata', () => {
+    // go to the Skosmos front page
+    cy.visit('/')
+
+    const expectedUrl = Cypress.config('baseUrl') + 'en/'
+    // check that the page has canonical URL metadata
+    cy.get('link[rel="canonical"]').should('have.attr', 'href', expectedUrl);
+    cy.get('head meta[property="og:url"]').should('have.attr', 'content', expectedUrl);
+  })
   it('links to vocabulary home', () => {
     // go to the Skosmos front page
     cy.visit('/')

--- a/tests/cypress/template/landing.cy.js
+++ b/tests/cypress/template/landing.cy.js
@@ -21,6 +21,14 @@ describe('Landing page', () => {
     cy.get('head meta[name="description"]').should('have.attr', 'content', expectedDescription);
     cy.get('head meta[property="og:description"]').should('have.attr', 'content', expectedDescription);
   })
+  it('Contains site name metadata', () => {
+    // go to the Skosmos front page
+    cy.visit('/')
+
+    const expectedSiteName = 'Skosmos being tested'
+    // check that the page has site name metadata
+    cy.get('head meta[property="og:site_name"]').should('have.attr', 'content', expectedSiteName);
+  })
   it('links to vocabulary home', () => {
     // go to the Skosmos front page
     cy.visit('/')

--- a/tests/cypress/template/vocab-home.cy.js
+++ b/tests/cypress/template/vocab-home.cy.js
@@ -9,6 +9,15 @@ describe('Vocabulary home page', () => {
     cy.get('head meta[name="title"]').should('have.attr', 'content', expectedTitle);
     cy.get('head meta[property="og:title"]').should('have.attr', 'content', expectedTitle);
   })
+  it('Contains description metadata', () => {
+    cy.visit('/test/en') // go to the "Test ontology" home page
+
+    const expectedDescription = 'Description of Test ontology'
+
+    // check that the page has description metadata
+    cy.get('head meta[name="description"]').should('have.attr', 'content', expectedDescription);
+    cy.get('head meta[property="og:description"]').should('have.attr', 'content', expectedDescription);
+  })
   it('contains vocabulary title', () => {
     cy.visit('/test/en') // go to the "Test ontology" home page
 

--- a/tests/cypress/template/vocab-home.cy.js
+++ b/tests/cypress/template/vocab-home.cy.js
@@ -25,6 +25,14 @@ describe('Vocabulary home page', () => {
     // check that the page has site name metadata
     cy.get('head meta[property="og:site_name"]').should('have.attr', 'content', expectedSiteName);
   })
+  it('Contains canonical URL metadata', () => {
+    cy.visit('/test/en') // go to the "Test ontology" home page
+
+    const expectedUrl = Cypress.config('baseUrl') + 'test/en/'
+    // check that the page has canonical URL metadata
+    cy.get('link[rel="canonical"]').should('have.attr', 'href', expectedUrl);
+    cy.get('head meta[property="og:url"]').should('have.attr', 'content', expectedUrl);
+  })
   it('contains vocabulary title', () => {
     cy.visit('/test/en') // go to the "Test ontology" home page
 

--- a/tests/cypress/template/vocab-home.cy.js
+++ b/tests/cypress/template/vocab-home.cy.js
@@ -18,6 +18,13 @@ describe('Vocabulary home page', () => {
     cy.get('head meta[name="description"]').should('have.attr', 'content', expectedDescription);
     cy.get('head meta[property="og:description"]').should('have.attr', 'content', expectedDescription);
   })
+  it('Contains site name metadata', () => {
+    cy.visit('/test/en') // go to the "Test ontology" home page
+
+    const expectedSiteName = 'Skosmos being tested'
+    // check that the page has site name metadata
+    cy.get('head meta[property="og:site_name"]').should('have.attr', 'content', expectedSiteName);
+  })
   it('contains vocabulary title', () => {
     cy.visit('/test/en') // go to the "Test ontology" home page
 

--- a/tests/cypress/template/vocab-search.cy.js
+++ b/tests/cypress/template/vocab-search.cy.js
@@ -11,6 +11,13 @@ describe('Vocabulary search page', () => {
       cy.get('head meta[name="title"]').should('have.attr', 'content', expectedTitle);
       cy.get('head meta[property="og:title"]').should('have.attr', 'content', expectedTitle);
   })
+  it('Contains site name metadata', () => {
+      cy.visit(`/${vocab}/en/search?clang=en&q=${term}`)
+
+      const expectedSiteName = 'Skosmos being tested'
+      // check that the page has site name metadata
+      cy.get('head meta[property="og:site_name"]').should('have.attr', 'content', expectedSiteName);
+  })
   it('Contains correct amount of search results ', () => {
       const count = 1;
       const searchCountTitle = `${count} results for \'${term}\'`;

--- a/tests/cypress/template/vocab-search.cy.js
+++ b/tests/cypress/template/vocab-search.cy.js
@@ -18,6 +18,14 @@ describe('Vocabulary search page', () => {
       // check that the page has site name metadata
       cy.get('head meta[property="og:site_name"]').should('have.attr', 'content', expectedSiteName);
   })
+  it('Contains canonical URL metadata', () => {
+      cy.visit(`/${vocab}/en/search?clang=en&q=${term}`)
+
+    const expectedUrl = Cypress.config('baseUrl') + `${vocab}/en/search?clang=en&q=${term}`
+    // check that the page has canonical URL metadata
+    cy.get('link[rel="canonical"]').should('have.attr', 'href', expectedUrl);
+    cy.get('head meta[property="og:url"]').should('have.attr', 'content', expectedUrl);
+  })
   it('Contains correct amount of search results ', () => {
       const count = 1;
       const searchCountTitle = `${count} results for \'${term}\'`;

--- a/tests/testconfig.ttl
+++ b/tests/testconfig.ttl
@@ -77,6 +77,7 @@
 
 :test a skosmos:Vocabulary, void:Dataset ;
 	dc:title "Test ontology"@en ;
+	dc:description "Description of Test ontology"@en ;
 	dc:subject :cat_science ;
     dc:type mdrtype:ONTOLOGY ;
 	void:dataDump <http://skosmos.skos/dump/test/> ;


### PR DESCRIPTION
## Reasons for creating this PR

This PR implements most of the remaining SEO functionality from #1533 :

* vocabulary description on vocab home page
* og:site_name on all pages
* og:type="website" on all pages
* og:url and link rel=canonical on all pages
* drop twitter:card (shouldn't be needed since twitter/X falls back on og:type)

In addition, there is a bug fix to the Request.getLangUrl method that broke when the Skosmos 3 code was restructured by moving backend code under `src/`. This fix could have been a separate PR but since the bug was causing problems for the canonical URL generation, I decided to fix it here in this PR. The fix is in a separate commit 9bdb8948d4246a410181db32cdc7dcf0efd2f309 .

## Link to relevant issue(s), if any

- part of #1533

## Description of the changes in this PR

* add VocabularyConfig.getDescription() method + PHPUnit test
* add new metadata elements to base-template.twig (and drop twitter:card)
* add blocks in page type templates to populate the metadata
* add cypress tests
* fix bug in Request.getLangUrl() method + correct the PHPUnit tests accordingly

## Known problems or uncertainties in this PR

None so far!

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
