### PR TITLE
Override default property labels on concept page

### DIFF
--- a/resource/js/concept-mappings.js
+++ b/resource/js/concept-mappings.js
@@ -9,12 +9,14 @@ const conceptMappingsApp = Vue.createApp({
     }
   },
   provide: {
-    content_lang: window.SKOSMOS.content_lang,
-    customLabels: window.SKOSMOS.customLabels
+    content_lang: window.SKOSMOS.content_lang
   },
   computed: {
     hasMappings () {
       return Object.keys(this.mappings).length > 0
+    },
+    customLabels () {
+      return window.SKOSMOS.customLabels
     }
   },
   methods: {
@@ -64,7 +66,7 @@ const conceptMappingsApp = Vue.createApp({
       </template>
       <template v-else-if="hasMappings">
         <div class="main-content-section p-5">
-          <concept-mappings :mappings="mappings"></concept-mappings>
+          <concept-mappings :mappings="mappings" :customLabels="customLabels"></concept-mappings>
         </div>
       </template>
     </div>
@@ -85,8 +87,8 @@ conceptMappingsApp.directive('load-concept-page', {
 })
 
 conceptMappingsApp.component('concept-mappings', {
-  props: ['mappings'],
-  inject: ['content_lang', 'customLabels'],
+  props: ['mappings', 'customLabels'],
+  inject: ['content_lang'],
   template: `
     <div class="row property prop-mapping" v-for="(mapping, label) in mappings">
       <template v-if="customLabels">

--- a/resource/js/concept-mappings.js
+++ b/resource/js/concept-mappings.js
@@ -9,7 +9,8 @@ const conceptMappingsApp = Vue.createApp({
     }
   },
   provide: {
-    content_lang: window.SKOSMOS.content_lang
+    content_lang: window.SKOSMOS.content_lang,
+    customLabels: window.SKOSMOS.customLabels
   },
   computed: {
     hasMappings () {
@@ -20,7 +21,7 @@ const conceptMappingsApp = Vue.createApp({
     loadMappings () {
       this.mappings = {} // clear mappings before starting to load new ones
       this.loading = true
-      const url = 'rest/v1/' + window.SKOSMOS.vocab + '/mappings?uri=' + window.SKOSMOS.uri + '&external=true&clang=' + window.SKOSMOS.lang + '&lang=' + window.SKOSMOS.content_lang
+      const url = 'rest/v1/' + window.SKOSMOS.vocab + '/mappings?uri=' + window.SKOSMOS.uri + '&external=true&lang=' + window.SKOSMOS.lang + '&clang=' + window.SKOSMOS.content_lang
       fetchWithAbort(url, 'concept')
         .then(data => {
           return data.json()
@@ -85,12 +86,19 @@ conceptMappingsApp.directive('load-concept-page', {
 
 conceptMappingsApp.component('concept-mappings', {
   props: ['mappings'],
-  inject: ['content_lang'],
+  inject: ['content_lang', 'customLabels'],
   template: `
-    <div class="row property prop-mapping" v-for="mapping in Object.entries(mappings)">
-      <div class="col-sm-4 px-0 property-label" :title="mapping[1][0].description"><h2>{{ mapping[0] }}</h2></div>
+    <div class="row property prop-mapping" v-for="(mapping, label) in mappings">
+      <template v-if="customLabels">
+        <div class="col-sm-4 px-0 property-label" :title="customLabels[mapping[0].type[0]][1] || mapping[0].description">
+          <h2>{{ customLabels[mapping[0].type[0]][0] }}</h2>
+        </div>
+      </template>
+      <template v-else>
+        <div class="col-sm-4 px-0 property-label" :title="mapping[0].description"><h2>{{ label }}</h2></div>
+      </template>
       <div class="col-sm-8">
-        <div class="row mb-2" v-for="m in mapping[1]">
+        <div class="row mb-2" v-for="m in mapping">
           <div class="col-sm-5 prop-mapping-label">
             <a :href="m.hrefLink">{{ m.prefLabel }}</a><span v-if="m.lang && m.lang !== this.content_lang"> ({{ m.lang }})</span>
           </div>

--- a/src/view/concept-card.inc
+++ b/src/view/concept-card.inc
@@ -29,8 +29,9 @@
 
       <div class="row" id="concept-heading">
         <div class="col-sm-4 px-0" id="concept-property-label">
-        {%- if custom_labels['skos:prefLabel']['label'][request.lang] -%}
-          {{ custom_labels['skos:prefLabel']['label'][request.lang]|capitalize }}
+        {%- set label = custom_labels['skos:prefLabel']['label'][request.lang] -%}
+        {%- if label -%}
+          {{ label[:1]|upper ~ label[1:] }} {# Capitalizing labels #}
         {%- else -%}
           {{ "skos:prefLabel" | trans }}
         {%- endif -%}
@@ -58,8 +59,9 @@
       {% for property in concept.properties %}{% if property.getSubPropertyOf != 'skos:hiddenLabel' %}
       <div class="row property prop-{{property.ID}}">
         <div class="col-sm-4 px-0 property-label"><h2>
-        {%- if custom_labels[property.type]['label'][request.lang] -%}
-          {{ custom_labels[property.type]['label'][request.lang]|capitalize }}
+        {%- set label = custom_labels[property.type]['label'][request.lang] -%}
+        {%- if label -%}
+          {{ label[:1]|upper ~ label[1:] }} {# Capitalizing labels #}
         {%- else -%}
           {{ property.label }}
         {%- endif -%}

--- a/src/view/concept-card.inc
+++ b/src/view/concept-card.inc
@@ -28,7 +28,13 @@
       {% endif %}
 
       <div class="row" id="concept-heading">
-        <div class="col-sm-4 px-0" id="concept-property-label">{{ "skos:prefLabel" | trans }}</div>
+        <div class="col-sm-4 px-0" id="concept-property-label">
+        {%- if custom_labels['skos:prefLabel']['label'][request.lang] -%}
+          {{ custom_labels['skos:prefLabel']['label'][request.lang] }}
+        {%- else -%}
+          {{ "skos:prefLabel" | trans }}
+        {%- endif -%}
+        </div>
         <div class="col-sm-8" id="concept-label">
         {% if concept.notation %}
           <h1 id="concept-preflabel"
@@ -51,7 +57,13 @@
 
       {% for property in concept.properties %}{% if property.getSubPropertyOf != 'skos:hiddenLabel' %}
       <div class="row property prop-{{property.ID}}">
-        <div class="col-sm-4 px-0 property-label"><h2>{{ property.label}}</h2></div>
+        <div class="col-sm-4 px-0 property-label"><h2>
+        {%- if custom_labels[property.type]['label'][request.lang] -%}
+          {{ custom_labels[property.type]['label'][request.lang] }}
+        {%- else -%}
+          {{ property.label }}
+        {%- endif -%}
+        </h2></div>
         <div class="col-sm-8 align-self-center property-value">
           <ul class="align-bottom">
           {% for propval in property.values %}

--- a/src/view/concept-card.inc
+++ b/src/view/concept-card.inc
@@ -30,7 +30,7 @@
       <div class="row" id="concept-heading">
         <div class="col-sm-4 px-0" id="concept-property-label">
         {%- if custom_labels['skos:prefLabel']['label'][request.lang] -%}
-          {{ custom_labels['skos:prefLabel']['label'][request.lang] }}
+          {{ custom_labels['skos:prefLabel']['label'][request.lang]|capitalize }}
         {%- else -%}
           {{ "skos:prefLabel" | trans }}
         {%- endif -%}
@@ -59,7 +59,7 @@
       <div class="row property prop-{{property.ID}}">
         <div class="col-sm-4 px-0 property-label"><h2>
         {%- if custom_labels[property.type]['label'][request.lang] -%}
-          {{ custom_labels[property.type]['label'][request.lang] }}
+          {{ custom_labels[property.type]['label'][request.lang]|capitalize }}
         {%- else -%}
           {{ property.label }}
         {%- endif -%}

--- a/src/view/scripts.inc
+++ b/src/view/scripts.inc
@@ -24,6 +24,14 @@ window.SKOSMOS = {
   {%- if request.plugins.callbacks ~%}
   "pluginCallbacks": [{% for function in request.plugins.callbacks %}{% if not loop.first %}, {% endif %}"{{ function }}"{% endfor %}],
   {%- endif ~%}
+  {%- if custom_labels -%}
+  "customLabels": { 
+    {%- for k, v in custom_labels -%}
+      {%- set label = v['label'][request.lang] -%}
+      {%- set description = v['description'][request.lang] -%}
+      {%- if not loop.first -%}, {%- endif -%}"{{k}}": ["{{label[:1]|upper ~ label[1:]}}", "{{description[:1]|upper ~ description[1:]}}"]{%- endfor -%} 
+  },
+  {%- endif -%}
   "baseHref": "{{ BaseHref }}",
   "language_strings": { "fi": { "fi": "suomi",
                                 "en": "englanti",

--- a/tests/VocabularyConfigTest.php
+++ b/tests/VocabularyConfigTest.php
@@ -699,6 +699,8 @@ class VocabularyConfigTest extends PHPUnit\Framework\TestCase
           'skos:prefLabel' => array( 'label' => array( 'en' => 'Caption', 'fi' => 'Luokka' ) ),
           'skos:notation' => array( 'label' => array( 'en' => 'UDC number', 'fi' => 'UDC-numero', 'sv' => 'UDC-nummer' ),
                                     'description' => array( 'en' => 'Class Number') ),
+          'skos:exactMatch' => array( 'label' => array( 'fi' => 'vastaava luokka', 'sv' => 'motsvarande klasser', 'en' => 'exactly matching classes' ),
+                                      'description' => array( 'en' => 'exactly matching classes in another vocabulary.' ) ),
         );
         $this->assertEquals($expected, $overrides);
     }

--- a/tests/cypress/template/concept.cy.js
+++ b/tests/cypress/template/concept.cy.js
@@ -230,12 +230,16 @@ describe('Concept page', () => {
   })
 
   it('overrides property labels', () => {
-    // Go to "Barracuda" concept page in vocab with property label overrides
-    cy.visit('/conceptPropertyLabels/en/page/ta0116')
+    // Go to "Carp" concept page in vocab with property label overrides
+    cy.visit('/conceptPropertyLabels/en/page/ta112')
     // Check that prefLabel property label is overridden correctly
-    cy.get('#concept-property-label').invoke('text').should('equal', 'Caption')
+    cy.get('#concept-property-label').invoke('text').should('include', 'Caption')
     // Check that notation property label is overridden correctly
-    cy.get('.prop-skos_notation .property-label h2').invoke('text').should('equal', 'UDC number')
+    cy.get('.prop-skos_notation .property-label h2').invoke('text').should('include', 'UDC number')
+    // Check that mapping property name is overridden correctly
+    cy.get('.prop-mapping h2', {'timeout': 20000}).eq(0).contains('Exactly matching classes')
+    // Check that mapping property title is overridden correctly
+    cy.get('.prop-mapping .property-label').eq(0).should('have.attr', 'title').and('contain', 'Exactly matching classes in another vocabulary.')
   })
   it('contains concept type', () => {
     cy.visit('/yso/en/page/p21685') // go to "music research" concept page

--- a/tests/cypress/template/concept.cy.js
+++ b/tests/cypress/template/concept.cy.js
@@ -2,7 +2,6 @@ describe('Concept page', () => {
   const pageLoadTypes = ["full", "partial"]
 
   // tests that should be executed both with and without partial page load
-
   pageLoadTypes.forEach((pageLoadType) => {
     it('contains concept preflabel / ' + pageLoadType, () => {
       if (pageLoadType == "full") {
@@ -230,6 +229,14 @@ describe('Concept page', () => {
     cy.get('#concept-breadcrumbs ol').find('li.show').should('have.length', 4)
   })
 
+  it('overrides property labels', () => {
+    // Go to "Barracuda" concept page in vocab with property label overrides
+    cy.visit('/conceptPropertyLabels/en/page/ta0116')
+    // Check that prefLabel property label is overridden correctly
+    cy.get('#concept-property-label').invoke('text').should('equal', 'Caption')
+    // Check that notation property label is overridden correctly
+    cy.get('.prop-skos_notation .property-label h2').invoke('text').should('equal', 'UDC number')
+  })
   it('contains concept type', () => {
     cy.visit('/yso/en/page/p21685') // go to "music research" concept page
 

--- a/tests/test-vocab-data/conceptPropertyLabels.ttl
+++ b/tests/test-vocab-data/conceptPropertyLabels.ttl
@@ -1,0 +1,47 @@
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix dc11: <http://purl.org/dc/elements/1.1/> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix test: <http://www.skosmos.skos/conceptPropertyLabels/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix skosmos: <http://www.skosmos.skos/> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix mads: <http://www.loc.gov/mads/rdf/v1#> .
+
+test:ta112 a skos:Concept ;
+    skos:notation "665" ;
+    skos:broader test:ta1 ;
+    skos:narrower test:ta121 ;
+    skos:exactMatch test:ta118 ;
+    skos:inScheme test:conceptscheme ;
+    skos:prefLabel "Carp"@en,
+        "Karppi"@fi ;
+    skos:altLabel "Golden crucian"@en;
+    skos:hiddenLabel "Karpit"@fi;
+    skos:scopeNote "Carp are oily freshwater fish"@en .
+
+test:ta118 a skos:Concept ;
+    skos:inScheme test:conceptscheme ;
+    skos:exactMatch test:ta112 ;
+    skos:prefLabel "-\"special\" character \\example\\"@en .
+
+test:ta121 a skos:Concept ;
+    skos:broader test:ta112 ;
+    skos:inScheme test:conceptscheme ;
+    skos:prefLabel "Crucian carp"@en .
+
+test:ta1 a skos:Concept ;
+    skos:inScheme test:conceptscheme ;
+    skos:narrower test:ta112 ;
+    skos:prefLabel "Fish"@en ;
+    skos:exactMatch <http://www.wikidata.org/entity/Q152> ;
+    skos:topConceptOf test:conceptscheme .
+
+test:conceptscheme a skos:ConceptScheme ;
+    rdfs:label "Test conceptscheme"@en ;
+    dct:modified "2014-10-01T16:29:03+00:00"^^xsd:dateTime ;
+    owl:versionInfo "The latest and greatest version"^^xsd:string ;
+    skos:hasTopConcept test:ta1 .

--- a/tests/testconfig.ttl
+++ b/tests/testconfig.ttl
@@ -333,8 +333,8 @@
 	dc:title "Test custom property labels"@en ;
 	dc:subject :cat_science ;
     dc:type mdrtype:ONTOLOGY ;
-	void:dataDump <http://skosmos.skos/dump/test/> ;
-	void:uriSpace "http://www.skosmos.skos/test/";
+	void:dataDump <http://skosmos.skos/dump/conceptPropertyLabels/> ;
+	void:uriSpace "http://www.skosmos.skos/conceptPropertyLabels/";
 	skosmos:defaultLanguage "en";
 	skosmos:language "en";
     skosmos:propertyLabelOverride
@@ -345,7 +345,8 @@
           rdfs:comment "Class Number"@en ],
         [ skosmos:property skos:exactMatch ;
           rdfs:label "vastaava luokka"@fi, "motsvarande klasser"@sv, "exactly matching classes"@en ;
-          rdfs:comment "exactly matching classes in another vocabulary."@en ] .
+          rdfs:comment "exactly matching classes in another vocabulary."@en ] ;
+        skosmos:sparqlGraph <http://www.skosmos.skos/conceptPropertyLabels/> .
 
 :cbd a skosmos:Vocabulary, void:Dataset ;
     dc11:title "A vocabulary for testing blank node processing and reification"@en ;

--- a/tests/testconfig.ttl
+++ b/tests/testconfig.ttl
@@ -342,7 +342,10 @@
           rdfs:label "Caption"@en, "Luokka"@fi ],
         [ skosmos:property skos:notation ;
           rdfs:label "UDC number"@en, "UDC-numero"@fi, "UDC-nummer"@sv ;
-          rdfs:comment "Class Number"@en ] .
+          rdfs:comment "Class Number"@en ],
+        [ skosmos:property skos:exactMatch ;
+          rdfs:label "vastaava luokka"@fi, "motsvarande klasser"@sv, "exactly matching classes"@en ;
+          rdfs:comment "exactly matching classes in another vocabulary."@en ] .
 
 :cbd a skosmos:Vocabulary, void:Dataset ;
     dc11:title "A vocabulary for testing blank node processing and reification"@en ;

--- a/tests/testconfig.ttl
+++ b/tests/testconfig.ttl
@@ -342,8 +342,7 @@
           rdfs:label "Caption"@en, "Luokka"@fi ],
         [ skosmos:property skos:notation ;
           rdfs:label "UDC number"@en, "UDC-numero"@fi, "UDC-nummer"@sv ;
-          rdfs:comment "Class Number"@en ] ;
-	skosmos:sparqlGraph <http://www.skosmos.skos/conceptPropertyLabels/> .
+          rdfs:comment "Class Number"@en ] .
 
 :cbd a skosmos:Vocabulary, void:Dataset ;
     dc11:title "A vocabulary for testing blank node processing and reification"@en ;


### PR DESCRIPTION
## Reasons for creating this PR

It is not currently possible to override default property labels on the concept page. This PR adds this functionality.

## Link to relevant issue(s), if any

- part of #1484

## Description of the changes in this PR

- Override default property labels in concept card and mappings
- Cypress tests
- Remove `skosmos:sparqlGraph` config option from `conceptPropertyLabels` test vocab
- Refactor mappings template
- Fix bug in mappings URL

## Known problems or uncertainties in this PR

## Checklist

- [ ] phpUnit tests pass locally with my changes
- [ ] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [ ] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [ ] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
