### PR TITLE
SEO: add description metadata to concept page

### DIFF
--- a/resource/translations/skosmos_en.po
+++ b/resource/translations/skosmos_en.po
@@ -885,3 +885,6 @@ msgstr "Copy to clipboard"
 
 msgid "Error"
 msgstr "Error"
+
+msgid "Concept %term% in vocabulary %vocab%"
+msgstr "Concept %term% in vocabulary %vocab%"

--- a/resource/translations/skosmos_fi.po
+++ b/resource/translations/skosmos_fi.po
@@ -894,3 +894,6 @@ msgstr "Kopioi leikepöydälle"
 
 msgid "Error"
 msgstr "Virhe"
+
+msgid "Concept %term% in vocabulary %vocab%"
+msgstr "Käsite %term% sanastossa %vocab%"

--- a/resource/translations/skosmos_se.po
+++ b/resource/translations/skosmos_se.po
@@ -881,3 +881,6 @@ msgstr "Diehtu"
 
 msgid "Error"
 msgstr "Error"
+
+msgid "Concept %term% in vocabulary %vocab%"
+msgstr "Doaba %term% sátnerájus %vocab%"

--- a/resource/translations/skosmos_sv.po
+++ b/resource/translations/skosmos_sv.po
@@ -893,3 +893,6 @@ msgstr "Kopiera till urklipp"
 
 msgid "Error"
 msgstr "Fel"
+
+msgid "Concept %term% in vocabulary %vocab%"
+msgstr "Begreppet %term% i vokabulären %vocab%"

--- a/src/view/concept.twig
+++ b/src/view/concept.twig
@@ -1,6 +1,7 @@
 {% set pageType = 'concept' %}
 {% extends "base-template.twig" %}
 {% block title %}{{ concept.label }} - {{ vocab.shortName }} - {{ GlobalConfig.serviceName }}{% endblock %}
+{% block description %}{{ "Concept %term% in vocabulary %vocab%" | trans({'%term%': concept.label, '%vocab%': vocab.title(request.contentLang)}) }}{% endblock %}
 {% block url %}{{ BaseHref }}{{ concept.uri|link_url(vocab,request.lang,'page',request.contentLang) }}{% endblock %}
 
 {% block content %}

--- a/tests/cypress/template/concept.cy.js
+++ b/tests/cypress/template/concept.cy.js
@@ -142,6 +142,14 @@ describe('Concept page', () => {
     cy.get('head meta[name="title"]').should('have.attr', 'content', expectedTitle);
     cy.get('head meta[property="og:title"]').should('have.attr', 'content', expectedTitle);
   })
+  it('Contains description metadata', () => {
+    cy.visit('/yso/en/page/p1265') // go to "archaeology" concept page
+
+    const expectedDescription = 'Concept archaeology in vocabulary YSO - General Finnish ontology (archaeology)'
+    // check that the page has description metadata
+    cy.get('head meta[name="description"]').should('have.attr', 'content', expectedDescription);
+    cy.get('head meta[property="og:description"]').should('have.attr', 'content', expectedDescription);
+  })
   it('Contains site name metadata', () => {
     cy.visit('/yso/en/page/p1265') // go to "archaeology" concept page
 


### PR DESCRIPTION
## Reasons for creating this PR

Adding one final missing piece of SEO functionality: description metadata on the concept page.

The description is translated using the normal translation mechanism. The current translations are:
* Finnish: Käsite xxxx sanastossa yyyy
* Swedish: Begreppet xxxx i vokabulären yyyy 
* English: Concept xxxx in vocabulary yyyy
* Northern Sámi: Doaba xxxx sátnerájus yyyy

where xxxx is the prefLabel of the concept and yyyy is the title (not the short name) of the vocabulary, as specified earlier in #1533.

## Link to relevant issue(s), if any

- part of #1533

## Description of the changes in this PR

* add description block to concept page twig template
* add translations (fi, sv, en, se) needed to generate the translation
* add cypress test to verify that it works

## Known problems or uncertainties in this PR

None

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
