### PR TITLE
Fix flaky getResourceFromUri test by increasing httpTimeout (Skosmos 2)

### DIFF
--- a/tests/GlobalConfigTest.php
+++ b/tests/GlobalConfigTest.php
@@ -43,7 +43,7 @@ class GlobalConfigTest extends PHPUnit\Framework\TestCase
 
     public function testGetHttpTimeout()
     {
-        $this->assertEquals(2, $this->config->getHttpTimeout());
+        $this->assertEquals(8, $this->config->getHttpTimeout());
     }
 
     public function testGetServiceName()

--- a/tests/testconfig.ttl
+++ b/tests/testconfig.ttl
@@ -30,7 +30,7 @@
     skosmos:sparqlCollationEnabled true ;
     # HTTP client configuration
     skosmos:sparqlTimeout 10 ;
-    skosmos:httpTimeout 2 ;
+    skosmos:httpTimeout 8 ;
     # customize the service name
     skosmos:serviceName "Skosmos being tested" ;
     # customize the base element. Set this if the automatic base url detection doesn't work. For example setups behind a proxy.


### PR DESCRIPTION
## Reasons for creating this PR

One of the Skosmos 2 PHPUnit tests (ModelTest::testGetResourceFromUri) was frequently failing, e.g. [this run](https://github.com/NatLibFi/Skosmos/actions/runs/10504426502/job/29099839944?pr=1663).

The problem is that this test triggers a HTTP request to Finto, which can sometimes take a bit longer than 2 seconds. This causes a HTTP timeout in the LinkedDataResolver code. The fix is to increase the httpTimeout in testconfig.ttl to 8 seconds.

A very similar fix for another flaky test was done recently for Skosmos 3 in PR #1652 .

## Link to relevant issue(s), if any

none

## Description of the changes in this PR

- increase httpTimeout from 2 to 8 seconds in testconfig.ttl
- change the PHPUnit test that checks the httpTimeout value accordingly

## Known problems or uncertainties in this PR

8 seconds should be enough for anyone, right?

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
