### PR TITLE
Css fixes for background for different page types

### DIFF
--- a/src/view/base-template.twig
+++ b/src/view/base-template.twig
@@ -99,7 +99,7 @@
       </div>
     </div>
   </main>
-  <footer class="bg-white pb-5">
+  <footer class="bg-white pb-5 mt-5">
     <div class="container py-5">
       <div class="row">
         <div class="col-md-7 pe-5">

--- a/src/view/base-template.twig
+++ b/src/view/base-template.twig
@@ -27,7 +27,7 @@
 {% endif %}
 {% for plugin, files in request.plugins.pluginsCSS %}{% for file in files %}<link href="{{ file }}" media="screen, print" rel="stylesheet" type="text/css">{% endfor %}{% endfor %}
 </head>
-<body{% if request.vocabid == '' and request.page != 'feedback' and request.page != 'about' and request.page != 'search' %} class="bg-light frontpage-logo"{% else %} class="bg-medium vocab-{{ request.vocabid }}"{% endif %}>
+<body class="{% if pageType =='landing' %}bg-white frontpage-logo{% else %}{% if pageType == 'concept' or pageType == 'vocab-home' %}bg-medium vocab-{{ request.vocabid }}{% else %}bg-light{% endif %}{% endif %}">
   <header>
     <a class="visually-hidden" id="skiptocontent" href="{{ request.langurl }}#maincontent">Skip to main</a>
     <div class="container-fluid bg-dark d-flex my-auto py-3 px-4 text-bg-dark">
@@ -65,8 +65,9 @@
         {% endif %}
       </ul>
     </div>
-    <div class="container-fluid bg-light py-4 px-4" id="headerbar">
-      {% if request.vocabid == '' %}
+    {% if pageType == 'landing' or pageType == 'vocab-home' or pageType == 'concept' %}
+    <div class="container-fluid bg-white py-4 px-4" id="headerbar">
+      {% if pageType == 'landing' %}
         <div id="skosmos-logo">
           <h1 class="visually-hidden">Skosmos</h1>
         </div>
@@ -85,8 +86,9 @@
       </div>
       {% endif %}
     </div>
+    {% endif %}
   </header>
-  <main id="main-container" class="{% if request.vocabid == '' or global_search %} frontpage{% elseif concept_uri != '' %} termpage{% elseif request.vocab != '' %} vocabpage{% if list_style %} {{ list_style }}{% endif %}{% endif %}">
+  <main id="main-container" class="{% if request.vocabid == '' or global_search %} frontpage{% elseif concept_uri != '' %} termpage{% elseif request.vocab != '' %} vocabpage{% if list_style %} {{ list_style }}{% endif %}{% endif %} py-5">
     <div class="container">
       <noscript>
         <strong>We're sorry but Skosmos doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>

--- a/src/view/base-template.twig
+++ b/src/view/base-template.twig
@@ -97,16 +97,16 @@
       </div>
     </div>
   </main>
-  <footer class="container bg-light pb-5">
-    <div class="row py-5">
-      <div class="col-md-7 pe-5">
+  <footer class="container-fluid bg-white pb-5">
+    <div class="row py-5 justify-content-md-center">
+      <div class="col-md-6 px-5">
         <p class="fs-5">
                   Skosmos is a web-based tool providing services for accessing controlled vocabularies,
                   which are used by indexers describing documents and searchers looking
                   for suitable keywords. Vocabularies are accessed via SPARQL endpoints containing SKOS vocabularies.
         </p>
       </div>
-      <div class="col-md-5 ps-5">
+      <div class="col-md-4 px-5">
         <span class="fs-5 fw-bold">{{ "Contact us!" | trans }}</span>
         <p class="fs-5">Yhteystiedot?<p>
       </div>

--- a/src/view/base-template.twig
+++ b/src/view/base-template.twig
@@ -97,18 +97,20 @@
       </div>
     </div>
   </main>
-  <footer class="container-fluid bg-white pb-5">
-    <div class="row py-5 justify-content-md-center">
-      <div class="col-md-6 px-5">
-        <p class="fs-5">
-                  Skosmos is a web-based tool providing services for accessing controlled vocabularies,
-                  which are used by indexers describing documents and searchers looking
-                  for suitable keywords. Vocabularies are accessed via SPARQL endpoints containing SKOS vocabularies.
-        </p>
-      </div>
-      <div class="col-md-4 px-5">
-        <span class="fs-5 fw-bold">{{ "Contact us!" | trans }}</span>
-        <p class="fs-5">Yhteystiedot?<p>
+  <footer class="bg-white pb-5">
+    <div class="container py-5">
+      <div class="row">
+        <div class="col-md-7 pe-5">
+          <p class="fs-5">
+                    Skosmos is a web-based tool providing services for accessing controlled vocabularies,
+                    which are used by indexers describing documents and searchers looking
+                    for suitable keywords. Vocabularies are accessed via SPARQL endpoints containing SKOS vocabularies.
+          </p>
+        </div>
+        <div class="col-md-5 px-3">
+          <span class="fs-5 fw-bold">{{ "Contact us!" | trans }}</span>
+          <p class="fs-5">Yhteystiedot?<p>
+        </div>
       </div>
     </div>
   </footer>


### PR DESCRIPTION
This PR is built upon #1661 

## Reasons for creating this PR

 - Fixes background colours for different Skosmos page types
   - White for the landing page
   - Light hue for search result page, about page & feedback page
   - Medium hue for vocabulary page & concept page
 - Spacing after the header bar and before the footer bar
 - Removing the large Skosmos logo from about page & feedback page

## Description of the changes in this PR

Twig logic and bootstrap class changes

## Known problems or uncertainties in this PR

None

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
