### PR TITLE
Css fixes of the landing page vocab list

### DIFF
--- a/resource/css/skosmos.css
+++ b/resource/css/skosmos.css
@@ -394,8 +394,20 @@ body {
   }
 
   /*** Main container frontpage ***/
-  #main-container.frontpage #vocab-box, #vocab-box .list-group-item {
-    background-color: var(--vocab-box-bg);
+
+  #vocabulary-list h2, #welcome-box h2, #vocab-info h2 {
+    font-family: var(--font-family-heading) !important;
+  }
+  header > h2 > a {
+    font-family: var(--font-family-heading) !important;
+    color: var(--dark-color)
+  }
+  #vocabulary-list .list-group-item {
+    background-color: var(--medium-color) !important;
+  }
+  #vocabulary-list .border-top {
+    border-top: 2px var(--dark-color) solid !important;
+    color: var(--secondary-dark-color);
   }
 
   .vocab-category {
@@ -960,20 +972,6 @@ body {
     }
   }
 
-  #vocabulary-list h2, #welcome-box h2, #vocab-info h2 {
-    font-family: var(--font-family-heading) !important;
-  }
-  header > h2 > a {
-    font-family: var(--font-family-heading) !important;
-    color: var(--dark-color)
-  }
-  #vocabulary-list .list-group-item {
-    background-color: var(--medium-color) !important;
-  }
-  #vocabulary-list .border-top {
-    border-top: 2px var(--dark-color) solid !important;
-    color: var(--secondary-dark-color);
-  }
   #alphabetical-menu > .list-group > .list-group-item {
     border: none !important;
   }

--- a/resource/css/skosmos.css
+++ b/resource/css/skosmos.css
@@ -29,6 +29,7 @@
   --vocab-text: var(--dark-color);
   --vocab-table-border: var(--medium-color);
   --vocab-link: var(--secondary-dark-color);
+  --vocab-box-text: var(--dark-color);
 
   /* Font definitions */
   --font-size: 14px;
@@ -402,11 +403,15 @@ body {
     color: var(--vocab-box-text);
   }
 
+  .vocab-category h3 {
+    color: var(--vocab-box-text);
+  }
+
   .vocab-category a {
     /** color: var(--secondary-medium-color) solid; **/
-    color: var(--vocab-box-link);
+    color: var(--vocab-link);
     font-weight: bold;
-    text-decoration: underline var(--vocab-box-link) solid;
+    text-decoration: underline ;
     text-decoration-thickness: 1px;
   }
 
@@ -968,12 +973,11 @@ body {
   #vocabulary-list .border-top {
     border-top: 2px var(--dark-color) solid !important;
     color: var(--secondary-dark-color);
-    text-decoration: underline var(--secondary-medium-color) solid;
   }
   #alphabetical-menu > .list-group > .list-group-item {
     border: none !important;
   }
-  
+
   tr > td {
     color: var(--dark-color);
   }

--- a/src/view/landing.twig
+++ b/src/view/landing.twig
@@ -15,7 +15,7 @@
       <h2 class="fs-2 fw-bold py-3">{{ "Available vocabularies and ontologies" | trans }}</h2>
       {% endif %}
       {% for vocabClassName,vocabArray in request.vocabList %}
-      <div class="vocab-category border-top border-dark-top">
+      <div class="vocab-category border-top">
         <h3 class="fs-3 py-3">{{ vocabClassName }}</h3>
         <ul class="list-group">
         {% for vocab in vocabArray %}

--- a/src/view/landing.twig
+++ b/src/view/landing.twig
@@ -15,8 +15,8 @@
       <h2 class="fs-2 fw-bold py-3">{{ "Available vocabularies and ontologies" | trans }}</h2>
       {% endif %}
       {% for vocabClassName,vocabArray in request.vocabList %}
-      <div class="vocab-category border-top">
-        <h3 class="fs-3 py-3">{{ vocabClassName }}</h3>
+      <div class="vocab-category border-top pb-5">
+        <h3 class="fs-3 pt-2">{{ vocabClassName }}</h3>
         <ul class="list-group">
         {% for vocab in vocabArray %}
           <li class="list-group-item border-0 ps-0"><a class="fs-4 fw-bold" href="{{ vocab.id }}/{{ request.lang }}/{% if request.contentLang != request.lang and request.contentLang != '' and request.contentLang in vocab.config.languages %}?clang={{ request.contentLang }}{% endif %}">{{ vocab.title }}</a></li>


### PR DESCRIPTION
This PR is built on #1668 

## Reasons for creating this PR

Fixes for the vocabulary list on the landing page

## Description of the changes in this PR
 - Fixed the styling for category headings on the landing page
 - Fixed the styling for vocabulary list links on the landing page

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
