### PR TITLE
Upgrade EasyRdf to fix Turtle fragment URIs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php_version: ["7.3", "7.4", "8.0", "8.1"]
+        php_version: ["8.0", "8.1"]
         experimental: [false]
         include:
           - php_version: "8.2"

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Skosmos is used as a basis for the [Finto](http://finto.fi) vocabulary service.
 The latest development version is also available at 
 [dev.finto.fi](http://dev.finto.fi).
 
-Skosmos is implemented using PHP (supported versions: 7.3, 7.4 and 8.0), with 
+Skosmos is implemented using PHP (supported versions: 8.0 and 8.1), with 
 Twig templates and e.g. jQuery and jsTree used to build the web interface, and 
 EasyRdf for SPARQL and RDF data access. 
 

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     "components/jquery": "3.6.*",
     "components/handlebars.js": "v4.7.7",
     "davidstutz/bootstrap-multiselect": "v1.1.1",
-    "sweetrdf/easyrdf": "1.10.*",
+    "sweetrdf/easyrdf": "1.13.*",
     "etdsolutions/waypoints": "4.0.0",
     "symfony/polyfill-php80": "1.*",
     "symfony/polyfill-php81": "1.*",

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     "components/jquery": "3.6.*",
     "components/handlebars.js": "v4.7.7",
     "davidstutz/bootstrap-multiselect": "v1.1.1",
-    "sweetrdf/easyrdf": "1.7.*",
+    "sweetrdf/easyrdf": "1.10.*",
     "etdsolutions/waypoints": "4.0.0",
     "symfony/polyfill-php80": "1.*",
     "symfony/polyfill-php81": "1.*",


### PR DESCRIPTION
## Reasons for creating this PR

We were using EasyRdf 1.7.x which is quite old and produces invalid Turtle fragment URIs in some cases, see #1591. The fix is to upgrade to easyrdf 1.10.x or newer. This PR upgrades to EasyRdf 1.13.x which is the most recent release that still works without breaking Skosmos 2 PHPUnit tests; EasyRdf 1.14.1 is currently the newest release. I don't think it makes sense to do extensive debugging of the failing Skosmos 2 unit tests, so I'm leaving the dependency at 1.13.x.

We need to drop support for PHP 7.x because EasyRdf 1.10 and above require at least PHP 8.0. This leaves only two supported PHP versions for Skosmos 2: PHP 8.0 and 8.1.

## Link to relevant issue(s), if any

- Fixes #1591 (for skosmos-2)

## Description of the changes in this PR

- upgrade to sweetrdf/easyrdf 1.13.x
- drop PHP 7.3 and 7.4 from the GitHub Actions CI test because they're incompatible with recent EasyRdf versions
- update README section on supported versions

## Known problems or uncertainties in this PR

I didn't investigate closer why some PHPUnit tests fail when using easyrdf 1.14.x.

We need to do a similar EasyRdf upgrade for Skosmos 3 as well (main branch).

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
