### PR TITLE
Fix Skosmos 2 twig syntax error on search result page

### DIFF
--- a/view/vocab-search-listing.twig
+++ b/view/vocab-search-listing.twig
@@ -2,7 +2,6 @@
 {% set concept_label = '' %}{% for concept in search_results %}{% set concept_label = concept.label %}{% endfor %}
 {% block title %}'{{ term }}' - {{ vocab.shortName(request.contentLang) }} - {{ GlobalConfig.serviceName }}{% endblock %}
 {% block url %}{{ BaseHref }}{{ request.langurl }}{% endblock %}
-{% endblock %}
 {% block content %}
 <div class="search-result-listing">
   <h2 class="sr-only">{% trans "Search results" %}</h2>


### PR DESCRIPTION
## Reasons for creating this PR

Search result pages are currently broken in Skosmos 2, after the SEO-related changes, due to a Twig template syntax bug. This PR will remove the extra endblock tag, making the search result page render properly again.

## Link to relevant issue(s), if any

- fix for changes made in #1666 

## Description of the changes in this PR

Drop extra endblock tag.

## Known problems or uncertainties in this PR

None

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
