### PR TITLE
Fix Skosmos 2 deprecated concept pages (bool value causes crash)

### DIFF
--- a/model/Concept.php
+++ b/model/Concept.php
@@ -32,6 +32,7 @@ class Concept extends VocabularyDataObject implements Modifiable
         'skos:member', # this shouldn't be shown on the group page
         'dc:created', # handled separately
         'dc:modified', # handled separately
+        'owl:deprecated'
     );
 
     /** related concepts that should be shown to users in the appendix */
@@ -660,7 +661,7 @@ class Concept extends VocabularyDataObject implements Modifiable
         foreach ($ret as $prop) {
             foreach ($prop->getValues() as $value) {
                 $label = $value->getLabel();
-                $propertyValues[(method_exists($label, 'getValue')) ? $label->getValue() : $label][] = $value->getType();
+                $propertyValues[(is_object($label) && method_exists($label, 'getValue')) ? $label->getValue() : $label][] = $value->getType();
             }
         }
 


### PR DESCRIPTION
## Reasons for creating this PR

Concept pages for deprecated concepts are currently broken in Skosmos 2. The bool value for `owl:deprecated` is causing a crash in Concept->removeDuplicateValues, like this:

```
[Fri Aug 30 11:48:39.758115 2024] [php:error] [pid 144739] [client 127.0.0.1:47930] PHP Fatal error:  Uncaught TypeError: method_exists(): Argument #1 ($object_or_class) must be of type object|string, bool given in /var/www/html/Skosmos2/model/Concept.php:663\nStack trace:\n#0 /var/www/html/Skosmos2/model/Concept.php(663): method_exists()\n#1 /var/www/html/Skosmos2/model/Concept.php(645): Concept->removeDuplicatePropertyValues()\n#2 /var/www/html/Skosmos2/vendor/twig/twig/src/Extension/CoreExtension.php(1570): Concept->getProperties()\n#3 /tmp/Skosmos2-template-cache/85/859484638bd554063232d14751ee5b62.php(400): twig_get_attribute()\n#4 /var/www/html/Skosmos2/vendor/twig/twig/src/Template.php(405): __TwigTemplate_402425c04623ea52800d487a70a4fa76->doDisplay()\n#5 /var/www/html/Skosmos2/vendor/twig/twig/src/Template.php(378): Twig\\Template->displayWithErrorHandling()\n#6 /tmp/Skosmos2-template-cache/f5/f599161f85f65508bd79705eed18e150.php(95): Twig\\Template->display()\n#7 /var/www/html/Skosmos2/vendor/twig/twig/src/Template.php(182): __TwigTemplate_3a76ea3e7d1dccaed153adfaa566d71b->block_content()\n#8 /tmp/Skosmos2-template-cache/bd/bdda9141010ddb078ba4895e1561cb70.php(864): Twig\\Template->displayBlock()\n#9 /var/www/html/Skosmos2/vendor/twig/twig/src/Template.php(182): __TwigTemplate_55703627091ff672c05e8057e32b3174->block_error()\n#10 /tmp/Skosmos2-template-cache/bd/bdda9141010ddb078ba4895e1561cb70.php(232): Twig\\Template->displayBlock()\n#11 /var/www/html/Skosmos2/vendor/twig/twig/src/Template.php(405): __TwigTemplate_55703627091ff672c05e8057e32b3174->doDisplay()\n#12 /var/www/html/Skosmos2/vendor/twig/twig/src/Template.php(378): Twig\\Template->displayWithErrorHandling()\n#13 /tmp/Skosmos2-template-cache/f5/f599161f85f65508bd79705eed18e150.php(56): Twig\\Template->display()\n#14 /var/www/html/Skosmos2/vendor/twig/twig/src/Template.php(405): __TwigTemplate_3a76ea3e7d1dccaed153adfaa566d71b->doDisplay()\n#15 /var/www/html/Skosmos2/vendor/twig/twig/src/Template.php(378): Twig\\Template->displayWithErrorHandling()\n#16 /var/www/html/Skosmos2/vendor/twig/twig/src/Template.php(390): Twig\\Template->display()\n#17 /var/www/html/Skosmos2/controller/WebController.php(192): Twig\\Template->render()\n#18 /var/www/html/Skosmos2/index.php(87): WebController->invokeVocabularyConcept()\n#19 {main}\n  thrown in /var/www/html/Skosmos2/model/Concept.php on line 663
```

## Link to relevant issue(s), if any

n/a

## Description of the changes in this PR

- avoid crash by adding an `is_object($label)` check
- add `owl:deprecated` to list of properties that will not be displayed on concept page (otherwise it would be shown to the user)

## Known problems or uncertainties in this PR

Still needs a unit test to verify.

The same fix has to be done for Skosmos 3 as well.

## Checklist

- [x] phpUnit tests pass locally with my changes
- [ ] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
