### PR TITLE
Fix deprecated concept pages (Skosmos 3)

### DIFF
--- a/src/model/Concept.php
+++ b/src/model/Concept.php
@@ -32,6 +32,7 @@ class Concept extends VocabularyDataObject implements Modifiable
         'skos:member', # this shouldn't be shown on the group page
         'dc:created', # handled separately
         'dc:modified', # handled separately
+        'owl:deprecated'
     );
 
     /** related concepts that should be shown to users in the appendix */
@@ -658,7 +659,7 @@ class Concept extends VocabularyDataObject implements Modifiable
         foreach ($ret as $prop) {
             foreach ($prop->getValues() as $value) {
                 $label = $value->getLabel();
-                $propertyValues[(method_exists($label, 'getValue')) ? $label->getValue() : $label][] = $value->getType();
+                $propertyValues[(is_object($label) && method_exists($label, 'getValue')) ? $label->getValue() : $label][] = $value->getType();
             }
         }
 

--- a/src/model/Concept.php
+++ b/src/model/Concept.php
@@ -32,7 +32,7 @@ class Concept extends VocabularyDataObject implements Modifiable
         'skos:member', # this shouldn't be shown on the group page
         'dc:created', # handled separately
         'dc:modified', # handled separately
-        'owl:deprecated'
+        'owl:deprecated', # indicated visually
     );
 
     /** related concepts that should be shown to users in the appendix */

--- a/tests/ConceptTest.php
+++ b/tests/ConceptTest.php
@@ -209,6 +209,18 @@ class ConceptTest extends PHPUnit\Framework\TestCase
     }
 
     /**
+     * @covers Concept::getProperties
+     * @covers Concept::removeDuplicatePropertyValues
+     */
+    public function testGetPropertiesOfDeprecatedConcept()
+    {
+        $results = $this->vocab->getConceptInfo('http://www.skosmos.skos/test/ta111', 'en');
+        $concept = reset($results);
+        $props = $concept->getProperties();
+        $this->assertNotContains('owl:deprecated', $props);
+    }
+
+    /**
      * @covers Concept::getMappingProperties
      * @covers ConceptProperty::getValues
      */

--- a/tests/ConceptTest.php
+++ b/tests/ConceptTest.php
@@ -214,8 +214,7 @@ class ConceptTest extends PHPUnit\Framework\TestCase
      */
     public function testGetPropertiesOfDeprecatedConcept()
     {
-        $results = $this->vocab->getConceptInfo('http://www.skosmos.skos/test/ta111', 'en');
-        $concept = reset($results);
+        $concept = $this->vocab->getConceptInfo('http://www.skosmos.skos/test/ta111', 'en');
         $props = $concept->getProperties();
         $this->assertNotContains('owl:deprecated', $props);
     }

--- a/tests/test-vocab-data/default_graph.ttl
+++ b/tests/test-vocab-data/default_graph.ttl
@@ -1,0 +1,7 @@
+@prefix owl:  <http://www.w3.org/2002/07/owl#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+
+# these triples are not part of any specific test vocabulary
+# but they should be accessible through the Fuseki default graph
+
+owl:deprecated a owl:DatatypeProperty; rdfs:label "deprecated" .


### PR DESCRIPTION
## Reasons for creating this PR

This is a forward-port of PR #1673, made for Skosmos 2, to Skosmos 3. The only additional change is a minor adjustment to the PHPUnit test because getConceptInfo works a bit differently in Skosmos 3.

## Link to relevant issue(s), if any

- Closes #1635

## Description of the changes in this PR

See #1673

## Known problems or uncertainties in this PR

Nope.

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
