### PR TITLE
Upgrade to sweetrdf/easyrdf 1.13.* to fix Turtle fragment URIs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "version": "3.0-dev",
   "require": {
-    "sweetrdf/easyrdf": "1.7.*",
+    "sweetrdf/easyrdf": "1.13.*",
     "symfony/polyfill-php80": "1.*",
     "symfony/polyfill-php81": "1.*",
     "twig/twig": "3.8.*",


### PR DESCRIPTION
## Reasons for creating this PR

Forward-port of #1671 for Skosmos 3. Upgrades EasyRdf to version 1.13.x in order to fix Turtle serialization for fragment URIs.

## Link to relevant issue(s), if any

- Closes #1591 

## Description of the changes in this PR

- upgrade to sweetrdf/easyrdf 1.13.x

## Known problems or uncertainties in this PR

easyrdf 1.14.x breaks unit tests and seems to be incompatible with the Fuseki version we are using. That needs more investigation so I'm leaving the dependency at 1.13.x.

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
