### PR TITLE
Avoid showing SEO/metadata description on vocab home page

### DIFF
--- a/model/Vocabulary.php
+++ b/model/Vocabulary.php
@@ -194,7 +194,11 @@ class Vocabulary extends DataObject implements Modifiable
         foreach ($conceptscheme->properties() as $prop) {
             foreach ($conceptscheme->allLiterals($prop, $lang) as $val) {
                 $prop = (substr($prop, 0, 5) == 'dc11:') ? str_replace('dc11:', 'dc:', $prop) : $prop;
-                $ret[$prop][$val->getValue()] = $val;
+                if ($prop === 'dc:description') {
+                    $ret[$prop] = [$val->getValue() => $val]; // override description from vocabulary config
+                } else {
+                    $ret[$prop][$val->getValue()] = $val;
+                }
             }
             if (!isset($ret[$prop]) || sizeof($ret[$prop]) == 0) { // not found with language tag
                 foreach ($conceptscheme->allLiterals($prop, null) as $val) {
@@ -202,7 +206,11 @@ class Vocabulary extends DataObject implements Modifiable
                     if ($val->getValue() instanceof DateTime) {
                         $val = Punic\Calendar::formatDate($val->getValue(), 'full', $lang) . ' ' . Punic\Calendar::format($val->getValue(), 'HH:mm:ss', $lang);
                     }
-                    $ret[$prop][] = $val;
+                    if ($prop === 'dc:description') {
+                        $ret[$prop] = [$val->getValue() => $val]; // override description from vocabulary config
+                    } else {
+                        $ret[$prop][] = $val;
+                    }
                 }
             }
             foreach ($conceptscheme->allResources($prop) as $val) {


### PR DESCRIPTION
## Reasons for creating this PR

It was possible for vocabulary descriptions set in the configuration that were intended for SEO / HTML metadata to be shown on vocabulary home page next to the longer description from the concept scheme metadata:

![image](https://github.com/user-attachments/assets/6c44f2d4-bd2d-4f47-8d6b-aa6acb364ff9)

This PR avoids the situation by making the description from the concept scheme override any descriptions defined in the configuration file:

![image](https://github.com/user-attachments/assets/a2b61860-f334-4db2-81bd-98e79d34fe33)

## Link to relevant issue(s), if any

- follow-up fix to #1666 

## Description of the changes in this PR

- when determining the description to show on the vocabulary home page, prefer the description from the concept scheme metadata (it will override the description set in the configuration file)

## Known problems or uncertainties in this PR

Probably the same thing, or something similar, needs to be done in Skosmos 3 as well.

No PHPUnit tests, sorry.

## Checklist

- [x] phpUnit tests pass locally with my changes
- [ ] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
