### PR TITLE
Move issue template user instructions into comments

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,8 +10,8 @@ assignees: ''
 ## URL address of the page where you encountered the problem
 
 ## Description of the problem
-Steps to produce the problem, and the expected outcome after it has been fixed
 
+<!-- Steps to produce the problem, and the expected outcome after it has been fixed -->
 ## Additional information (e.g. screenshots) about the problem
 
 ## The browser you used when the problem appeared

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -11,10 +11,9 @@ assignees: ''
 
 ## Who are the users that would benefit from the enhancement and how?
 
-(Name specific organizations, roles and/or communities if possible, and/or point to relevant discussion elsewhere)
-
+<!-- Name specific organizations, roles and/or communities if possible, and/or point to relevant discussion elsewhere -->
 ## What new functionalities would the enhancement make possible?
 
 ## Why is the enhancement important?
 
-(Why should this be prioritized, instead of spending energy on something else? Who would do the work to make this happen?)
+<!-- Why should this be prioritized, instead of spending energy on something else? Who would do the work to make this happen? -->


### PR DESCRIPTION
This PR changes issue template instructions into comments so that they will not be shown in the actual issue.