### PR TITLE
Add PHP 8.3 support + change Docker base image to Ubuntu 24.04 with PHP 8.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php_version: ["8.0", "8.1", "8.2"]
+        php_version: ["8.0", "8.1", "8.2", "8.3"]
         experimental: [false]
 
     steps:

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "phpunit/phpunit": "9.5.*",
     "symfony/dom-crawler": "5.4.*",
     "mockery/mockery": "1.5.1",
-    "friendsofphp/php-cs-fixer": "3.16.*"
+    "friendsofphp/php-cs-fixer": "3.64.*"
   },
   "autoload": {
     "classmap": ["src/controller/", "src/model/", "src/model/sparql/"]

--- a/dockerfiles/Dockerfile.ubuntu
+++ b/dockerfiles/Dockerfile.ubuntu
@@ -8,7 +8,7 @@ COPY package.json ./
 RUN npm install --omit=dev --ignore-scripts
 
 # Stage 1: runtime image
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 LABEL maintainer="National Library of Finland"
 LABEL version="0.1"
@@ -20,13 +20,13 @@ RUN apt-get update && apt-get install -y \
     apache2 \
     curl \
     git \
-    libapache2-mod-php8.1 \
+    libapache2-mod-php8.3 \
     locales \
-    php8.1 \
-    php8.1-curl \
-    php8.1-xsl \
-    php8.1-intl \
-    php8.1-mbstring \
+    php8.3 \
+    php8.3-curl \
+    php8.3-xsl \
+    php8.3-intl \
+    php8.3-mbstring \
     php-apcu \
     php-zip \
     unzip \
@@ -60,7 +60,7 @@ ENV LC_ALL=en_US.UTF-8
 ENV LANG=en_US.UTF-8  
 
 # timezone
-RUN sed -i 's/;date.timezone =/date.timezone = "UTC"/g' /etc/php/8.1/apache2/php.ini
+RUN sed -i 's/;date.timezone =/date.timezone = "UTC"/g' /etc/php/8.3/apache2/php.ini
 
 COPY dockerfiles/config/000-default.conf /etc/apache2/sites-available/000-default.conf
 

--- a/src/controller/EntityController.php
+++ b/src/controller/EntityController.php
@@ -15,7 +15,7 @@ class EntityController extends Controller
     {
         $baseurl = $this->getBaseHref();
         $vocid = $vocab->getId();
-        $query = http_build_query(array('uri'=>$uri, 'format'=>$targetFormat));
+        $query = http_build_query(array('uri' => $uri, 'format' => $targetFormat));
         $url = $baseurl . "rest/v1/$vocid/data?$query";
         $this->redirect303($url);
     }
@@ -35,7 +35,7 @@ class EntityController extends Controller
                 $url = $baseurl . "$vocid/page/$localname";
             } else {
                 // must use full URI
-                $query = http_build_query(array('uri'=>$uri));
+                $query = http_build_query(array('uri' => $uri));
                 $url = $baseurl . "$vocid/page/?" . $query;
             }
         }

--- a/src/controller/RestController.php
+++ b/src/controller/RestController.php
@@ -53,7 +53,7 @@ class RestController extends Controller
     }
 
 
-/** Global REST methods **/
+    /** Global REST methods **/
 
     /**
      * Returns all the vocabularies available on the server in a json object.
@@ -105,7 +105,7 @@ class RestController extends Controller
         // convert to vocids array to support multi-vocabulary search
         $vocids = ($vocabs !== null && $vocabs !== '') ? explode(' ', $vocabs) : array();
         $vocabObjects = array();
-        foreach($vocids as $vocid) {
+        foreach ($vocids as $vocid) {
             $vocabObjects[] = $this->model->getVocabulary($vocid);
         }
         $parameters->setVocabularies($vocabObjects);
@@ -195,7 +195,7 @@ class RestController extends Controller
         $this->returnJson($ret);
     }
 
-/** Vocabulary-specific methods **/
+    /** Vocabulary-specific methods **/
 
     /**
      * Loads the vocabulary metadata. And wraps the result in a json-ld object.
@@ -985,7 +985,7 @@ class RestController extends Controller
             $topconcepts = $request->getVocab()->getTopConcepts(array_keys($schemes), $request->getLang());
             foreach ($topconcepts as $top) {
                 if (!isset($results[$top['uri']])) {
-                    $results[$top['uri']] = array('uri' => $top['uri'], 'top'=>$top['topConceptOf'], 'tops'=>array($top['topConceptOf']), 'prefLabel' => $top['label'], 'hasChildren' => $top['hasChildren']);
+                    $results[$top['uri']] = array('uri' => $top['uri'], 'top' => $top['topConceptOf'], 'tops' => array($top['topConceptOf']), 'prefLabel' => $top['label'], 'hasChildren' => $top['hasChildren']);
                     if (isset($top['notation'])) {
                         $results[$top['uri']]['notation'] = $top['notation'];
                     }
@@ -1148,7 +1148,7 @@ class RestController extends Controller
         $changeList = $request->getVocab()->getChangeList($prop, $request->getLang(), $offset, $limit);
 
         $simpleChangeList = array();
-        foreach($changeList as $conceptInfo) {
+        foreach ($changeList as $conceptInfo) {
             if (array_key_exists('date', $conceptInfo)) {
                 $concept = array(
                     'uri' => $conceptInfo['uri'],

--- a/src/controller/WebController.php
+++ b/src/controller/WebController.php
@@ -341,7 +341,7 @@ class WebController extends Controller
         $vocids = ($vocabs !== null && $vocabs !== '') ? explode(' ', $vocabs) : null;
         $vocabObjects = array();
         if ($vocids) {
-            foreach($vocids as $vocid) {
+            foreach ($vocids as $vocid) {
                 try {
                     $vocabObjects[] = $this->model->getVocabulary($vocid);
                 } catch (ValueError $e) {
@@ -381,7 +381,7 @@ class WebController extends Controller
                 'search_count' => $counts,
                 'languages' => $this->languages,
                 'search_results' => $searchResults,
-                'rest' => $parameters->getOffset()>0,
+                'rest' => $parameters->getOffset() > 0,
                 'global_search' => true,
                 'search_failed' => $errored,
                 'term' => $request->getQueryParamRaw('q'),
@@ -453,7 +453,7 @@ class WebController extends Controller
                 'vocab' => $vocab,
                 'search_results' => $searchResults,
                 'search_count' => $counts,
-                'rest' => $parameters->getOffset()>0,
+                'rest' => $parameters->getOffset() > 0,
                 'limit_parent' => $parameters->getParentLimit(),
                 'limit_type' =>  $request->getQueryParam('type') ? explode('+', $request->getQueryParam('type')) : null,
                 'limit_group' => $parameters->getGroupLimit(),

--- a/src/model/BaseConfig.php
+++ b/src/model/BaseConfig.php
@@ -43,7 +43,7 @@ abstract class BaseConfig extends DataObject
      * @param string $lang preferred language for the literal
      * @return string string value for the given property, or the default value if not found
      */
-    protected function getLiteral($property, $default=null, $lang=null)
+    protected function getLiteral($property, $default = null, $lang = null)
     {
         if (!isset($lang)) {
             $lang = $this->getLang();

--- a/src/model/Cache.php
+++ b/src/model/Cache.php
@@ -19,7 +19,7 @@ class Cache
     /**
      * Wraps apc_store() and apcu_store()
      */
-    public function store($key, $value, $ttl=3600)
+    public function store($key, $value, $ttl = 3600)
     {
         if (function_exists('apcu_store')) {
             return apcu_store($key, $value, $ttl);

--- a/src/model/Concept.php
+++ b/src/model/Concept.php
@@ -144,7 +144,7 @@ class Concept extends VocabularyDataObject implements Modifiable
                 return $this->resource->label($fallback);
             }
             // We need to check all the labels in case one of them matches a subtag of the current language
-            foreach($this->resource->allLiterals('skos:prefLabel') as $label) {
+            foreach ($this->resource->allLiterals('skos:prefLabel') as $label) {
                 // the label lang code is a subtag of the UI lang eg. en-GB - create a new literal with the main language
                 if ($label !== null && strpos($label->getLang(), $fallback . '-') === 0) {
                     return EasyRdf\Literal::create($label, $fallback);
@@ -174,7 +174,7 @@ class Concept extends VocabularyDataObject implements Modifiable
     public function getXlLabel()
     {
         $labels = $this->resource->allResources('skosxl:prefLabel');
-        foreach($labels as $labres) {
+        foreach ($labels as $labres) {
             $label = $labres->getLiteral('skosxl:literalForm');
             if ($label !== null && $label->getLang() == $this->clang) {
                 return new LabelSkosXL($this->model, $labres);
@@ -306,7 +306,7 @@ class Concept extends VocabularyDataObject implements Modifiable
      * @param string[] $seen Processed resources so far
      * @param string[] $props (optional) limit to these property URIs
      */
-    private function addExternalTriplesToGraph($res, &$seen, $props=null)
+    private function addExternalTriplesToGraph($res, &$seen, $props = null)
     {
         if (array_key_exists($res->getUri(), $seen) && $seen[$res->getUri()] === 0) {
             return;
@@ -531,15 +531,15 @@ class Concept extends VocabularyDataObject implements Modifiable
                 // if not found in current vocabulary, look up in the default graph to be able
                 // to read an ontology loaded in a separate graph
                 // note that this imply that the property has an rdf:type declared for the query to work
-                if(!$is_well_known && !$proplabel) {
+                if (!$is_well_known && !$proplabel) {
                     $envLangLabels = $this->model->getDefaultSparql()->queryLabel($longUri, $this->getLang());
 
                     $defaultPropLabel = $this->model->getDefaultSparql()->queryLabel($longUri, '');
 
-                    if($envLangLabels) {
+                    if ($envLangLabels) {
                         $proplabel = $envLangLabels[$this->getLang()];
                     } else {
-                        if($defaultPropLabel) {
+                        if ($defaultPropLabel) {
                             $proplabel = $defaultPropLabel[''];
                         }
                     }
@@ -552,7 +552,7 @@ class Concept extends VocabularyDataObject implements Modifiable
                 }
 
                 // also look up superprops in the default graph if not found in current vocabulary
-                if(!$is_well_known && (!$superprops || empty($superprops))) {
+                if (!$is_well_known && (!$superprops || empty($superprops))) {
                     $superprops = $this->model->getDefaultSparql()->querySuperProperties($longUri);
                 }
 
@@ -570,7 +570,7 @@ class Concept extends VocabularyDataObject implements Modifiable
                 }
 
                 // searching for subproperties of literals too
-                if($superprops) {
+                if ($superprops) {
                     foreach ($superprops as $subi) {
                         $suburi = EasyRdf\RdfNamespace::shorten($subi) ? EasyRdf\RdfNamespace::shorten($subi) : $subi;
                         $duplicates[$suburi] = $prop;
@@ -827,7 +827,7 @@ class Concept extends VocabularyDataObject implements Modifiable
                     $groups[$collLabel] = array($group);
 
                     $res = $collection;
-                    while($super = $this->graph->resourcesMatching('skos:member', $res)) {
+                    while ($super = $this->graph->resourcesMatching('skos:member', $res)) {
                         foreach ($super as $res) {
                             $superprop = new ConceptPropertyValue($this->model, $this->vocab, $res, 'skosmos:memberOfSuper', $this->clang);
                             array_unshift($groups[$collLabel], $superprop);
@@ -937,7 +937,7 @@ class Concept extends VocabularyDataObject implements Modifiable
             'skos' => EasyRdf\RdfNamespace::get("skos"),
             'isothes' => EasyRdf\RdfNamespace::get("isothes"),
             'rdfs' => EasyRdf\RdfNamespace::get("rdfs"),
-            'owl' =>EasyRdf\RdfNamespace::get("owl"),
+            'owl' => EasyRdf\RdfNamespace::get("owl"),
             'dct' => EasyRdf\RdfNamespace::get("dcterms"),
             'dc11' => EasyRdf\RdfNamespace::get("dc11"),
             'uri' => '@id',

--- a/src/model/ConceptProperty.php
+++ b/src/model/ConceptProperty.php
@@ -30,7 +30,7 @@ class ConceptProperty
      * @param string $super URI of superproperty
      * @param boolean $sort_by_notation whether to sort the property values by their notation code
      */
-    public function __construct($model, $prop, $label, $tooltip=null, $super=null, $sort_by_notation=false)
+    public function __construct($model, $prop, $label, $tooltip = null, $super = null, $sort_by_notation = false)
     {
         $this->model = $model;
         $this->prop = $prop;

--- a/src/model/ConceptPropertyValue.php
+++ b/src/model/ConceptPropertyValue.php
@@ -58,7 +58,7 @@ class ConceptPropertyValue extends VocabularyDataObject
                 }
                 // We need to check all the labels in case one of them matches a subtag of the current language
                 if ($this->resource->allLiterals('skos:prefLabel')) {
-                    foreach($this->resource->allLiterals('skos:prefLabel') as $label) {
+                    foreach ($this->resource->allLiterals('skos:prefLabel') as $label) {
                         // the label lang code is a subtag of the UI lang eg. en-GB - create a new literal with the main language
                         if ($label !== null && strpos($label->getLang(), $fallback . '-') === 0) {
                             return EasyRdf\Literal::create($label, $fallback);
@@ -164,7 +164,7 @@ class ConceptPropertyValue extends VocabularyDataObject
     {
         $ret = array();
         $props = $this->resource->propertyUris();
-        foreach($props as $prop) {
+        foreach ($props as $prop) {
             $prop = (EasyRdf\RdfNamespace::shorten($prop) !== null) ? EasyRdf\RdfNamespace::shorten($prop) : $prop;
             $propkey = str_starts_with($prop, 'dc11:') ?
                 str_replace('dc11:', 'dc:', $prop) : $prop;

--- a/src/model/ConceptPropertyValueLiteral.php
+++ b/src/model/ConceptPropertyValueLiteral.php
@@ -101,7 +101,7 @@ class ConceptPropertyValueLiteral extends VocabularyDataObject
     {
         $graph = $this->resource->getGraph();
         $labelResources = $graph->resourcesMatching('skosxl:literalForm', $this->literal);
-        foreach($labelResources as $labres) {
+        foreach ($labelResources as $labres) {
             return new LabelSkosXL($this->model, $labres);
         }
         return null;

--- a/src/model/GlobalConfig.php
+++ b/src/model/GlobalConfig.php
@@ -30,7 +30,7 @@ class GlobalConfig extends BaseConfig
      */
     private $configModifiedTime = null;
 
-    public function __construct(Model $model, string $config_name='../../config.ttl')
+    public function __construct(Model $model, string $config_name = '../../config.ttl')
     {
         $this->cache = new Cache();
         $this->filePath = realpath(dirname(__FILE__) . "/" . $config_name);
@@ -78,7 +78,7 @@ class GlobalConfig extends BaseConfig
                 $this->cache->store($key, $this->graph);
                 $this->cache->store($nskey, $this->namespaces);
             }
-        // @codeCoverageIgnoreEnd
+            // @codeCoverageIgnoreEnd
         } else { // APC not available, parse on every request
             $this->parseConfig($this->filePath);
         }

--- a/src/model/LabelSkosXL.php
+++ b/src/model/LabelSkosXL.php
@@ -11,7 +11,7 @@ class LabelSkosXL extends DataObject
     {
         $label = null;
         $labels = $this->resource->allResources('skosxl:prefLabel');
-        foreach($labels as $labres) {
+        foreach ($labels as $labres) {
             $label = $labres->getLiteral('skosxl:literalForm');
             if ($label->getLang() == $this->clang) {
                 return $label;
@@ -24,7 +24,7 @@ class LabelSkosXL extends DataObject
     {
         $ret = array();
         $props = $this->resource->properties();
-        foreach($props as $prop) {
+        foreach ($props as $prop) {
             if ($prop !== 'rdf:type' && $prop !== 'skosxl:literalForm') {
                 // make sure to use the correct gettext keys for DC namespace
                 $propkey = str_starts_with($prop, 'dc11:') ?

--- a/src/model/Model.php
+++ b/src/model/Model.php
@@ -29,7 +29,7 @@ class Model
     /**
      * Initializes the Model object
      */
-    public function __construct(string $config_filename="../../config.ttl")
+    public function __construct(string $config_filename = "../../config.ttl")
     {
         $this->resolver = new Resolver($this);
         $this->globalConfig = new GlobalConfig($this, $config_filename);
@@ -274,11 +274,11 @@ class Model
         }
 
         $vocabs = $params->getVocabs();
-        $showDeprecated=false;
+        $showDeprecated = false;
         if (sizeof($vocabs) === 1) { // search within vocabulary
             $voc = $vocabs[0];
             $sparql = $voc->getSparql();
-            $showDeprecated=$voc->getConfig()->getShowDeprecated();
+            $showDeprecated = $voc->getConfig()->getShowDeprecated();
         } else { // multi-vocabulary or global search
             $voc = null;
             $sparql = $this->getDefaultSparql();
@@ -439,7 +439,7 @@ class Model
     public function getVocabularyCategories()
     {
         $cats = $this->globalConfig->getGraph()->allOfType('skos:Concept');
-        if(empty($cats)) {
+        if (empty($cats)) {
             return array(new VocabularyCategory($this, null));
         }
 
@@ -520,9 +520,9 @@ class Model
         }
 
         // if there are multiple vocabularies and one is the preferred vocabulary, return it
-        if($preferredVocabId != null) {
+        if ($preferredVocabId != null) {
             foreach ($vocabs as $vocab) {
-                if($vocab->getId() == $preferredVocabId) {
+                if ($vocab->getId() == $preferredVocabId) {
                     try {
                         // double check that a label exists in the preferred vocabulary
                         if ($vocab->getConceptLabel($uri, null) !== null) {
@@ -628,7 +628,7 @@ class Model
                 $resource = $this->resolver->resolve($uri, $this->getConfig()->getHttpTimeout());
                 $this->globalConfig->getCache()->store($key, $resource, self::URI_FETCH_TTL);
             }
-        // @codeCoverageIgnoreEnd
+            // @codeCoverageIgnoreEnd
         } else { // APC not available, parse on every request
             $resource = $this->resolver->resolve($uri, $this->getConfig()->getHttpTimeout());
         }

--- a/src/model/PluginRegister.php
+++ b/src/model/PluginRegister.php
@@ -5,7 +5,7 @@ class PluginRegister
     private $requestedPlugins;
     private $pluginOrder;
 
-    public function __construct($requestedPlugins=array())
+    public function __construct($requestedPlugins = array())
     {
         $this->requestedPlugins = $requestedPlugins;
         $this->pluginOrder = array();
@@ -49,7 +49,7 @@ class PluginRegister
      * @param boolean $raw interpret $type values as raw text instead of files
      * @return array
      */
-    private function filterPlugins($type, $raw=false)
+    private function filterPlugins($type, $raw = false)
     {
         $plugins = $this->getPlugins();
         $plugins = $this->sortPlugins($plugins);
@@ -94,7 +94,7 @@ class PluginRegister
      * @param array $names the plugin name strings (foldernames) in an array
      * @return array
      */
-    public function getPluginsJS($names=null)
+    public function getPluginsJS($names = null)
     {
         if ($names) {
             $names = array_merge($this->requestedPlugins, $names);
@@ -108,7 +108,7 @@ class PluginRegister
      * @param array $names the plugin name strings (foldernames) in an array
      * @return array
      */
-    public function getPluginsCSS($names=null)
+    public function getPluginsCSS($names = null)
     {
         if ($names) {
             $names = array_merge($this->requestedPlugins, $names);
@@ -122,7 +122,7 @@ class PluginRegister
      * @param array $names the plugin name strings (foldernames) in an array
      * @return array
      */
-    public function getPluginsTemplates($names=null)
+    public function getPluginsTemplates($names = null)
     {
         if ($names) {
             $names = array_merge($this->requestedPlugins, $names);
@@ -136,7 +136,7 @@ class PluginRegister
      * @param array $names the plugin name strings (foldernames) in an array
      * @return array
      */
-    public function getTemplates($names=null)
+    public function getTemplates($names = null)
     {
         $templateStrings = array();
         $plugins = $this->getPluginsTemplates($names);
@@ -144,7 +144,7 @@ class PluginRegister
             foreach ($templates as $path) {
                 if (file_exists($path)) {
                     $filename = explode('/', $path);
-                    $filename = $filename[sizeof($filename)-1];
+                    $filename = $filename[sizeof($filename) - 1];
                     $id = $folder . '-' . substr($filename, 0, (strrpos($filename, ".")));
                     $templateStrings[$id] = file_get_contents($path);
                 }
@@ -158,7 +158,7 @@ class PluginRegister
      * @param array $names the plugin name strings (foldernames) in an array
      * @return array
      */
-    public function getPluginCallbacks($names=null)
+    public function getPluginCallbacks($names = null)
     {
         if ($names) {
             $names = array_merge($this->requestedPlugins, $names);

--- a/src/model/Request.php
+++ b/src/model/Request.php
@@ -208,7 +208,7 @@ class Request
      * @param string $newlang new UI language to set
      * @return string the relative url of the page
      */
-    public function getLangUrl($newlang=null)
+    public function getLangUrl($newlang = null)
     {
         $script_name = str_replace('/src/index.php', '', $this->getServerConstant('SCRIPT_NAME'));
         $langurl = substr(str_replace($script_name, '', strval($this->getServerConstant('REQUEST_URI'))), 1);

--- a/src/model/Vocabulary.php
+++ b/src/model/Vocabulary.php
@@ -338,7 +338,7 @@ class Vocabulary extends DataObject implements Modifiable
      * @param string $array the uri of the concept array class, eg. isothes:ThesaurusArray
      * @param string $group the uri of the  concept group class, eg. isothes:ConceptGroup
      */
-    public function getStatistics($lang = '', $array=null, $group=null)
+    public function getStatistics($lang = '', $array = null, $group = null)
     {
         $sparql = $this->getSparql();
         // find the number of concepts
@@ -668,7 +668,7 @@ class Vocabulary extends DataObject implements Modifiable
         return $this->getSparql()->queryChangeList($prop, $clang, $offset, $limit, $showDeprecated);
     }
 
-    public function getTitle($lang=null)
+    public function getTitle($lang = null)
     {
         return $this->config->getTitle($lang);
     }

--- a/src/model/VocabularyConfig.php
+++ b/src/model/VocabularyConfig.php
@@ -30,7 +30,7 @@ class VocabularyConfig extends BaseConfig
     "skos:related", "skos:historyNote", "skosmos:memberOf",
     "skosmos:memberOfArray");
 
-    public function __construct(Model $model, EasyRdf\Resource $resource, array $globalPlugins=array())
+    public function __construct(Model $model, EasyRdf\Resource $resource, array $globalPlugins = array())
     {
         parent::__construct($model, $resource);
         $this->globalPlugins = $globalPlugins;

--- a/src/model/resolver/LOCResource.php
+++ b/src/model/resolver/LOCResource.php
@@ -11,7 +11,7 @@ class LOCResource extends RemoteResource
         }
 
         try {
-            $opts = array('http' => array('method'=>'HEAD',
+            $opts = array('http' => array('method' => 'HEAD',
                                           'user_agent' => 'Skosmos',
                                           'timeout' => $timeout));
             $context  = stream_context_create($opts);

--- a/src/model/sparql/GenericSparql.php
+++ b/src/model/sparql/GenericSparql.php
@@ -92,7 +92,7 @@ class GenericSparql
         $starttime = microtime(true);
         $result = $this->client->query($query);
         $elapsed = intval(round((microtime(true) - $starttime) * 1000));
-        if(method_exists($result, 'numRows')) {
+        if (method_exists($result, 'numRows')) {
             $numRows = $result->numRows();
             $logger->info("[qid $queryId] result: $numRows rows returned in $elapsed ms");
         } else { // graph result
@@ -108,7 +108,7 @@ class GenericSparql
      * @param Vocabulary[]|null $vocabs
      * @return string
      */
-    protected function generateFromClause($vocabs=null)
+    protected function generateFromClause($vocabs = null)
     {
         $clause = '';
         if (!$vocabs) {
@@ -718,9 +718,9 @@ EOQ;
                 $conceptscheme['title'] = $row->title->getValue();
             }
             // add dct:subject and their labels in the result
-            if(isset($row->domain) && isset($row->domainLabel)) {
-                $conceptscheme['subject']['uri']=$row->domain->getURI();
-                $conceptscheme['subject']['prefLabel']=$row->domainLabel->getValue();
+            if (isset($row->domain) && isset($row->domainLabel)) {
+                $conceptscheme['subject']['uri'] = $row->domain->getURI();
+                $conceptscheme['subject']['prefLabel'] = $row->domainLabel->getValue();
             }
 
             $ret[$row->cs->getURI()] = $conceptscheme;
@@ -1048,15 +1048,15 @@ EOQ;
         $schemecond = '';
         if (!empty($schemes)) {
             $conditions = array();
-            foreach($schemes as $scheme) {
+            foreach ($schemes as $scheme) {
                 $conditions[] = "{?s skos:inScheme <$scheme>}";
             }
             $schemecond = '{'.implode(" UNION ", $conditions).'}';
         }
-        $filterDeprecated="";
+        $filterDeprecated = "";
         //show or hide deprecated concepts
-        if(!$showDeprecated) {
-            $filterDeprecated="FILTER NOT EXISTS { ?s owl:deprecated true }";
+        if (!$showDeprecated) {
+            $filterDeprecated = "FILTER NOT EXISTS { ?s owl:deprecated true }";
         }
         // extra conditions for parent and group, if specified
         $parentcond = ($params->getParentLimit()) ? "?s skos:broader+ <" . $params->getParentLimit() . "> ." : "";
@@ -1147,7 +1147,7 @@ EOQ;
             $hit['type'][] = $this->shortenUri($typeuri);
         }
 
-        if(!empty($fields)) {
+        if (!empty($fields)) {
             foreach ($fields as $prop) {
                 $propname = $prop . 's';
                 if (isset($row->$propname)) {
@@ -1300,9 +1300,9 @@ EOQ;
         $filtercondLabel = $conditions['filterpref'];
         $filtercondALabel = $conditions['filteralt'];
         $qualifierClause = $qualifier ? "OPTIONAL { ?s <" . $qualifier->getURI() . "> ?qualifier }" : "";
-        $filterDeprecated="";
-        if(!$showDeprecated) {
-            $filterDeprecated="FILTER NOT EXISTS { ?s owl:deprecated true }";
+        $filterDeprecated = "";
+        if (!$showDeprecated) {
+            $filterDeprecated = "FILTER NOT EXISTS { ?s owl:deprecated true }";
         }
         $query = <<<EOQ
 SELECT DISTINCT ?s ?label ?alabel ?qualifier
@@ -2071,7 +2071,7 @@ EOQ;
                 $ret[$uri]['exact'] = $row->exact->getUri();
             }
             if (isset($row->tops)) {
-                $topConceptsList=explode(" ", $row->tops->getValue());
+                $topConceptsList = explode(" ", $row->tops->getValue());
                 // sort to guarantee an alphabetical ordering of the URI
                 sort($topConceptsList);
                 $ret[$uri]['tops'] = $topConceptsList;
@@ -2232,9 +2232,9 @@ EOQ;
     private function generateConceptGroupContentsQuery($groupClass, $group, $lang, $showDeprecated = false)
     {
         $fcl = $this->generateFromClause();
-        $filterDeprecated="";
-        if(!$showDeprecated) {
-            $filterDeprecated="  FILTER NOT EXISTS { ?conc owl:deprecated true }";
+        $filterDeprecated = "";
+        if (!$showDeprecated) {
+            $filterDeprecated = "  FILTER NOT EXISTS { ?conc owl:deprecated true }";
         }
         $query = <<<EOQ
 SELECT ?conc ?super ?label ?members ?type ?notation $fcl
@@ -2321,7 +2321,7 @@ EOQ;
      * @param boolean $showDeprecated whether to include deprecated concepts in the change list
      * @return string sparql query
      */
-    private function generateChangeListQuery($prop, $lang, $offset, $limit=200, $showDeprecated=false)
+    private function generateChangeListQuery($prop, $lang, $offset, $limit = 200, $showDeprecated = false)
     {
         $fcl = $this->generateFromClause();
         $offset = ($offset) ? 'OFFSET ' . $offset : '';
@@ -2415,7 +2415,7 @@ EOQ;
      * @param boolean $showDeprecated whether to include deprecated concepts in the change list
      * @return array Result array
      */
-    public function queryChangeList($prop, $lang, $offset, $limit, $showDeprecated=false)
+    public function queryChangeList($prop, $lang, $offset, $limit, $showDeprecated = false)
     {
         $query = $this->generateChangeListQuery($prop, $lang, $offset, $limit, $showDeprecated);
 

--- a/src/model/sparql/JenaTextSparql.php
+++ b/src/model/sparql/JenaTextSparql.php
@@ -94,7 +94,7 @@ class JenaTextSparql extends GenericSparql
      */
     private function formatOrderBy($expression, $lang)
     {
-        if(!$this->model->getConfig()->getCollationEnabled()) {
+        if (!$this->model->getConfig()->getCollationEnabled()) {
             return $expression;
         }
         $orderby = sprintf('arq:collation(\'%2$s\', %1$s)', $expression, $lang);
@@ -134,9 +134,9 @@ class JenaTextSparql extends GenericSparql
 
         $qualifierClause = $qualifier ? "OPTIONAL { ?s <" . $qualifier->getURI() . "> ?qualifier }" : "";
 
-        $filterDeprecated="";
-        if(!$showDeprecated) {
-            $filterDeprecated="FILTER NOT EXISTS { ?s owl:deprecated true }";
+        $filterDeprecated = "";
+        if (!$showDeprecated) {
+            $filterDeprecated = "FILTER NOT EXISTS { ?s owl:deprecated true }";
         }
 
         $query = <<<EOQ


### PR DESCRIPTION
## Reasons for creating this PR

This PR adds support for PHP 8.3 in Skosmos 3 and upgrades the Docker base image to Ubuntu 24.04 which includes PHP 8.3.

## Link to relevant issue(s), if any

- Closes #1665

## Description of the changes in this PR

- enable PHP 8.3 build in GitHub Actions CI
- upgrade PHP-CS-Fixer to 3.64.0 to support PHP 8.3
- change the PHP code style to match new defaults in PHP-CS-Fixer
- upgrade Docker base image to Ubuntu 24.04 with PHP 8.3

## Known problems or uncertainties in this PR

None

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
