### PR TITLE
Add cypress tests for hierarchy Vue component

### DIFF
--- a/tests/cypress/template/sidebar-hierarchy.cy.js
+++ b/tests/cypress/template/sidebar-hierarchy.cy.js
@@ -1,10 +1,99 @@
 describe('Hierarchy', () => {
+  it('Loads top concepts', () => {
+    // Go to test vocab home page
+    cy.visit('/test/en/')
+    // Check that hierarchy tab is available and click it open
+    cy.get('#hierarchy').should('not.have.class', 'disabled').click()
+    // Check that hierarchy includes correct top concept
+    cy.get('#hierarchy-list li').should('have.length', 1).first().invoke('text').should('contain', 'Fish')
+  })
+  it('Loads children and hides them on button click', () => {
+    // Go to test vocab home page
+    cy.visit('/test/en/')
+    // Click hierarchy tab open
+    cy.get('#hierarchy').click()
+    // Click hierarchy open button of top concept
+    cy.get('#hierarchy-list li button').first().click({force: true})
+    // Check that children are loaded in
+    cy.get('#hierarchy-list li ul').first().children().should('have.length', 9)
+    // Click hierarchy open button again
+    cy.get('#hierarchy-list li button').first().click({force: true})
+    // Check that children are hidden
+    cy.get('#hierarchy-list li ul').should('not.exist')
+  })
+  it('Loads children on concept click', () => {
+    // Go to test vocab home page
+    cy.visit('/test/en/')
+    // Click hierarchy tab open
+    cy.get('#hierarchy').click()
+    // Click first top concept link
+    cy.get('#hierarchy-list li a').first().click()
+    // Check that children are loaded in
+    cy.get('#hierarchy-list li ul').first().children().should('have.length', 9)
+    // Check that clicked element is selected
+    cy.get('#hierarchy-list li a').first().should('have.class', 'selected')
+  })
+  it('Shows no button for concepts with no children', () => {
+    // Go to test vocab home page
+    cy.visit('/test/en/')
+    // Click hierarchy tab open
+    cy.get('#hierarchy').click()
+    // Click hierarchy open button of top concept
+    cy.get('#hierarchy-list li button').first().click({force: true})
+    // Check that concept with no children has no button
+    cy.get('#hierarchy-list li').eq(1).find('button').should('not.exist')
+  })
+  it('Loads hierarchy on concept page', () => {
+    // Go to "Bass" concept page
+    cy.visit('/test/en/page/ta116')
+    // Check that hierarchy tab is active
+    cy.get('#hierarchy a').should('have.class', 'active')
+    // Check that selected element is "Bass"
+    cy.get('#hierarchy-list .selected').should('have.length', 1).invoke('text').should('contain', 'Bass')
+    // Check that "Bass" has 1 child "Black sea bass"
+    cy.get('#hierarchy-list li:has(.selected)').last().find('ul').should('have.length', 1).invoke('text').should('contain', 'Black sea bass')
+    // Check that hierarchy includes correct top concept
+    cy.get('#hierarchy-list li').first().invoke('text').should('contain', 'Fish')
+    // Check that other concepts are loaded
+    cy.get('#hierarchy-list li ul').first().children().should('have.length', 9)
+  })
+  it('Loads hierarchy after opening concept page', () => {
+    // Go to test vocab home page
+    cy.visit('/test/en/')
+    // Click on "Bass" in alphabetical index
+    cy.get('#tab-alphabetical .sidebar-list li a').first().click()
+    // Check that new concept page has been loaded
+    cy.get('#concept-heading h1', {'timeout': 15000}).invoke('text').should('equal', 'Bass')
+    // Click hierarchy tab open
+    cy.get('#hierarchy').click()
+    // Check that selected element is "Bass"
+    cy.get('#hierarchy-list .selected').should('have.length', 1).invoke('text').should('contain', 'Bass')
+    // Check that "Bass" has 1 child "Black sea bass"
+    cy.get('#hierarchy-list li:has(.selected)').last().find('ul').should('have.length', 1).invoke('text').should('contain', 'Black sea bass')
+    // Check that hierarchy includes correct top concept
+    cy.get('#hierarchy-list li a').first().invoke('text').should('contain', 'Fish')
+    // Check that other concepts are loaded
+    cy.get('#hierarchy-list li ul').first().children().should('have.length', 9)
+  })
+  it('Scrolls to selected concept on load', () => {
+    // Go to "ages (periods of time)" YSO concept page
+    cy.visit('/yso/en/page/p4623')
+    // Check that opened concept was scrolled to and is visible in hierarchy
+    cy.get('#hierarchy-list a[href="yso/en/page/p4623"]').should('be.visible')
+  })
   it('Sorts concepts based on labels', () => {
     // Go to "properties" concept page in a vocab with sorting based on labels
     cy.visit('/yso/en/page/p2742')
     // First and second concepts in hierarchy should be sorted by label
     cy.get('#hierarchy-list .list-group-item').eq(0).find('.concept-label').invoke('text').should('contain', 'events and action')
     cy.get('#hierarchy-list .list-group-item').eq(1).find('.concept-label').invoke('text').should('contain', 'objects')
+  })
+  it('Sorts concepts based on labels and content language', () => {
+    // Go to "properties" concept page in a vocab with sorting based on labels
+    cy.visit('/yso/en/page/p2742?clang=fi')
+    // First and second concepts in hierarchy should be sorted by label according to content language
+    cy.get('#hierarchy-list .list-group-item').eq(0).find('.concept-label').invoke('text').should('contain', 'oliot')
+    cy.get('#hierarchy-list .list-group-item').eq(1).find('.concept-label').invoke('text').should('contain', 'ominaisuudet')
   })
   it('Sorts concepts based on notation codes in lexical order', () => {
     // Go to "Tuna" concept page in a vocab with lexical sorting

--- a/tests/cypress/template/vocab-search.cy.js
+++ b/tests/cypress/template/vocab-search.cy.js
@@ -45,13 +45,14 @@ describe('Vocabulary search page', () => {
       cy.get('div.search-result > ul > li > span > i.property-hover.fa-solid.fa-arrows-to-circle')
 
       //Check that there is correct amount of different properties for the search result
-      cy.get('div.search-result > ul > li').should('have.length', 3)
+      cy.get('div.search-result > ul > li').should('have.length', 4)
 
       //Check the order of search result properties
       cy.get('div.search-result > ul').within(() => {
         cy.get('li').eq(0).invoke('text').should('contain', 'Fish')
-        cy.get('li').eq(1).invoke('text').should('contain', 'Test class')
-        cy.get('li').eq(2).invoke('text').should('contain', 'http://www.skosmos.skos/test/ta116')
+        cy.get('li').eq(1).invoke('text').should('contain', 'Black sea bass')
+        cy.get('li').eq(2).invoke('text').should('contain', 'Test class')
+        cy.get('li').eq(3).invoke('text').should('contain', 'http://www.skosmos.skos/test/ta116')
       })
 
   })

--- a/tests/test-vocab-data/test.ttl
+++ b/tests/test-vocab-data/test.ttl
@@ -73,6 +73,10 @@ test:ta112 a skos:Concept, meta:TestClass ;
     	"Finnish"@fi,
     	"Without lang tag" .
 
+test:ta113 a skos:Concept, meta:TestClass ;
+    skos:broader test:ta1 ;
+    skos:inScheme test:conceptscheme .
+
 test:ta114 a skos:Concept, meta:TestClass ;
     skos:broader test:ta1 ;
     dct:modified "1986-21-00"^^xsd:date ; # date invalid on purpose
@@ -89,7 +93,8 @@ test:ta115 a skos:Concept, meta:TestClass ;
 test:ta116 a skos:Concept, meta:TestClass ;
     skos:broader test:ta1 ;
     skos:inScheme test:conceptscheme ;
-    skos:prefLabel "Bass"@en .
+    skos:prefLabel "Bass"@en ;
+    skos:narrower test:ta122.
 
 test:ta117 a skos:Concept, meta:TestClass ;
     skos:broader test:ta1 ;
@@ -105,7 +110,8 @@ test:ta118 a skos:Concept, meta:TestClass ;
 test:ta119 a skos:Concept, meta:TestClass ;
     skos:broader test:ta1 ;
     skos:inScheme test:conceptscheme ;
-    skos:prefLabel "Hauki"@fi .
+    skos:prefLabel "Hauki"@fi ;
+    skos:narrower test:ta123 .
 
 test:ta120 a skos:Concept, meta:TestClass ;
     skos:broader test:ta1 ;


### PR DESCRIPTION
## Reasons for creating this PR

Hierarchy Vue component currently has limited tests, this PR adds more of them.

## Link to relevant issue(s), if any

- Part of #1521

## Description of the changes in this PR

- Add more cypress tests for hierarchy
- Fix test vocab hierarchy
- Update `search-vocab` cypress tests to reflect new test vocab

Addresses requirement 7 in #1521

## Known problems or uncertainties in this PR

## Checklist

- [ ] phpUnit tests pass locally with my changes
- [ ] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [ ] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [ ] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
