### PR TITLE
Updated vocab load curl command to v8.5.0 compliant

### DIFF
--- a/tests/init_containers.sh
+++ b/tests/init_containers.sh
@@ -17,6 +17,6 @@ done
 for fn in ../tests/test-vocab-data/*.ttl; do
     name=$(basename "${fn}" .ttl)
     echo "Loading test vocabulary $name"
-    curl -I -X PUT -H Content-Type:text/turtle -T "$fn" -G http://localhost:9030/skosmos/data --data-urlencode graph="http://www.skosmos.skos/$name/"
+    curl -X PUT -H "Content-Type: text/turtle" -T "$fn" "http://localhost:9030/skosmos/data?graph=http://www.skosmos.skos/$name/"
     echo
 done

--- a/tests/init_containers.sh
+++ b/tests/init_containers.sh
@@ -17,6 +17,6 @@ done
 for fn in ../tests/test-vocab-data/*.ttl; do
     name=$(basename "${fn}" .ttl)
     echo "Loading test vocabulary $name"
-    curl -X PUT -H "Content-Type: text/turtle" -T "$fn" "http://localhost:9030/skosmos/data?graph=http://www.skosmos.skos/$name/"
+    curl -X PUT -H "Content-Type: text/turtle" --data-binary "@$fn" "http://localhost:9030/skosmos/data?graph=http://www.skosmos.skos/$name/"
     echo
 done


### PR DESCRIPTION
## Reasons for creating this PR

The cUrl command in tests/init_containers does not work with the a newer curl verision and needed a re-write. The previous command was working on curl 7.81.0. This one is tested with curl 8.5.0.

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
