### PR TITLE
Updates to php library dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "sweetrdf/easyrdf": "1.13.*",
     "symfony/polyfill-php80": "1.*",
     "symfony/polyfill-php81": "1.*",
-    "twig/twig": "3.8.*",
+    "twig/twig": "3.14.*",
     "willdurand/negotiation": "3.1.*",
     "punic/punic": "3.8.*",
     "ml/json-ld": "1.*",
@@ -21,7 +21,7 @@
     "symfony/twig-bundle": "6.4.*"
   },
   "require-dev": {
-    "phpunit/phpunit": "9.5.*",
+    "phpunit/phpunit": "9.6.*",
     "symfony/dom-crawler": "6.4.*",
     "symfony/config": "6.4.*",
     "symfony/runtime": "6.4.*",

--- a/composer.json
+++ b/composer.json
@@ -10,14 +10,14 @@
     "symfony/polyfill-php81": "1.*",
     "twig/twig": "3.8.*",
     "willdurand/negotiation": "3.1.*",
-    "punic/punic": "3.5.1",
+    "punic/punic": "3.8.*",
     "ml/json-ld": "1.*",
     "ext-intl": "*",
     "ext-mbstring": "*",
     "ext-xsl": "*",
     "monolog/monolog": "1.27.*",
     "symfony/translation": "6.4.*",
-    "symfony/translation-contracts": "3.0.*",
+    "symfony/translation-contracts": "3.5.*",
     "symfony/twig-bundle": "6.4.*"
   },
   "require-dev": {
@@ -30,7 +30,7 @@
     "symfony/dotenv": "6.4.*",
     "symfony/lokalise-translation-provider": "6.4.*",
     "symfony/console": "6.4.*",
-    "mockery/mockery": "1.5.1",
+    "mockery/mockery": "1.6.*",
     "friendsofphp/php-cs-fixer": "3.64.*"
   },
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "ext-intl": "*",
     "ext-mbstring": "*",
     "ext-xsl": "*",
-    "monolog/monolog": "1.27.*",
+    "monolog/monolog": "3.7.*",
     "symfony/translation": "6.4.*",
     "symfony/translation-contracts": "3.5.*",
     "symfony/twig-bundle": "6.4.*"

--- a/tests/ConceptPropertyValueLiteralTest.php
+++ b/tests/ConceptPropertyValueLiteralTest.php
@@ -61,8 +61,8 @@ class ConceptPropertyValueLiteralTest extends PHPUnit\Framework\TestCase
      */
     public function testGetLabelThatIsABrokenDate()
     {
-        set_error_handler(function ($code, $message, $file, $line) {
-            throw new \PHPUnit\Framework\Error($message);
+        set_error_handler(function ($code, $message) {
+            throw new \PHPUnit\Framework\Error($message,$code);
         });
 
         try {

--- a/tests/ConceptPropertyValueLiteralTest.php
+++ b/tests/ConceptPropertyValueLiteralTest.php
@@ -61,11 +61,22 @@ class ConceptPropertyValueLiteralTest extends PHPUnit\Framework\TestCase
      */
     public function testGetLabelThatIsABrokenDate()
     {
-        $this->expectWarning();
-        $vocab = $this->model->getVocabulary('dates');
-        $concept = $vocab->getConceptInfo("http://www.skosmos.skos/date/d2", "en");
-        $props = $concept->getProperties();
-        $propvals = $props['http://www.skosmos.skos/date/ownDate']->getValues();
+        set_error_handler(function ($errno, $errstr, $errfile, $errline) {
+            throw new \ErrorException($errstr, $errno, 0, $errfile, $errline);
+        });
+
+        try {
+            $vocab = $this->model->getVocabulary('dates');
+
+            $this->expectException(\ErrorException::class);
+            $this->expectExceptionMessage("Failed to parse time string (1986-21-00) at position 6 (1): Unexpected character");
+
+            $concept = $vocab->getConceptInfo("http://www.skosmos.skos/date/d2", "en");
+            $props = $concept->getProperties();
+            $propvals = $props['http://www.skosmos.skos/date/ownDate']->getValues();
+        } finally {
+            restore_error_handler();
+        }
     }
 
     /**

--- a/tests/ConceptPropertyValueLiteralTest.php
+++ b/tests/ConceptPropertyValueLiteralTest.php
@@ -61,14 +61,14 @@ class ConceptPropertyValueLiteralTest extends PHPUnit\Framework\TestCase
      */
     public function testGetLabelThatIsABrokenDate()
     {
-        set_error_handler(function ($errno, $errstr, $errfile, $errline) {
-            throw new \ErrorException($errstr, $errno, 0, $errfile, $errline);
+        set_error_handler(function ($code, $message, $file, $line) {
+            throw new \PHPUnit\Framework\Error($message);
         });
 
         try {
             $vocab = $this->model->getVocabulary('dates');
 
-            $this->expectException(\ErrorException::class);
+            $this->expectException(\PHPUnit\Framework\Error::class);
             $this->expectExceptionMessage("Failed to parse time string (1986-21-00) at position 6 (1): Unexpected character");
 
             $concept = $vocab->getConceptInfo("http://www.skosmos.skos/date/d2", "en");

--- a/tests/ConceptTest.php
+++ b/tests/ConceptTest.php
@@ -312,8 +312,8 @@ class ConceptTest extends PHPUnit\Framework\TestCase
      */
     public function testGetTimestampInvalidWarning()
     {
-        set_error_handler(function ($code, $message, $file, $line) {
-            throw new \PHPUnit\Framework\Error($message);
+        set_error_handler(function ($code, $message) {
+            throw new \PHPUnit\Framework\Error($message, $code);
         });
 
         try {

--- a/tests/ConceptTest.php
+++ b/tests/ConceptTest.php
@@ -312,10 +312,22 @@ class ConceptTest extends PHPUnit\Framework\TestCase
      */
     public function testGetTimestampInvalidWarning()
     {
-        $this->expectError();
-        $vocab = $this->model->getVocabulary('test');
-        $concept = $vocab->getConceptInfo("http://www.skosmos.skos/test/ta114", "en");
-        $props = $concept->getDate(); # this should throw a E_USER_WARNING exception
+        set_error_handler(function ($errno, $errstr, $errfile, $errline) {
+            throw new \ErrorException($errstr, $errno, 0, $errfile, $errline);
+        });
+
+        try {
+            $vocab = $this->model->getVocabulary('test');
+
+            $this->expectException(\ErrorException::class);
+            $this->expectExceptionMessage("Failed to parse time string (1986-21-00) at position 6 (1): Unexpected character");
+
+            $concept = $vocab->getConceptInfo("http://www.skosmos.skos/test/ta114", "en");
+            $props = $concept->getDate(); # this should throw an ErrorException
+
+        } finally {
+            restore_error_handler();
+        }
     }
 
     /**

--- a/tests/ConceptTest.php
+++ b/tests/ConceptTest.php
@@ -312,18 +312,18 @@ class ConceptTest extends PHPUnit\Framework\TestCase
      */
     public function testGetTimestampInvalidWarning()
     {
-        set_error_handler(function ($errno, $errstr, $errfile, $errline) {
-            throw new \ErrorException($errstr, $errno, 0, $errfile, $errline);
+        set_error_handler(function ($code, $message, $file, $line) {
+            throw new \PHPUnit\Framework\Error($message);
         });
 
         try {
             $vocab = $this->model->getVocabulary('test');
 
-            $this->expectException(\ErrorException::class);
+            $this->expectException(\PHPUnit\Framework\Error::class);
             $this->expectExceptionMessage("Failed to parse time string (1986-21-00) at position 6 (1): Unexpected character");
 
             $concept = $vocab->getConceptInfo("http://www.skosmos.skos/test/ta114", "en");
-            $props = $concept->getDate(); # this should throw an ErrorException
+            $concept->getDate(); # this should throw an ErrorException
 
         } finally {
             restore_error_handler();

--- a/tests/VocabularyConfigTest.php
+++ b/tests/VocabularyConfigTest.php
@@ -164,8 +164,8 @@ class VocabularyConfigTest extends PHPUnit\Framework\TestCase
      */
     public function testGetDefaultLanguageWhenNotSet()
     {
-        set_error_handler(function ($code, $message, $file, $line) {
-            throw new \PHPUnit\Framework\Error($message);
+        set_error_handler(function ($code, $message) {
+            throw new \PHPUnit\Framework\Error($message, $code);
         });
         try {
             $vocab = $this->model->getVocabulary('testdiff');
@@ -217,8 +217,8 @@ class VocabularyConfigTest extends PHPUnit\Framework\TestCase
      */
     public function testGetDataURLsNotGuessable()
     {
-        set_error_handler(function ($code, $message, $file, $line) {
-            throw new \PHPUnit\Framework\Error($message);
+        set_error_handler(function ($code, $message) {
+            throw new \PHPUnit\Framework\Error($message, $code);
         });
 
         try {
@@ -259,8 +259,8 @@ class VocabularyConfigTest extends PHPUnit\Framework\TestCase
      */
     public function testGetDataURLsMarcNotDefined()
     {
-        set_error_handler(function ($code, $message, $file, $line) {
-            throw new \PHPUnit\Framework\Error($message);
+        set_error_handler(function ($code, $message) {
+            throw new \PHPUnit\Framework\Error($message, $code);
         });
 
         try {
@@ -686,8 +686,8 @@ class VocabularyConfigTest extends PHPUnit\Framework\TestCase
      */
     public function testGetPropertyOrderUnknown()
     {
-        set_error_handler(function ($code, $message, $file, $line) {
-            throw new \PHPUnit\Framework\Error($message);
+        set_error_handler(function ($code, $message) {
+            throw new \PHPUnit\Framework\Error($message, $code);
         });
 
         try {

--- a/tests/VocabularyConfigTest.php
+++ b/tests/VocabularyConfigTest.php
@@ -17,6 +17,8 @@ class VocabularyConfigTest extends PHPUnit\Framework\TestCase
         setlocale(LC_ALL, 'en_GB.utf8');
         $this->model = new Model('/../../tests/testconfig.ttl');
         $this->assertNotNull($this->model->getVocabulary('test')->getConfig()->getPluginRegister(), "The PluginRegister of the model was not initialized!");
+
+
     }
 
     /**
@@ -164,10 +166,17 @@ class VocabularyConfigTest extends PHPUnit\Framework\TestCase
      */
     public function testGetDefaultLanguageWhenNotSet()
     {
-        $vocab = $this->model->getVocabulary('testdiff');
-        $this->expectError();
-        $this->expectErrorMessage("Default language for vocabulary 'testdiff' unknown, choosing 'en'.");
-        $lang = $vocab->getConfig()->getDefaultLanguage();
+        set_error_handler(function ($errno, $errstr, $errfile, $errline) {
+            throw new \ErrorException($errstr, $errno, 0, $errfile, $errline);
+        });
+        try {
+            $vocab = $this->model->getVocabulary('testdiff');
+            $this->expectException(\ErrorException::class);
+            $this->expectExceptionMessage("Default language for vocabulary 'testdiff' unknown, choosing 'en'.");
+            $lang = $vocab->getConfig()->getDefaultLanguage();
+        } finally {
+            restore_error_handler();
+        }
     }
 
     /**
@@ -210,10 +219,19 @@ class VocabularyConfigTest extends PHPUnit\Framework\TestCase
      */
     public function testGetDataURLsNotGuessable()
     {
-        $vocab = $this->model->getVocabulary('test');
-        $this->expectWarning();
-        $this->expectWarningMessage("Could not guess format for <http://skosmos.skos/dump/test/>.");
-        $url = $vocab->getConfig()->getDataURLs();
+        set_error_handler(function ($errno, $errstr, $errfile, $errline) {
+            throw new \ErrorException($errstr, $errno, 0, $errfile, $errline);
+        });
+
+        try {
+            $vocab = $this->model->getVocabulary('test');
+            $this->expectException(\ErrorException::class);
+            $this->expectExceptionMessage("Could not guess format for <http://skosmos.skos/dump/test/>.");
+
+            $url = $vocab->getConfig()->getDataURLs();
+        } finally {
+            restore_error_handler();
+        }
     }
 
     /**
@@ -243,11 +261,21 @@ class VocabularyConfigTest extends PHPUnit\Framework\TestCase
      */
     public function testGetDataURLsMarcNotDefined()
     {
-        $vocab = $this->model->getVocabulary('marc-undefined');
-        $this->expectWarning();
-        $this->expectWarningMessage("Could not guess format for <http://skosmos.skos/dump/test/marc-undefined.mrcx>.");
-        $url = $vocab->getConfig()->getDataURLs();
-        $this->assertEquals(array(), $url);
+        set_error_handler(function ($errno, $errstr, $errfile, $errline) {
+            throw new \ErrorException($errstr, $errno, 0, $errfile, $errline);
+        });
+
+        try {
+            $vocab = $this->model->getVocabulary('marc-undefined');
+
+            $this->expectException(\ErrorException::class);
+            $this->expectExceptionMessage("Could not guess format for <http://skosmos.skos/dump/test/marc-undefined.mrcx>.");
+
+            $url = $vocab->getConfig()->getDataURLs();
+            $this->assertEquals(array(), $url);
+        } finally {
+            restore_error_handler();
+        }
     }
 
     /**
@@ -660,11 +688,20 @@ class VocabularyConfigTest extends PHPUnit\Framework\TestCase
      */
     public function testGetPropertyOrderUnknown()
     {
-        $vocab = $this->model->getVocabulary('testUnknownPropertyOrder');
-        $this->expectWarning();
-        $this->expectWarningMessage("Property order for vocabulary 'testUnknownPropertyOrder' unknown, using default order");
-        $params = $vocab->getConfig()->getPropertyOrder();
-        $this->assertEquals(VocabularyConfig::DEFAULT_PROPERTY_ORDER, $params);
+        set_error_handler(function ($errno, $errstr, $errfile, $errline) {
+            throw new \ErrorException($errstr, $errno, 0, $errfile, $errline);
+        });
+
+        try {
+            $vocab = $this->model->getVocabulary('testUnknownPropertyOrder');
+            $this->expectException(\ErrorException::class);
+            $this->expectExceptionMessage("Property order for vocabulary 'testUnknownPropertyOrder' unknown, using default order");
+
+            $params = $vocab->getConfig()->getPropertyOrder();
+            $this->assertEquals(VocabularyConfig::DEFAULT_PROPERTY_ORDER, $params);
+        } finally {
+            restore_error_handler();
+        }
     }
 
     /**

--- a/tests/VocabularyConfigTest.php
+++ b/tests/VocabularyConfigTest.php
@@ -17,8 +17,6 @@ class VocabularyConfigTest extends PHPUnit\Framework\TestCase
         setlocale(LC_ALL, 'en_GB.utf8');
         $this->model = new Model('/../../tests/testconfig.ttl');
         $this->assertNotNull($this->model->getVocabulary('test')->getConfig()->getPluginRegister(), "The PluginRegister of the model was not initialized!");
-
-
     }
 
     /**

--- a/tests/VocabularyConfigTest.php
+++ b/tests/VocabularyConfigTest.php
@@ -166,12 +166,12 @@ class VocabularyConfigTest extends PHPUnit\Framework\TestCase
      */
     public function testGetDefaultLanguageWhenNotSet()
     {
-        set_error_handler(function ($errno, $errstr, $errfile, $errline) {
-            throw new \ErrorException($errstr, $errno, 0, $errfile, $errline);
+        set_error_handler(function ($code, $message, $file, $line) {
+            throw new \PHPUnit\Framework\Error($message);
         });
         try {
             $vocab = $this->model->getVocabulary('testdiff');
-            $this->expectException(\ErrorException::class);
+            $this->expectException(\PHPUnit\Framework\Error::class);
             $this->expectExceptionMessage("Default language for vocabulary 'testdiff' unknown, choosing 'en'.");
             $lang = $vocab->getConfig()->getDefaultLanguage();
         } finally {
@@ -219,13 +219,13 @@ class VocabularyConfigTest extends PHPUnit\Framework\TestCase
      */
     public function testGetDataURLsNotGuessable()
     {
-        set_error_handler(function ($errno, $errstr, $errfile, $errline) {
-            throw new \ErrorException($errstr, $errno, 0, $errfile, $errline);
+        set_error_handler(function ($code, $message, $file, $line) {
+            throw new \PHPUnit\Framework\Error($message);
         });
 
         try {
             $vocab = $this->model->getVocabulary('test');
-            $this->expectException(\ErrorException::class);
+            $this->expectException(\PHPUnit\Framework\Error::class);
             $this->expectExceptionMessage("Could not guess format for <http://skosmos.skos/dump/test/>.");
 
             $url = $vocab->getConfig()->getDataURLs();
@@ -261,14 +261,14 @@ class VocabularyConfigTest extends PHPUnit\Framework\TestCase
      */
     public function testGetDataURLsMarcNotDefined()
     {
-        set_error_handler(function ($errno, $errstr, $errfile, $errline) {
-            throw new \ErrorException($errstr, $errno, 0, $errfile, $errline);
+        set_error_handler(function ($code, $message, $file, $line) {
+            throw new \PHPUnit\Framework\Error($message);
         });
 
         try {
             $vocab = $this->model->getVocabulary('marc-undefined');
 
-            $this->expectException(\ErrorException::class);
+            $this->expectException(\PHPUnit\Framework\Error::class);
             $this->expectExceptionMessage("Could not guess format for <http://skosmos.skos/dump/test/marc-undefined.mrcx>.");
 
             $url = $vocab->getConfig()->getDataURLs();
@@ -688,13 +688,13 @@ class VocabularyConfigTest extends PHPUnit\Framework\TestCase
      */
     public function testGetPropertyOrderUnknown()
     {
-        set_error_handler(function ($errno, $errstr, $errfile, $errline) {
-            throw new \ErrorException($errstr, $errno, 0, $errfile, $errline);
+        set_error_handler(function ($code, $message, $file, $line) {
+            throw new \PHPUnit\Framework\Error($message);
         });
 
         try {
             $vocab = $this->model->getVocabulary('testUnknownPropertyOrder');
-            $this->expectException(\ErrorException::class);
+            $this->expectException(\PHPUnit\Framework\Error::class);
             $this->expectExceptionMessage("Property order for vocabulary 'testUnknownPropertyOrder' unknown, using default order");
 
             $params = $vocab->getConfig()->getPropertyOrder();


### PR DESCRIPTION
## Reasons for creating this PR

Library dependencies need to be inspected periodically to keep the PHP codebase up-to-date

## Description of the changes in this PR

Changes to composer.json. The changes can be implemented by running `php composer.phar update`. Remaining work can be inspected by running `php composer.phar outdated`. Possible vulnerabilitiy reports can be inspected by running `php composer.phar audit`.

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
