### PR TITLE
Skosmos 2: Fix PHP 8.1 deprecation message that broke content language links

### DIFF
--- a/model/Vocabulary.php
+++ b/model/Vocabulary.php
@@ -137,7 +137,7 @@ class Vocabulary extends DataObject implements Modifiable
      */
     public function getLocalName($uri)
     {
-        return str_replace($this->getUriSpace(), "", $uri);
+        return ($uri !== null) ? str_replace($this->getUriSpace(), "", $uri) : '';
     }
 
     /**


### PR DESCRIPTION
## Reasons for creating this PR

PHP deprecations warnings may break content language switching links. See #1701 

This PR fixes the problem by ensuring that str_replace cannot be called with a null value as the third parameter.

## Link to relevant issue(s), if any

- Closes #1701

## Description of the changes in this PR

* check for null values before calling str_replace in Vocabulary->getLocalName()

## Known problems or uncertainties in this PR

* Maybe should be done for Skosmos 3 as well, just in case?
* No unit test, sorry

## Checklist

- [x] phpUnit tests pass locally with my changes
- [ ] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
