### PR TITLE
Don't HTML encode quotes in REST API callback, to fix ONKI Selector (Skosmos 3)

### DIFF
--- a/src/controller/RestController.php
+++ b/src/controller/RestController.php
@@ -25,7 +25,7 @@ class RestController extends Controller
         // wrap with JSONP callback if requested
         if (filter_input(INPUT_GET, 'callback', FILTER_SANITIZE_FULL_SPECIAL_CHARS)) {
             header("Content-type: application/javascript; charset=utf-8");
-            echo filter_input(INPUT_GET, 'callback', FILTER_SANITIZE_FULL_SPECIAL_CHARS) . "(" . json_encode($data) . ");";
+            echo filter_input(INPUT_GET, 'callback', FILTER_SANITIZE_FULL_SPECIAL_CHARS, FILTER_FLAG_NO_ENCODE_QUOTES) . "(" . json_encode($data) . ");";
             return;
         }
 


### PR DESCRIPTION
## Reasons for creating this PR

See PR #1705. This is the same fix but for Skosmos 3.

## Link to relevant issue(s), if any

n/a

## Description of the changes in this PR

- when sanitizing the callback parameter, apply the [FILTER_FLAG_NO_ENCODE_QUOTES](https://www.php.net/manual/en/filter.constants.php#constant.filter-flag-no-encode-quotes) option which prevents encoding quotes

## Known problems or uncertainties in this PR

n/a

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
