### PR TITLE
Set HTTP user-agent to 'Skosmos' when performing requests

### DIFF
--- a/src/model/resolver/LinkedDataResource.php
+++ b/src/model/resolver/LinkedDataResource.php
@@ -16,7 +16,7 @@ class LinkedDataResource extends RemoteResource
         try {
             // change the timeout setting for external requests
             $httpclient = EasyRdf\Http::getDefaultHttpClient();
-            $httpclient->setConfig(array('timeout' => $timeout));
+            $httpclient->setConfig(array('timeout' => $timeout, 'useragent' => 'Skosmos'));
             EasyRdf\Http::setDefaultHttpClient($httpclient);
 
             $graph = EasyRdf\Graph::newAndLoad(EasyRdf\Utils::removeFragmentFromUri($this->uri));

--- a/src/model/resolver/WDQSResource.php
+++ b/src/model/resolver/WDQSResource.php
@@ -11,7 +11,7 @@ class WDQSResource extends RemoteResource
             EasyRdf\Format::unregister('json');
             // change the timeout setting for external requests
             $httpclient = EasyRdf\Http::getDefaultHttpClient();
-            $httpclient->setConfig(array('timeout' => $timeout));
+            $httpclient->setConfig(array('timeout' => $timeout, 'useragent' => 'Skosmos'));
             $httpclient->setHeaders('Accept', 'text/turtle');
             EasyRdf\Http::setDefaultHttpClient($httpclient);
 

--- a/src/model/sparql/GenericSparql.php
+++ b/src/model/sparql/GenericSparql.php
@@ -125,7 +125,8 @@ class GenericSparql
     {
         // configure the HTTP client used by EasyRdf\Sparql\Client
         $httpclient = EasyRdf\Http::getDefaultHttpClient();
-        $httpclient->setConfig(array('timeout' => $this->model->getConfig()->getSparqlTimeout()));
+        $httpclient->setConfig(array('timeout' => $this->model->getConfig()->getSparqlTimeout(),
+                                     'useragent' => 'Skosmos'));
 
         // if special cache control (typically no-cache) was requested by the
         // client, set the same type of cache control headers also in subsequent


### PR DESCRIPTION
## Reasons for creating this PR

See #1691. It's good practice to use a custom HTTP user agent instead of relying on library defaults. This code sets the user-agent to `Skosmos` every time EasyRdf is used to perform HTTP requests (including SPARQL). There is one more place in the code (LOCResolver) that performs HTTP requests directly using stream operations, but in that code the user-agent was already set to `Skosmos`.

I decided not to include the Skosmos version number in the user-agent string based on discussion with other Skosmos developers. 

## Link to relevant issue(s), if any

- Closes #1691

## Description of the changes in this PR

- set the HTTP user agent (via EasyRdf config setting) in all places where the Skosmos backend code performs HTTP requests

## Known problems or uncertainties in this PR

No unit tests, but I don't think it's easy to test this with PHPUnit. However, I tested manually that the changes do have an effect by looking at HTTP server logs.

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
