### PR TITLE
Set the UI language cookie

### DIFF
--- a/resource/js/navbar-ui-languages.js
+++ b/resource/js/navbar-ui-languages.js
@@ -12,10 +12,10 @@ function addLanguageEventListeners() {
   languageLinks.forEach(function(link) {
     link.addEventListener('click', function(event) {
       event.preventDefault()
-      setLangCookie(this.getAttribute('href'))
+      const langValue = this.getAttribute('id').substring(9) //strip the 'language-' part of the id
+      setLangCookie(langValue)
     })
   })
 }
-
 // register the language link event listeners
 document.addEventListener('DOMContentLoaded', addLanguageEventListeners)

--- a/resource/js/navbar-ui-languages.js
+++ b/resource/js/navbar-ui-languages.js
@@ -1,4 +1,4 @@
-function setLangCookie(lang) {
+function setLangCookie (lang) {
   // The cookie path should be relative if the baseHref is known
   let cookiePath = '/'
   if (window.SKOSMOS.baseHref && window.SKOSMOS.baseHref.replace(window.origin, '')) {
@@ -6,11 +6,11 @@ function setLangCookie(lang) {
   }
   document.cookie = `SKOSMOS_LANGUAGE=${lang};path=${cookiePath}`
 }
-function addLanguageEventListeners() {
-  const languageLinks = document.querySelectorAll('.nav-item.language a');
-  languageLinks.forEach(function(link) {
-    link.addEventListener('click', function(event) {
-      const langValue = this.getAttribute('id').substring(9) //strip the 'language-' part of the id
+function addLanguageEventListeners () {
+  const languageLinks = document.querySelectorAll('.nav-item.language a')
+  languageLinks.forEach(function (link) {
+    link.addEventListener('click', function (event) {
+      const langValue = this.getAttribute('id').substring(9) // strip the 'language-' part of the id
       setLangCookie(langValue)
     })
   })

--- a/resource/js/navbar-ui-languages.js
+++ b/resource/js/navbar-ui-languages.js
@@ -1,0 +1,21 @@
+function setLangCookie(lang) {
+  // The cookie path should be relative if the baseHref is known
+  let cookiePath = '/'
+  if (window.SKOSMOS.baseHref && window.SKOSMOS.baseHref.replace(window.origin, '')) {
+    cookiePath = window.SKOSMOS.baseHref.replace(window.origin, '')
+  }
+  document.cookie = `SKOSMOS_LANGUAGE=${lang};path=${cookiePath}`
+  console.log('KEKSI asetettu parametrille ' + lang)
+}
+function addLanguageEventListeners() {
+  const languageLinks = document.querySelectorAll('.nav-item.language a');
+  languageLinks.forEach(function(link) {
+    link.addEventListener('click', function(event) {
+      event.preventDefault()
+      setLangCookie(this.getAttribute('href'))
+    })
+  })
+}
+
+// register the language link event listeners
+document.addEventListener('DOMContentLoaded', addLanguageEventListeners)

--- a/resource/js/navbar-ui-languages.js
+++ b/resource/js/navbar-ui-languages.js
@@ -5,13 +5,11 @@ function setLangCookie(lang) {
     cookiePath = window.SKOSMOS.baseHref.replace(window.origin, '')
   }
   document.cookie = `SKOSMOS_LANGUAGE=${lang};path=${cookiePath}`
-  console.log('KEKSI asetettu parametrille ' + lang)
 }
 function addLanguageEventListeners() {
   const languageLinks = document.querySelectorAll('.nav-item.language a');
   languageLinks.forEach(function(link) {
     link.addEventListener('click', function(event) {
-      event.preventDefault()
       const langValue = this.getAttribute('id').substring(9) //strip the 'language-' part of the id
       setLangCookie(langValue)
     })

--- a/resource/js/navbar.js
+++ b/resource/js/navbar.js
@@ -1,6 +1,6 @@
-function setLangCookie(lang) {
+function setLangCookie (lang) {
   // The cookie path should be relative if the baseHref is known
-  let cookiePath = window.SKOSMOS.baseHref?.replace(window.origin, '') || '/'
+  const cookiePath = window.SKOSMOS.baseHref?.replace(window.origin, '') || '/'
   const date = new Date()
   date.setTime(date.getTime() + 365 * 24 * 60 * 60 * 1000) // 365 days from now
   document.cookie = `SKOSMOS_LANGUAGE=${lang}; expires=${date.toGMTString()}; path=${cookiePath}; SameSite=Lax`

--- a/resource/js/navbar.js
+++ b/resource/js/navbar.js
@@ -4,7 +4,17 @@ function setLangCookie (lang) {
   if (window.SKOSMOS.baseHref && window.SKOSMOS.baseHref.replace(window.origin, '')) {
     cookiePath = window.SKOSMOS.baseHref.replace(window.origin, '')
   }
-  document.cookie = `SKOSMOS_LANGUAGE=${lang};path=${cookiePath}`
+  const path = '; path=' + cookiePath
+
+  var date = new Date()
+  const msPerDay = 24*60*60*1000
+  const days = 365
+  date.setTime(date.getTime() + days*msPerDay)
+  const expires = '; expires=' + date.toGMTString()
+
+  const langValue = 'SKOSMOS_LANGUAGE='+lang
+
+  document.cookie = langValue + expires + path + '; SameSite=Lax'
 }
 function addLanguageEventListeners () {
   const languageLinks = document.querySelectorAll('.nav-item.language a')

--- a/resource/js/navbar.js
+++ b/resource/js/navbar.js
@@ -1,20 +1,9 @@
-function setLangCookie (lang) {
+function setLangCookie(lang) {
   // The cookie path should be relative if the baseHref is known
-  let cookiePath = '/'
-  if (window.SKOSMOS.baseHref && window.SKOSMOS.baseHref.replace(window.origin, '')) {
-    cookiePath = window.SKOSMOS.baseHref.replace(window.origin, '')
-  }
-  const path = '; path=' + cookiePath
-
+  let cookiePath = window.SKOSMOS.baseHref?.replace(window.origin, '') || '/'
   const date = new Date()
-  const msPerDay = 24 * 60 * 60 * 1000
-  const days = 365
-  date.setTime(date.getTime() + days * msPerDay)
-  const expires = '; expires=' + date.toGMTString()
-
-  const langValue = 'SKOSMOS_LANGUAGE=' + lang
-
-  document.cookie = langValue + expires + path + '; SameSite=Lax'
+  date.setTime(date.getTime() + 365 * 24 * 60 * 60 * 1000) // 365 days from now
+  document.cookie = `SKOSMOS_LANGUAGE=${lang}; expires=${date.toGMTString()}; path=${cookiePath}; SameSite=Lax`
 }
 function addLanguageEventListeners () {
   const languageLinks = document.querySelectorAll('.nav-item.language a')

--- a/resource/js/navbar.js
+++ b/resource/js/navbar.js
@@ -6,13 +6,13 @@ function setLangCookie (lang) {
   }
   const path = '; path=' + cookiePath
 
-  var date = new Date()
-  const msPerDay = 24*60*60*1000
+  const date = new Date()
+  const msPerDay = 24 * 60 * 60 * 1000
   const days = 365
-  date.setTime(date.getTime() + days*msPerDay)
+  date.setTime(date.getTime() + days * msPerDay)
   const expires = '; expires=' + date.toGMTString()
 
-  const langValue = 'SKOSMOS_LANGUAGE='+lang
+  const langValue = 'SKOSMOS_LANGUAGE=' + lang
 
   document.cookie = langValue + expires + path + '; SameSite=Lax'
 }

--- a/src/view/base-template.twig
+++ b/src/view/base-template.twig
@@ -62,7 +62,7 @@
         {% if languages|length > 1 %}
         {% for langcode, langdata in languages %}
         {% if request.lang != langcode %}
-        <li class="nav-item" id="language">
+        <li class="nav-item language">
           <a class="fs-6 text-light ms-3 text-decoration-none" id="language-{{ langcode}}" href="{{ request.langurl(langcode) }}"> {{ langdata.name }}</a>
         </li>
         {% endif %}

--- a/src/view/base-template.twig
+++ b/src/view/base-template.twig
@@ -63,7 +63,7 @@
         {% for langcode, langdata in languages %}
         {% if request.lang != langcode %}
         <li class="nav-item language">
-          <a class="fs-6 text-light ms-3 text-decoration-none" id="language-{{ langcode}}" href="{{ request.langurl(langcode) }}"> {{ langdata.name }}</a>
+          <a class="fs-6 text-light ms-3 text-decoration-none" id="language-{{ langcode }}" href="{{ request.langurl(langcode) }}"> {{ langdata.name }}</a>
         </li>
         {% endif %}
         {% endfor %}

--- a/src/view/scripts.inc.twig
+++ b/src/view/scripts.inc.twig
@@ -111,4 +111,4 @@ window.SKOSMOS = {
 
 <!-- Other (non-Vue) JS functionality -->
 <script src="resource/js/copy-to-clipboard.js"></script>
-<script src="resource/js/navbar-ui-languages.js"></script>
+<script src="resource/js/navbar.js"></script>

--- a/src/view/scripts.inc.twig
+++ b/src/view/scripts.inc.twig
@@ -111,3 +111,4 @@ window.SKOSMOS = {
 
 <!-- Other (non-Vue) JS functionality -->
 <script src="resource/js/copy-to-clipboard.js"></script>
+<script src="resource/js/navbar-ui-languages.js"></script>

--- a/tests/cypress/template/navbar-languages.cy.js
+++ b/tests/cypress/template/navbar-languages.cy.js
@@ -1,0 +1,12 @@
+describe('Navbar languages', () => {
+
+  it('Sets and reads SKOSMOS_LANGUAGE cookie correctly', () => {
+    cy.visit('/')
+
+    cy.get('.nav-item.language a').first().click()
+    cy.getCookie('SKOSMOS_LANGUAGE').should('exist')
+    cy.getCookie('SKOSMOS_LANGUAGE').should('have.property', 'value', 'fi')
+
+    cy.url().should('include', '/fi/')
+  })
+})

--- a/tests/cypress/template/navbar-languages.cy.js
+++ b/tests/cypress/template/navbar-languages.cy.js
@@ -2,6 +2,7 @@ describe('Navbar languages', () => {
 
   it('Sets and reads SKOSMOS_LANGUAGE cookie correctly', () => {
     cy.visit('/')
+    cy.url().should('not.include', '/fi/') // The default language is not Finnish
 
     cy.get('.nav-item.language a').first().click()
     cy.getCookie('SKOSMOS_LANGUAGE').should('exist')
@@ -10,6 +11,6 @@ describe('Navbar languages', () => {
     cy.url().should('include', '/fi/')
 
     cy.visit('/')
-    cy.url().should('include', '/fi/')
+    cy.url().should('include', '/fi/') // Skosmos chooses the default language based on the cookie
   })
 })

--- a/tests/cypress/template/navbar-languages.cy.js
+++ b/tests/cypress/template/navbar-languages.cy.js
@@ -8,5 +8,8 @@ describe('Navbar languages', () => {
     cy.getCookie('SKOSMOS_LANGUAGE').should('have.property', 'value', 'fi')
 
     cy.url().should('include', '/fi/')
+
+    cy.visit('/')
+    cy.url().should('include', '/fi/')
   })
 })


### PR DESCRIPTION
## Reasons for creating this PR

## Link to relevant issue(s), if any

- Closes #1696 

## Description of the changes in this PR

 - Fixed the navbar language menu
 - Added functionality for setting the language cookie
 - Added tests for setting and reading the language cookie

## Known problems or uncertainties in this PR

- The functionality in index.php and web controller seemed to be OK, they might need a tweak in this

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
