### PR TITLE
Implement basic functionality of groups view using Vue

### DIFF
--- a/resource/css/skosmos.css
+++ b/resource/css/skosmos.css
@@ -549,18 +549,21 @@ body {
     font-weight: bold !important;
   }
 
-  /*** sidebar hierarchy tab ***/
-  #tab-hierarchy .sidebar-list .list-group-item {
+  /*** sidebar hierarchy and groups tabs ***/
+  #tab-hierarchy .sidebar-list .list-group-item,
+  #tab-groups .sidebar-list .list-group-item {
     border-left: 1px dashed var(--vocab-text);
     border-radius: 0;
     white-space: nowrap;
   }
 
-  #tab-hierarchy .sidebar-list .list-group-item.top-concept {
+  #tab-hierarchy .sidebar-list .list-group-item.top-concept,
+  #tab-groups .sidebar-list .list-group-item.top-concept {
     border: none;
   }
 
-  #tab-hierarchy .sidebar-list .list-group-item .concept-label {
+  #tab-hierarchy .sidebar-list .list-group-item .concept-label,
+  #tab-groups .sidebar-list .list-group-item .concept-label {
     display: inline-block;
     border-left: 1px dashed var(--vocab-text);
     margin-left: 16px;
@@ -569,7 +572,8 @@ body {
   }
 
   /* horizontal line before concept */
-  #tab-hierarchy .sidebar-list .list-group-item .concept-label::before {
+  #tab-hierarchy .sidebar-list .list-group-item .concept-label::before,
+  #tab-groups .sidebar-list .list-group-item .concept-label::before {
     content: '';
     position: absolute;
     left: 16px;
@@ -580,7 +584,8 @@ body {
   }
 
   /* hiding bottom of vertical line on last concept of list */
-  #tab-hierarchy .sidebar-list .list-group-item .concept-label.last::before {
+  #tab-hierarchy .sidebar-list .list-group-item .concept-label.last::before,
+  #tab-groups .sidebar-list .list-group-item .concept-label.last::before {
     top: auto;
     bottom: 0;
     height: calc(100% - 13px);
@@ -590,20 +595,24 @@ body {
   }
 
   /* no border for children of the last concept */
-  #tab-hierarchy .sidebar-list .list-group-item span.last + ul > li {
+  #tab-hierarchy .sidebar-list .list-group-item span.last + ul > li,
+  #tab-groups .sidebar-list .list-group-item span.last + ul > li  {
     border: none;
     margin-left: 1px !important; /* add a 1px margin to offset missing border */
   }
 
-  #tab-hierarchy .sidebar-list .list-group-item a.selected {
+  #tab-hierarchy .sidebar-list .list-group-item a.selected,
+  #tab-groups .sidebar-list .list-group-item a.selected {
     color: var(--vocab-text) !important;
   }
 
-  #tab-hierarchy .sidebar-list .list-group-item .concept-notation {
+  #tab-hierarchy .sidebar-list .list-group-item .concept-notation,
+  #tab-groups .sidebar-list .list-group-item .concept-notation {
     color: var(--dark-color);
   }
 
-  #tab-hierarchy .sidebar-list .list-group-item a.selected .concept-notation {
+  #tab-hierarchy .sidebar-list .list-group-item a.selected .concept-notation,
+  #tab-groups .sidebar-list .list-group-item a.selected .concept-notation {
     font-weight: bold;
   }
 

--- a/resource/css/skosmos.css
+++ b/resource/css/skosmos.css
@@ -568,6 +568,7 @@ body {
     border-left: 1px dashed var(--vocab-text);
     margin-left: 16px;
     padding-left: 14px;
+    padding-right: 14px;
     white-space: wrap;
   }
 

--- a/resource/js/tab-groups.js
+++ b/resource/js/tab-groups.js
@@ -101,7 +101,7 @@ const tabGroupsApp = Vue.createApp({
                   console.log('groups', this.groups)
                 })
             } else {
-              // If selected concept has no members, set isOpen for it and its parents
+              // If selected group has no members, set isOpen for the group and its parents
               this.setIsOpenAndAddMembers(result, this.selectedGroup, [])
 
               this.groups = result
@@ -109,7 +109,7 @@ const tabGroupsApp = Vue.createApp({
               console.log('groups', this.groups)
             }
           } else {
-            // If we are on vocab home page, simply set groups to previous result
+            // If we are on vocab home page, simply set groups to result
             this.groups = result
             this.loadingGroups = false
             console.log('groups', this.groups)

--- a/resource/js/tab-groups.js
+++ b/resource/js/tab-groups.js
@@ -1,0 +1,146 @@
+/* global Vue */
+/* global partialPageLoad, getConceptURL */
+
+const tabGroupsApp = Vue.createApp({
+  data () {
+    return {
+      groups: [],
+      selectedGroup: '',
+    }
+  },
+  provide () {
+    return {
+      
+    }
+  },
+  mounted () {
+    // Load groups if groups tab is active when the page is first opened (otherwise only load groups when the tab is clicked)
+    if (document.querySelector('#groups > a').classList.contains('active')) {
+      this.loadGroups()
+    }
+  },
+  beforeUpdate () {
+
+  },
+  methods: {
+    handleClickGroupsEvent () {
+      // Only load groups if groups tab is available
+      if (!document.querySelector('#groups > a').classList.contains('disabled')) {
+        this.loadGroups()
+      }
+    },
+    loadGroups () {
+      fetch('rest/v1/' + window.SKOSMOS.vocab + '/groups/?lang=' + window.SKOSMOS.content_lang)
+        .then(data => {
+          return data.json()
+        })
+        .then(data => {
+          const groups = data.groups
+          const result = []
+        
+          // Map groups by uri with group properties for easy lookup
+          const uriMap = new Map()
+          for (const group of groups) {
+            uriMap.set(group.uri, { ...group, childGroups: [], isOpen: false, isGroup: true })
+          }
+
+          // Iterate through groups and set child groups in uriMap
+          for (const group of groups) {
+            if (group.childGroups) {
+              for (const childUri of group.childGroups) {
+                const child = uriMap.get(childUri)
+                if (child) {
+                  uriMap.get(group.uri).childGroups.push(child)
+                }
+              }
+            }
+        
+            // Add top level groups to result list
+            if (!groups.some(other => other.childGroups?.includes(group.uri))) {
+              result.push(uriMap.get(group.uri))
+            }
+          }
+          
+          return {result, uriMap}
+        })
+        .then(({result, uriMap}) => {
+
+          // Check which page we are on
+          if (window.SKOSMOS.uri) {
+            // If we are on concept/group page, set open nodes and load group members
+            this.selectedGroup = window.SKOSMOS.uri
+
+            fetch('rest/v1/' + window.SKOSMOS.vocab + '/groupMembers/?lang=' + window.SKOSMOS.content_lang + '&uri=' + window.SKOSMOS.uri)
+              .then(data => {
+                return data.json()
+              })
+              .then(data => {
+                // Filter out existing groups from members list and add the correct properties
+                const members = data.members
+                  .filter(m => !uriMap.has(m.uri))
+                  .map(m => {
+                    return {...m, childGroups: [], isOpen: false, isGroup: false }
+                  })
+                console.log(members)
+
+                // Set isOpen to true for the selected group and its parents and add child members to selected group
+                this.setIsOpenAndAddMembers(result, this.selectedGroup, members)
+
+                this.groups = result
+                console.log("groups", this.groups)
+              })
+          } else {
+            // If we are on vocab home page, just set groups
+            this.groups = result
+            console.log("groups", this.groups)
+          }
+        })
+    },
+    setIsOpenAndAddMembers (tree, selectedGroup, members) {
+      // Recursive function to find selected group and set its properties
+      const findAndSet = node => {
+        if (node.uri === selectedGroup) {
+          // If selected group was found, set this group to open, add members to it and return true
+          node.isOpen = true
+          node.childGroups.push(...members)
+          return true
+        }
+
+        for (const child of node.childGroups) {
+          // Recursively call findAndSet for all children
+          if (findAndSet(child)) {
+            // If selected group was found in children, set this group to open and return true 
+            node.isOpen = true
+            return true
+          }
+        }
+
+        // If selected group was not found, return false
+        return false
+      }
+  
+      for (const root of tree) {
+        findAndSet(root)
+      }
+    }
+  },
+  template: `
+    <div v-click-tab-groups="handleClickGroupsEvent">
+    </div>
+  `
+})
+
+/* Custom directive used to add an event listener on clicks on the groups nav-item element */
+tabGroupsApp.directive('click-tab-groups', {
+  beforeMount: (el, binding) => {
+    el.clickTabEvent = event => {
+      binding.value() // calling the method given as the attribute value (handleClickGroupsEvent)
+    }
+    document.querySelector('#groups').addEventListener('click', el.clickTabEvent) // registering an event listener on clicks on the groups nav-item element
+  },
+  unmounted: el => {
+    document.querySelector('#groups').removeEventListener('click', el.clickTabEvent)
+  }
+})
+
+tabGroupsApp.mount('#tab-groups')

--- a/resource/js/tab-groups.js
+++ b/resource/js/tab-groups.js
@@ -25,7 +25,7 @@ const tabGroupsApp = Vue.createApp({
     }
   },
   beforeUpdate () {
-
+    this.setListStyle()
   },
   methods: {
     handleClickGroupsEvent () {
@@ -47,7 +47,7 @@ const tabGroupsApp = Vue.createApp({
 
           const groups = data.groups
           const result = []
-        
+
           // Map groups by uri with group properties for easy lookup
           const uriMap = new Map()
           for (const group of groups) {
@@ -64,17 +64,16 @@ const tabGroupsApp = Vue.createApp({
                 }
               }
             }
-        
+
             // Add top level groups to result list
             if (!groups.some(other => other.childGroups?.includes(group.uri))) {
               result.push(uriMap.get(group.uri))
             }
           }
-          
-          return {result, uriMap}
-        })
-        .then(({result, uriMap}) => {
 
+          return { result, uriMap }
+        })
+        .then(({ result, uriMap }) => {
           // Check that we are on a group page
           if (uriMap.has(window.SKOSMOS.uri)) {
             this.selectedGroup = window.SKOSMOS.uri
@@ -91,7 +90,7 @@ const tabGroupsApp = Vue.createApp({
                   const members = data.members
                     .filter(m => !uriMap.has(m.uri))
                     .map(m => {
-                      return {...m, childGroups: [], isOpen: false, isGroup: false }
+                      return { ...m, childGroups: [], isOpen: false, isGroup: false }
                     })
 
                   // Set isOpen to true for the selected group and its parents and add child members to selected group
@@ -99,7 +98,7 @@ const tabGroupsApp = Vue.createApp({
 
                   this.groups = result
                   this.loadingGroups = false
-                  console.log("groups", this.groups)
+                  console.log('groups', this.groups)
                 })
             } else {
               // If selected concept has no members, set isOpen for it and its parents
@@ -107,13 +106,13 @@ const tabGroupsApp = Vue.createApp({
 
               this.groups = result
               this.loadingGroups = false
-              console.log("groups", this.groups)
-            } 
+              console.log('groups', this.groups)
+            }
           } else {
             // If we are on vocab home page, simply set groups to previous result
             this.groups = result
             this.loadingGroups = false
-            console.log("groups", this.groups)
+            console.log('groups', this.groups)
           }
         })
     },
@@ -130,7 +129,7 @@ const tabGroupsApp = Vue.createApp({
         for (const child of node.childGroups) {
           // Recursively call findAndSet for all children
           if (findAndSet(child)) {
-            // If selected group was found in children, set this group to open and return true 
+            // If selected group was found in children, set this group to open and return true
             node.isOpen = true
             return true
           }
@@ -139,7 +138,7 @@ const tabGroupsApp = Vue.createApp({
         // If selected group was not found, return false
         return false
       }
-  
+
       for (const root of tree) {
         findAndSet(root)
       }
@@ -148,7 +147,7 @@ const tabGroupsApp = Vue.createApp({
       // TODO: set list style when mounting component and resizing window
     },
     loadChildren (group) {
-      // Load child groups only if group has children and they have not been loaded yet
+      // Load children only if group has children and they have not been loaded yet
       if (group.childGroups.length === 0 && group.hasMembers) {
         this.loadingChildren.push(group)
         fetch('rest/v1/' + window.SKOSMOS.vocab + '/groupMembers/?lang=' + window.SKOSMOS.content_lang + '&uri=' + group.uri)
@@ -158,7 +157,7 @@ const tabGroupsApp = Vue.createApp({
           .then(data => {
             console.log('data', data)
             for (const m of data.members) {
-              group.childGroups.push({...m, childGroups: [], isOpen: false, isGroup: false})
+              group.childGroups.push({ ...m, childGroups: [], isOpen: false, isGroup: false })
             }
             this.loadingChildren = this.loadingChildren.filter(x => x !== group)
             console.log('groups', this.groups)

--- a/resource/js/tab-groups.js
+++ b/resource/js/tab-groups.js
@@ -6,11 +6,16 @@ const tabGroupsApp = Vue.createApp({
     return {
       groups: [],
       selectedGroup: '',
+      loadingGroups: true,
+      loadingChildGroups: [],
+      listStyle: {}
     }
   },
   provide () {
     return {
-      
+      partialPageLoad,
+      getConceptURL,
+      showNotation: window.SKOSMOS.showNotation
     }
   },
   mounted () {
@@ -30,11 +35,16 @@ const tabGroupsApp = Vue.createApp({
       }
     },
     loadGroups () {
+      this.loadingGroups = true
       fetch('rest/v1/' + window.SKOSMOS.vocab + '/groups/?lang=' + window.SKOSMOS.content_lang)
         .then(data => {
           return data.json()
         })
         .then(data => {
+          console.log('groups data', data)
+
+          this.groups = []
+
           const groups = data.groups
           const result = []
         
@@ -75,6 +85,7 @@ const tabGroupsApp = Vue.createApp({
                 return data.json()
               })
               .then(data => {
+                console.log('members data', data)
                 // Filter out existing groups from members list and add the correct properties
                 const members = data.members
                   .filter(m => !uriMap.has(m.uri))
@@ -87,11 +98,13 @@ const tabGroupsApp = Vue.createApp({
                 this.setIsOpenAndAddMembers(result, this.selectedGroup, members)
 
                 this.groups = result
+                this.loadingGroups = false
                 console.log("groups", this.groups)
               })
           } else {
-            // If we are on vocab home page, just set groups
+            // If we are on vocab home page, simply set groups
             this.groups = result
+            this.loadingGroups = false
             console.log("groups", this.groups)
           }
         })
@@ -122,10 +135,28 @@ const tabGroupsApp = Vue.createApp({
       for (const root of tree) {
         findAndSet(root)
       }
+    },
+    setListStyle () {
+      // TODO: set list style when mounting component and resizing window
+    },
+    loadChildGroups () {
+
     }
   },
   template: `
-    <div v-click-tab-groups="handleClickGroupsEvent">
+    <div v-click-tab-groups="handleClickGroupsEvent" v-resize-window="setListStyle">
+      <div id="groups-list" class="sidebar-list p-0" :style="listStyle">
+        <ul v-if="!loadingGroups" class="list-group">
+          <tab-groups-wrapper
+            :groups="groups"
+            :selectedGroup="selectedGroup"
+            :loadingChildGroups="loadingChildGroups"
+            @load-child-groups="loadChildGroups($event)"
+            @select-group="selectedGroup = $event"
+          ></tab-groups-wrapper>
+        </ul>
+        <i v-else class="fa-solid fa-spinner fa-spin-pulse"></i>
+      </div>
     </div>
   `
 })
@@ -141,6 +172,111 @@ tabGroupsApp.directive('click-tab-groups', {
   unmounted: el => {
     document.querySelector('#groups').removeEventListener('click', el.clickTabEvent)
   }
+})
+
+/* Custom directive used to add an event listener on resizing the window */
+tabGroupsApp.directive('resize-window', {
+  beforeMount: (el, binding) => {
+    el.resizeWindowEvent = event => {
+      binding.value() // calling the method given as the attribute value (setListStyle)
+    }
+    window.addEventListener('resize', el.resizeWindowEvent) // registering an event listener on resizing the window
+  },
+  unmounted: el => {
+    window.removeEventListener('resize', el.resizeWindowEvent)
+  }
+})
+
+tabGroupsApp.component('tab-groups-wrapper', {
+  props: ['groups', 'selectedGroup', 'loadingChildGroups'],
+  emits: ['loadChildGroups', 'selectGroup'],
+  mounted () {
+  },
+  methods: {
+    loadChildGroups (group) {
+      this.$emit('loadChildGroups', group)
+    },
+    selectGroup (group) {
+      this.$emit('selectGroup', group)
+    }
+  },
+  template: `
+    <template v-for="(g, i) in groups" >
+      <tab-groups
+        :group="g"
+        :selectedGroup="selectedGroup"
+        :isTopGroup="true"
+        :isLast="i == groups.length - 1"
+        :loadingChildGroups="loadingChildGroups"
+        @load-child-groups="loadChildGroups($event)"
+        @select-group="selectGroup($event)"
+      ></tab-groups>
+    </template>
+  `
+})
+
+tabGroupsApp.component('tab-groups', {
+  props: ['group', 'selectedGroup', 'isTopGroup', 'isLast', 'loadingChildGroups'],
+  emits: ['loadChildGroups', 'selectGroup'],
+  inject: ['partialPageLoad', 'getConceptURL', 'showNotation'],
+  methods: {
+    handleClickOpenEvent (group) {
+      group.isOpen = !group.isOpen
+      this.$emit('loadChildGroups', group)
+    },
+    handleClickGroupEvent (event, group) {
+      group.isOpen = true
+      this.$emit('loadChildGroups', group)
+      this.$emit('selectGroup', group.uri)
+      this.partialPageLoad(event, this.getConceptURL(group.uri))
+    },
+    loadChildGroupsRecursive (group) {
+      this.$emit('loadChildGroups', group)
+    },
+    selectGroupRecursive (group) {
+      this.$emit('selectGroup', group)
+    }
+  },
+  template: `
+    <li class="list-group-item p-0" :class="{ 'top-concept': isTopGroup }">
+      <button type="button" class="hierarchy-button btn btn-primary" aria-label="Open"
+        :class="{ 'open': group.isOpen }"
+        v-if="group.hasMembers"
+        @click="handleClickOpenEvent(group)"
+      >
+        <template v-if="loadingChildGroups.includes(group)">
+          <i class="fa-solid fa-spinner fa-spin-pulse"></i>
+        </template>
+        <template v-else>
+          <img v-if="group.isOpen" alt="" src="resource/pics/black-lower-right-triangle.png">
+          <img v-else alt="" src="resource/pics/lower-right-triangle.png">
+        </template>
+      </button>
+      <span class="concept-label" :class="{ 'last': isLast }">
+        <a :class="{ 'selected': selectedGroup === group.uri }"
+          :href="getConceptURL(group.uri)"
+          @click="handleClickGroupEvent($event, group)"
+          aria-label="Go to the concept page"
+        >
+          <span v-if="showNotation && group.notation" class="concept-notation">{{ group.notation }} </span>
+          {{ group.prefLabel }}
+        </a>
+      </span>
+      <ul class="list-group ps-3" v-if="group.childGroups.length !== 0 && group.isOpen">
+        <template v-for="(g, i) in group.childGroups">
+          <tab-groups
+            :group="g"
+            :selectedGroup="selectedGroup"
+            :isTopGroup="false"
+            :isLast="i == group.childGroups.length - 1"
+            :loadingChildGroups="loadingChildGroups"
+            @load-child-groups="loadChildGroupsRecursive($event)"
+            @select-group="selectGroupRecursive($event)"
+          ></tab-groups>
+        </template>
+      </ul>
+    </li>
+  `
 })
 
 tabGroupsApp.mount('#tab-groups')

--- a/src/controller/WebController.php
+++ b/src/controller/WebController.php
@@ -478,13 +478,7 @@ class WebController extends Controller
         $vocab = $request->getVocab();
 
         $defaultView = $vocab->getConfig()->getDefaultSidebarView();
-        // load template
-        if ($defaultView === 'groups') {
-            $this->invokeGroupIndex($request, true);
-            return;
-        } elseif ($defaultView === 'new') {
-            $this->invokeChangeList($request);
-        }
+
         $pluginParameters = json_encode($vocab->getConfig()->getPluginParameters());
 
         $template = $this->twig->load('vocab-home.twig');

--- a/src/view/scripts.inc.twig
+++ b/src/view/scripts.inc.twig
@@ -107,6 +107,7 @@ window.SKOSMOS = {
 <script src="resource/js/concept-mappings.js"></script>
 <script src="resource/js/tab-alpha.js"></script>
 <script src="resource/js/tab-hierarchy.js"></script>
+<script src="resource/js/tab-groups.js"></script>
 <script src="resource/js/vocab-search.js"></script>
 
 <!-- Other (non-Vue) JS functionality -->


### PR DESCRIPTION
## Reasons for creating this PR

Groups view has not been implemented in the sidebar in Skosmos 3. This PR adds the groups view with basic functionality using Vue.

## Link to relevant issue(s), if any

- Closes #1710
- Part of #1704 

## Description of the changes in this PR

- Removing sidebar template loading on vocab home page in web controller
- Adding basic functionality of the groups view
  - Loading groups and building hierarchy tree on vocab home, concept and group pages
  - Loading new members for groups on button click
  - Displaying hierarchy tree in UI

Addresses requirement 1 ( + 2, 3.2, 3.3 and 3.5)  in #1704

## Known problems or uncertainties in this PR

## Checklist

- [ ] phpUnit tests pass locally with my changes
- [ ] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [ ] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [ ] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
