### PR TITLE
Upgrade to PHPUnit 10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "symfony/twig-bundle": "6.4.*"
   },
   "require-dev": {
-    "phpunit/phpunit": "9.6.*",
+    "phpunit/phpunit": "10.5.*",
     "symfony/dom-crawler": "6.4.*",
     "symfony/config": "6.4.*",
     "symfony/runtime": "6.4.*",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,14 +1,9 @@
 <?xml version="1.0"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" bootstrap="tests/bootstrap.php" processIsolation="true" convertDeprecationsToExceptions="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-  <coverage processUncoveredFiles="true">
-    <include>
-      <directory suffix=".php">src/controller</directory>
-      <directory suffix=".php">src/model</directory>
-      <directory suffix=".php">src/model/sparql</directory>
-    </include>
-    <exclude>
-      <directory>vendor</directory>
-    </exclude>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" bootstrap="tests/bootstrap.php" processIsolation="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" cacheDirectory=".phpunit.cache">
+  <php>
+    <ini name="date.timezone" value="UTC"/>
+  </php>
+  <coverage>
     <report>
       <clover outputFile="build/logs/clover.xml"/>
       <html outputDirectory="./report" lowUpperBound="35" highLowerBound="70"/>
@@ -20,4 +15,14 @@
       <directory suffix=".php">tests</directory>
     </testsuite>
   </testsuites>
+  <source>
+    <include>
+      <directory suffix=".php">src/controller</directory>
+      <directory suffix=".php">src/model</directory>
+      <directory suffix=".php">src/model/sparql</directory>
+    </include>
+    <exclude>
+      <directory>vendor</directory>
+    </exclude>
+  </source>
 </phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -12,7 +12,7 @@
   <logging/>
   <testsuites>
     <testsuite name="tests">
-      <directory suffix=".php">tests</directory>
+      <directory>tests</directory>
     </testsuite>
   </testsuites>
   <source>

--- a/src/model/resolver/LOCResource.php
+++ b/src/model/resolver/LOCResource.php
@@ -16,6 +16,9 @@ class LOCResource extends RemoteResource
                                           'timeout' => $timeout));
             $context  = stream_context_create($opts);
             $fd = fopen($this->uri, 'rb', false, $context);
+            if ($fd === false) {
+                return null;
+            }
             $headers = stream_get_meta_data($fd)['wrapper_data'];
             foreach ($headers as $header) {
                 if (strpos(strtolower($header), 'x-preflabel:') === 0) {

--- a/tests/ConceptPropertyValueLiteralTest.php
+++ b/tests/ConceptPropertyValueLiteralTest.php
@@ -61,22 +61,22 @@ class ConceptPropertyValueLiteralTest extends PHPUnit\Framework\TestCase
      */
     public function testGetLabelThatIsABrokenDate()
     {
-        set_error_handler(function ($code, $message) {
-            throw new \PHPUnit\Framework\Error($message,$code);
-        });
+        set_error_handler(
+            static function ( $errno, $errstr ) {
+                restore_error_handler();
+                throw new Exception( $errstr, $errno );
+            },
+            E_ALL
+        );
 
-        try {
-            $vocab = $this->model->getVocabulary('dates');
+        $vocab = $this->model->getVocabulary('dates');
 
-            $this->expectException(\PHPUnit\Framework\Error::class);
-            $this->expectExceptionMessage("Failed to parse time string (1986-21-00) at position 6 (1): Unexpected character");
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage("Failed to parse time string (1986-21-00) at position 6 (1): Unexpected character");
 
-            $concept = $vocab->getConceptInfo("http://www.skosmos.skos/date/d2", "en");
-            $props = $concept->getProperties();
-            $propvals = $props['http://www.skosmos.skos/date/ownDate']->getValues();
-        } finally {
-            restore_error_handler();
-        }
+        $concept = $vocab->getConceptInfo("http://www.skosmos.skos/date/d2", "en");
+        $props = $concept->getProperties();
+        $propvals = $props['http://www.skosmos.skos/date/ownDate']->getValues();
     }
 
     /**

--- a/tests/ConceptPropertyValueLiteralTest.php
+++ b/tests/ConceptPropertyValueLiteralTest.php
@@ -64,14 +64,14 @@ class ConceptPropertyValueLiteralTest extends PHPUnit\Framework\TestCase
         set_error_handler(
             static function ( $errno, $errstr ) {
                 restore_error_handler();
-                throw new Exception( $errstr, $errno );
+                throw new UserWarning( $errstr, $errno );
             },
             E_ALL
         );
 
         $vocab = $this->model->getVocabulary('dates');
 
-        $this->expectException(Exception::class);
+        $this->expectException(UserWarning::class);
         $this->expectExceptionMessage("Failed to parse time string (1986-21-00) at position 6 (1): Unexpected character");
 
         $concept = $vocab->getConceptInfo("http://www.skosmos.skos/date/d2", "en");

--- a/tests/ConceptTest.php
+++ b/tests/ConceptTest.php
@@ -315,14 +315,14 @@ class ConceptTest extends PHPUnit\Framework\TestCase
         set_error_handler(
             static function ( $errno, $errstr ) {
                 restore_error_handler();
-                throw new Exception( $errstr, $errno );
+                throw new UserWarning( $errstr, $errno );
             },
             E_ALL
         );
 
         $vocab = $this->model->getVocabulary('test');
 
-        $this->expectException(Exception::class);
+        $this->expectException(UserWarning::class);
         $this->expectExceptionMessage("Failed to parse time string (1986-21-00) at position 6 (1): Unexpected character");
 
         $concept = $vocab->getConceptInfo("http://www.skosmos.skos/test/ta114", "en");

--- a/tests/ConceptTest.php
+++ b/tests/ConceptTest.php
@@ -227,7 +227,8 @@ class ConceptTest extends PHPUnit\Framework\TestCase
     {
         $vocab = $this->model->getVocabulary('duplicates');
         $concept = $vocab->getConceptInfo("http://www.skosmos.skos/dup/d3", "en");
-        $props = $concept->getMappingProperties();
+        // suppress fsockopen PHP warnings caused by trying to resolve www.skosmos.skos
+        @$props = $concept->getMappingProperties();
         $values = $props['skos:closeMatch']->getValues();
         $this->assertCount(2, $values);
     }

--- a/tests/ConceptTest.php
+++ b/tests/ConceptTest.php
@@ -312,22 +312,21 @@ class ConceptTest extends PHPUnit\Framework\TestCase
      */
     public function testGetTimestampInvalidWarning()
     {
-        set_error_handler(function ($code, $message) {
-            throw new \PHPUnit\Framework\Error($message, $code);
-        });
+        set_error_handler(
+            static function ( $errno, $errstr ) {
+                restore_error_handler();
+                throw new Exception( $errstr, $errno );
+            },
+            E_ALL
+        );
 
-        try {
-            $vocab = $this->model->getVocabulary('test');
+        $vocab = $this->model->getVocabulary('test');
 
-            $this->expectException(\PHPUnit\Framework\Error::class);
-            $this->expectExceptionMessage("Failed to parse time string (1986-21-00) at position 6 (1): Unexpected character");
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage("Failed to parse time string (1986-21-00) at position 6 (1): Unexpected character");
 
-            $concept = $vocab->getConceptInfo("http://www.skosmos.skos/test/ta114", "en");
-            $concept->getDate(); # this should throw an ErrorException
-
-        } finally {
-            restore_error_handler();
-        }
+        $concept = $vocab->getConceptInfo("http://www.skosmos.skos/test/ta114", "en");
+        $concept->getDate(); # this should throw an ErrorException
     }
 
     /**
@@ -612,7 +611,7 @@ class ConceptTest extends PHPUnit\Framework\TestCase
      * Data provider for testGetModifiedDate test method.
      * @return array
      */
-    public function modifiedDateDataProvider()
+    public static function modifiedDateDataProvider()
     {
         return [
           ["cat", "2018-12-13T06:28:14", "+00:00"],  # set #0

--- a/tests/ResolverTest.php
+++ b/tests/ResolverTest.php
@@ -19,7 +19,8 @@ class ResolverTest extends PHPUnit\Framework\TestCase
     public function testResolveLOCZeroTimeout()
     {
         $uri = "http://id.loc.gov/authorities/subjects/sh85016673"; // LCSH: Breakwaters
-        $resource = $this->resolver->resolve($uri, 0);
+        // use @ to suppress the timeout warning
+        @$resource = $this->resolver->resolve($uri, 0);
         $this->assertNull($resource);
     }
 
@@ -32,7 +33,8 @@ class ResolverTest extends PHPUnit\Framework\TestCase
     public function testResolveWDQSZeroTimeout()
     {
         $uri = "http://www.wikidata.org/entity/Q42"; // Wikidata: Douglas Adams
-        $resource = $this->resolver->resolve($uri, 0);
+        // use @ to suppress the timeout warning
+        @$resource = $this->resolver->resolve($uri, 0);
         $this->assertNull($resource);
     }
 
@@ -45,7 +47,8 @@ class ResolverTest extends PHPUnit\Framework\TestCase
     public function testResolveLDZeroTimeout()
     {
         $uri = "http://paikkatiedot.fi/so/1000772/10048472"; // PNR: Ahlainen
-        $resource = $this->resolver->resolve($uri, 0);
+        // use @ to suppress the timeout warning
+        @$resource = $this->resolver->resolve($uri, 0);
         $this->assertNull($resource);
     }
 

--- a/tests/RestControllerTest.php
+++ b/tests/RestControllerTest.php
@@ -26,13 +26,15 @@ class RestControllerTest extends \PHPUnit\Framework\TestCase
      */
     public function testDataAsJson()
     {
+        ob_start();
+
         $request = new Request($this->model);
         $request->setQueryParam('format', 'application/json');
         $request->setURI('http://www.skosmos.skos/test/ta117');
         $request->setVocab("test");
         $this->controller->data($request);
 
-        $out = $this->getActualOutput();
+        $out = ob_get_clean();
 
         $expected = <<<EOD
 {
@@ -150,12 +152,14 @@ EOD;
      */
     public function testSearchJsonLd()
     {
+        ob_start();
+
         $request = new Request($this->model);
         $request->setQueryParam('format', 'application/json');
         $request->setQueryParam('query', '*bass');
         $this->controller->search($request);
 
-        $out = $this->getActualOutput();
+        $out = ob_get_clean();
 
         $expected = <<<EOD
 {
@@ -217,13 +221,15 @@ EOD;
      */
     public function testSearchJsonLdWithAdditionalFields()
     {
+        ob_start();
+
         $request = new Request($this->model);
         $request->setQueryParam('format', 'application/json');
         $request->setQueryParam('query', '*bass');
         $request->setQueryParam('fields', 'broader relatedMatch');
         $this->controller->search($request);
 
-        $out = $this->getActualOutput();
+        $out = ob_get_clean();
 
         $expected = <<<EOD
 {
@@ -305,7 +311,7 @@ EOD;
     /**
      * Data provider for testSearchWithZero test.
      */
-    public function provideSearchWithZeroData(): array
+    public static function provideSearchWithZeroData(): array
     {
         return [
           ['0', true],
@@ -325,13 +331,16 @@ EOD;
      */
     public function testSearchWithZero(string $query, bool $isSuccess)
     {
+        ob_start();
+
         $request = new Request($this->model);
         $request->setQueryParam('format', 'application/json');
         $request->setQueryParam('query', $query);
         $request->setQueryParam('fields', 'broader relatedMatch');
         $this->controller->search($request);
 
-        $out = $this->getActualOutput();
+        $out = ob_get_clean();
+
         if ($isSuccess) {
             $this->assertStringNotContainsString("400 Bad Request", $out, "The REST search call returned an unexpected 400 bad request error!");
         } else {
@@ -344,12 +353,14 @@ EOD;
      */
     public function testIndexLettersJsonLd()
     {
+        ob_start();
+
         $request = new Request($this->model);
         $request->setVocab('test');
         $request->setLang('en');
         $this->controller->indexLetters($request);
 
-        $out = $this->getActualOutput();
+        $out = ob_get_clean();
 
         $expected = <<<EOD
 {
@@ -385,12 +396,14 @@ EOD;
      */
     public function testIndexConceptsJsonLd()
     {
+        ob_start();
+
         $request = new Request($this->model);
         $request->setVocab('test');
         $request->setLang('en');
         $this->controller->indexConcepts("B", $request);
 
-        $out = $this->getActualOutput();
+        $out = ob_get_clean();
 
         $expected = <<<EOD
 {
@@ -435,13 +448,15 @@ EOD;
      */
     public function testIndexConceptsJsonLdLimit()
     {
+        ob_start();
+
         $request = new Request($this->model);
         $request->setVocab('test');
         $request->setLang('en');
         $request->setQueryParam('limit', '2');
         $this->controller->indexConcepts("B", $request);
 
-        $out = $this->getActualOutput();
+        $out = ob_get_clean();
 
         $expected = <<<EOD
 {
@@ -480,13 +495,15 @@ EOD;
      */
     public function testIndexConceptsJsonLdOffset()
     {
+        ob_start();
+
         $request = new Request($this->model);
         $request->setVocab('test');
         $request->setLang('en');
         $request->setQueryParam('offset', '1');
         $this->controller->indexConcepts("B", $request);
 
-        $out = $this->getActualOutput();
+        $out = ob_get_clean();
 
         $expected = <<<EOD
 {
@@ -525,6 +542,8 @@ EOD;
      */
     public function testIndexConceptsJsonLdLimitOffset()
     {
+        ob_start();
+
         $request = new Request($this->model);
         $request->setVocab('test');
         $request->setLang('en');
@@ -532,7 +551,7 @@ EOD;
         $request->setQueryParam('offset', '1');
         $this->controller->indexConcepts("B", $request);
 
-        $out = $this->getActualOutput();
+        $out = ob_get_clean();
 
         $expected = <<<EOD
 {
@@ -565,6 +584,8 @@ EOD;
      */
     public function testLabelOnePrefOneAltLabel()
     {
+        ob_start();
+
         $request = new Request($this->model);
         $request->setQueryParam('format', 'application/json');
         $request->setURI('http://www.skosmos.skos/test/ta112');
@@ -572,7 +593,7 @@ EOD;
         $request->setLang('en');
 
         $this->controller->label($request);
-        $out = $this->getActualOutput();
+        $out = ob_get_clean();
 
         $expected = <<<EOD
  {"@context": {
@@ -599,13 +620,15 @@ EOD;
      */
     public function testLabelGlobal()
     {
+        ob_start();
+
         $request = new Request($this->model);
         $request->setQueryParam('format', 'application/json');
         $request->setURI('http://www.skosmos.skos/test/ta112');
         $request->setLang('en');
 
         $this->controller->label($request);
-        $out = $this->getActualOutput();
+        $out = ob_get_clean();
 
         $expected = <<<EOD
  {"@context": {
@@ -632,13 +655,15 @@ EOD;
      */
     public function testLabelGlobalNonexistentVocab()
     {
+        ob_start();
+
         $request = new Request($this->model);
         $request->setQueryParam('format', 'application/json');
         $request->setURI('http://www.skosmos.skos/nonexistent/vocab');
         $request->setLang('en');
 
         $this->controller->label($request);
-        $out = $this->getActualOutput();
+        $out = ob_get_clean();
 
         $expected = "404 Not Found : Could not find concept <http://www.skosmos.skos/nonexistent/vocab>";
         $this->assertEquals($expected, $out);
@@ -649,6 +674,8 @@ EOD;
      */
     public function testLabelOnePrefOneHiddenLabel()
     {
+        ob_start();
+
         $request = new Request($this->model);
         $request->setQueryParam('format', 'application/json');
         $request->setURI('http://www.skosmos.skos/test/ta112');
@@ -656,7 +683,7 @@ EOD;
         $request->setLang('fi');
 
         $this->controller->label($request);
-        $out = $this->getActualOutput();
+        $out = ob_get_clean();
 
         $expected = <<<EOD
  {"@context": {
@@ -683,6 +710,8 @@ EOD;
      */
     public function testLabelOnePrefLabel()
     {
+        ob_start();
+
         $request = new Request($this->model);
         $request->setQueryParam('format', 'application/json');
         $request->setURI('http://www.skosmos.skos/test/ta111');
@@ -690,7 +719,7 @@ EOD;
         $request->setLang('en');
 
         $this->controller->label($request);
-        $out = $this->getActualOutput();
+        $out = ob_get_clean();
 
         $expected = <<<EOD
  {"@context": {
@@ -714,6 +743,8 @@ EOD;
      */
     public function testLabelNoPrefLabel()
     {
+        ob_start();
+
         $request = new Request($this->model);
         $request->setQueryParam('format', 'application/json');
         $request->setURI('http://www.skosmos.skos/test/ta111');
@@ -721,7 +752,7 @@ EOD;
         $request->setLang('sv');
 
         $this->controller->label($request);
-        $out = $this->getActualOutput();
+        $out = ob_get_clean();
 
         $expected = <<<EOD
  {"@context": {
@@ -744,6 +775,8 @@ EOD;
      */
     public function testLabelNoConcept()
     {
+        ob_start();
+
         $request = new Request($this->model);
         $request->setQueryParam('format', 'application/json');
         $request->setURI('http://www.skosmos.skos/test/nonexistent');
@@ -751,7 +784,7 @@ EOD;
         $request->setLang('en');
 
         $this->controller->label($request);
-        $out = $this->getActualOutput();
+        $out = ob_get_clean();
 
         $expected = "404 Not Found : Could not find concept <http://www.skosmos.skos/test/nonexistent>";
         $this->assertEquals($expected, $out);
@@ -762,6 +795,8 @@ EOD;
      */
     public function testNewConcepts()
     {
+        ob_start();
+
         $request = new Request($this->model);
         $request->setQueryParam('format', 'application/json');
         $request->setURI('http://www.skosmos.skos/changes');
@@ -771,7 +806,7 @@ EOD;
         $request->setQueryParam('offset', '0');
 
         $this->controller->newConcepts($request);
-        $changeList = $this->getActualOutput();
+        $changeList = ob_get_clean();
 
         $expected = <<<EOD
  {"@context": {
@@ -823,6 +858,8 @@ EOD;
      */
     public function testModifiedConcepts()
     {
+        ob_start();
+
         $request = new Request($this->model);
         $request->setQueryParam('format', 'application/json');
         $request->setURI('http://www.skosmos.skos/test');
@@ -832,7 +869,7 @@ EOD;
         $request->setQueryParam('offset', '0');
 
         $this->controller->modifiedConcepts($request);
-        $changeList = $this->getActualOutput();
+        $changeList = ob_get_clean();
 
         $expected = <<<EOD
 {"@context": {
@@ -857,6 +894,8 @@ EOD;
      */
     public function testDeprecatedChanges()
     {
+        ob_start();
+
         $request = new Request($this->model);
         $request->setQueryParam('format', 'application/json');
         $request->setURI('http://www.skosmos.skos/changes');
@@ -866,7 +905,7 @@ EOD;
         $request->setQueryParam('offset', '0');
 
         $this->controller->modifiedConcepts($request);
-        $changeList = $this->getActualOutput();
+        $changeList = ob_get_clean();
 
         $expected = <<<EOD
 {"@context": {
@@ -895,13 +934,16 @@ EOD;
      */
     public function testVocabularyStatistics()
     {
+        ob_start();
+
         $request = new Request($this->model);
         $request->setQueryParam('format', 'application/json');
         $request->setVocab('test');
         $request->setLang('en');
 
         $this->controller->vocabularyStatistics($request);
-        $statistics = $this->getActualOutput();
+        $statistics = ob_get_clean();
+
         $expected = <<<EOD
 {
   "@context": {

--- a/tests/VocabularyConfigTest.php
+++ b/tests/VocabularyConfigTest.php
@@ -164,17 +164,18 @@ class VocabularyConfigTest extends PHPUnit\Framework\TestCase
      */
     public function testGetDefaultLanguageWhenNotSet()
     {
-        set_error_handler(function ($code, $message) {
-            throw new \PHPUnit\Framework\Error($message, $code);
-        });
-        try {
-            $vocab = $this->model->getVocabulary('testdiff');
-            $this->expectException(\PHPUnit\Framework\Error::class);
-            $this->expectExceptionMessage("Default language for vocabulary 'testdiff' unknown, choosing 'en'.");
-            $lang = $vocab->getConfig()->getDefaultLanguage();
-        } finally {
-            restore_error_handler();
-        }
+        set_error_handler(
+            static function ( $errno, $errstr ) {
+                restore_error_handler();
+                throw new Exception( $errstr, $errno );
+            },
+            E_ALL
+        );
+
+        $vocab = $this->model->getVocabulary('testdiff');
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage("Default language for vocabulary 'testdiff' unknown, choosing 'en'.");
+        $lang = $vocab->getConfig()->getDefaultLanguage();
     }
 
     /**
@@ -217,19 +218,19 @@ class VocabularyConfigTest extends PHPUnit\Framework\TestCase
      */
     public function testGetDataURLsNotGuessable()
     {
-        set_error_handler(function ($code, $message) {
-            throw new \PHPUnit\Framework\Error($message, $code);
-        });
+        set_error_handler(
+            static function ( $errno, $errstr ) {
+                restore_error_handler();
+                throw new Exception( $errstr, $errno );
+            },
+            E_ALL
+        );
 
-        try {
-            $vocab = $this->model->getVocabulary('test');
-            $this->expectException(\PHPUnit\Framework\Error::class);
-            $this->expectExceptionMessage("Could not guess format for <http://skosmos.skos/dump/test/>.");
+        $vocab = $this->model->getVocabulary('test');
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage("Could not guess format for <http://skosmos.skos/dump/test/>.");
 
-            $url = $vocab->getConfig()->getDataURLs();
-        } finally {
-            restore_error_handler();
-        }
+        $url = $vocab->getConfig()->getDataURLs();
     }
 
     /**
@@ -259,21 +260,21 @@ class VocabularyConfigTest extends PHPUnit\Framework\TestCase
      */
     public function testGetDataURLsMarcNotDefined()
     {
-        set_error_handler(function ($code, $message) {
-            throw new \PHPUnit\Framework\Error($message, $code);
-        });
+        set_error_handler(
+            static function ( $errno, $errstr ) {
+                restore_error_handler();
+                throw new Exception( $errstr, $errno );
+            },
+            E_ALL
+        );
 
-        try {
-            $vocab = $this->model->getVocabulary('marc-undefined');
+        $vocab = $this->model->getVocabulary('marc-undefined');
 
-            $this->expectException(\PHPUnit\Framework\Error::class);
-            $this->expectExceptionMessage("Could not guess format for <http://skosmos.skos/dump/test/marc-undefined.mrcx>.");
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage("Could not guess format for <http://skosmos.skos/dump/test/marc-undefined.mrcx>.");
 
-            $url = $vocab->getConfig()->getDataURLs();
-            $this->assertEquals(array(), $url);
-        } finally {
-            restore_error_handler();
-        }
+        $url = $vocab->getConfig()->getDataURLs();
+        $this->assertEquals(array(), $url);
     }
 
     /**
@@ -686,20 +687,20 @@ class VocabularyConfigTest extends PHPUnit\Framework\TestCase
      */
     public function testGetPropertyOrderUnknown()
     {
-        set_error_handler(function ($code, $message) {
-            throw new \PHPUnit\Framework\Error($message, $code);
-        });
+        set_error_handler(
+            static function ( $errno, $errstr ) {
+                restore_error_handler();
+                throw new Exception( $errstr, $errno );
+            },
+            E_ALL
+        );
 
-        try {
-            $vocab = $this->model->getVocabulary('testUnknownPropertyOrder');
-            $this->expectException(\PHPUnit\Framework\Error::class);
-            $this->expectExceptionMessage("Property order for vocabulary 'testUnknownPropertyOrder' unknown, using default order");
+        $vocab = $this->model->getVocabulary('testUnknownPropertyOrder');
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage("Property order for vocabulary 'testUnknownPropertyOrder' unknown, using default order");
 
-            $params = $vocab->getConfig()->getPropertyOrder();
-            $this->assertEquals(VocabularyConfig::DEFAULT_PROPERTY_ORDER, $params);
-        } finally {
-            restore_error_handler();
-        }
+        $params = $vocab->getConfig()->getPropertyOrder();
+        $this->assertEquals(VocabularyConfig::DEFAULT_PROPERTY_ORDER, $params);
     }
 
     /**

--- a/tests/VocabularyConfigTest.php
+++ b/tests/VocabularyConfigTest.php
@@ -167,13 +167,13 @@ class VocabularyConfigTest extends PHPUnit\Framework\TestCase
         set_error_handler(
             static function ( $errno, $errstr ) {
                 restore_error_handler();
-                throw new Exception( $errstr, $errno );
+                throw new UserWarning( $errstr, $errno );
             },
             E_ALL
         );
 
         $vocab = $this->model->getVocabulary('testdiff');
-        $this->expectException(Exception::class);
+        $this->expectException(UserWarning::class);
         $this->expectExceptionMessage("Default language for vocabulary 'testdiff' unknown, choosing 'en'.");
         $lang = $vocab->getConfig()->getDefaultLanguage();
     }
@@ -221,13 +221,13 @@ class VocabularyConfigTest extends PHPUnit\Framework\TestCase
         set_error_handler(
             static function ( $errno, $errstr ) {
                 restore_error_handler();
-                throw new Exception( $errstr, $errno );
+                throw new UserWarning( $errstr, $errno );
             },
             E_ALL
         );
 
         $vocab = $this->model->getVocabulary('test');
-        $this->expectException(Exception::class);
+        $this->expectException(UserWarning::class);
         $this->expectExceptionMessage("Could not guess format for <http://skosmos.skos/dump/test/>.");
 
         $url = $vocab->getConfig()->getDataURLs();
@@ -263,14 +263,14 @@ class VocabularyConfigTest extends PHPUnit\Framework\TestCase
         set_error_handler(
             static function ( $errno, $errstr ) {
                 restore_error_handler();
-                throw new Exception( $errstr, $errno );
+                throw new UserWarning( $errstr, $errno );
             },
             E_ALL
         );
 
         $vocab = $this->model->getVocabulary('marc-undefined');
 
-        $this->expectException(Exception::class);
+        $this->expectException(UserWarning::class);
         $this->expectExceptionMessage("Could not guess format for <http://skosmos.skos/dump/test/marc-undefined.mrcx>.");
 
         $url = $vocab->getConfig()->getDataURLs();
@@ -690,13 +690,13 @@ class VocabularyConfigTest extends PHPUnit\Framework\TestCase
         set_error_handler(
             static function ( $errno, $errstr ) {
                 restore_error_handler();
-                throw new Exception( $errstr, $errno );
+                throw new UserWarning( $errstr, $errno );
             },
             E_ALL
         );
 
         $vocab = $this->model->getVocabulary('testUnknownPropertyOrder');
-        $this->expectException(Exception::class);
+        $this->expectException(UserWarning::class);
         $this->expectExceptionMessage("Property order for vocabulary 'testUnknownPropertyOrder' unknown, using default order");
 
         $params = $vocab->getConfig()->getPropertyOrder();

--- a/tests/WebControllerTest.php
+++ b/tests/WebControllerTest.php
@@ -20,67 +20,67 @@ class WebControllerTest extends TestCase
      * methods that perform the action are abstracted away, this data provider works for both.
      * @return array
      */
-    public function gitAndConfigModifiedDateDataProvider()
+    public static function gitAndConfigModifiedDateDataProvider()
     {
         return [
             # cache disabled
             [
                 false, # cache enabled
                 null, # cached value
-                $this->datetime('01-Feb-2009') # modified date time
+                self::datetime('01-Feb-2009') # modified date time
             ], # set #0
             # cache enabled, but nothing fetched
             [
                 true, # cache enabled
                 null, # cached value
-                $this->datetime('01-Feb-2009') # modified date time
+                self::datetime('01-Feb-2009') # modified date time
             ], # set #1
             # cache enabled, cached value returned
             [
                 true, # cache enabled
-                $this->datetime('01-Feb-2009'), # cached value
+                self::datetime('01-Feb-2009'), # cached value
                 null # modified date time
             ], # set #2
         ];
     }
 
-    public function modifiedDateDataProvider()
+    public static function modifiedDateDataProvider()
     {
         return [
             # concept has the most recent date time
             [
-                $this->datetime('01-Feb-2011'), # concept
-                $this->datetime('01-Feb-2002'), # git
-                $this->datetime('01-Feb-2003'), # config
-                $this->datetime('01-Feb-2011')  # returned
+                self::datetime('01-Feb-2011'), # concept
+                self::datetime('01-Feb-2002'), # git
+                self::datetime('01-Feb-2003'), # config
+                self::datetime('01-Feb-2011')  # returned
             ], # set #0
             # concept has the most recent date time
             [
-                $this->datetime('01-Feb-2011'), # concept
+                self::datetime('01-Feb-2011'), # concept
                 null, # git
-                $this->datetime('01-Feb-2003'), # config
-                $this->datetime('01-Feb-2011')  # returned
+                self::datetime('01-Feb-2003'), # config
+                self::datetime('01-Feb-2011')  # returned
             ], # set #1
             # concept has the most recent date time
             [
-                $this->datetime('01-Feb-2011'), # concept
+                self::datetime('01-Feb-2011'), # concept
                 null, # git
                 null, # config
-                $this->datetime('01-Feb-2011')  # returned
+                self::datetime('01-Feb-2011')  # returned
             ], # set #2
             # git has the most recent date time
             [
-                $this->datetime('01-Feb-2001'), # concept
-                $this->datetime('01-Feb-2012'), # git
-                $this->datetime('01-Feb-2003'), # config
-                $this->datetime('01-Feb-2012')  # returned
+                self::datetime('01-Feb-2001'), # concept
+                self::datetime('01-Feb-2012'), # git
+                self::datetime('01-Feb-2003'), # config
+                self::datetime('01-Feb-2012')  # returned
             ], # set #3
             # config has the most recent date time
             [
-                $this->datetime('01-Feb-2001'), # concept
-                $this->datetime('01-Feb-2002'), # git
-                $this->datetime('01-Feb-2013'), # config
-                $this->datetime('01-Feb-2013')  # returned
+                self::datetime('01-Feb-2001'), # concept
+                self::datetime('01-Feb-2002'), # git
+                self::datetime('01-Feb-2013'), # config
+                self::datetime('01-Feb-2013')  # returned
             ], # set #4
             # no date time found
             [
@@ -97,7 +97,7 @@ class WebControllerTest extends TestCase
      * @param string $string
      * @return bool|DateTime
      */
-    private function datetime(string $string)
+    private static function datetime(string $string)
     {
         return DateTime::createFromFormat("j-M-Y", $string);
     }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -9,12 +9,5 @@ if (!$endpoint) {
     putenv('SKOSMOS_SPARQL_ENDPOINT=http://localhost:9030/skosmos/sparql');
 }
 
-# Allow running git commands in the php-actions/phpunit container
-# (prevent "dubious ownership" error; /app is owned by another user, not root)
-if (getenv('GITHUB_ACTIONS') === 'true') {
-    mkdir('/home/runner');
-    exec('git config --global --add safe.directory /app');
-}
-
 require_once(__DIR__ . '/../vendor/autoload.php');
 require_once(__DIR__ . '/../src/model/Model.php');

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -11,3 +11,7 @@ if (!$endpoint) {
 
 require_once(__DIR__ . '/../vendor/autoload.php');
 require_once(__DIR__ . '/../src/model/Model.php');
+
+class UserWarning extends \Exception {
+    // custom exception class to capture E_USER_WARNING in PHPUnit tests
+}


### PR DESCRIPTION
## Reasons for creating this PR

We need to upgrade to PHPUnit 10; see #1699

## Link to relevant issue(s), if any

- Closes #1699

## Description of the changes in this PR

* bump the phpunit dependency from 9.6.* to 10.5.*
* migrate phpunit.xml configuration to PHPUnit 10 style
* make data provider methods static, as required by PHPUnit 10
* fix RestControllerTest tests that depended on getActualOutput(), which was removed in PHPUnit 10 (use PHP output buffering directly)
* rework error handlers that capture user warnings and check their messages (coined a new UserWarning exception class for this purpose)
* suppress some PHP warnings using `@` operator (these are no longer swallowed by PHPUnit)
* remove stale code from bootstrap.php
* misc other fixes to tests so that they don't trigger warnings

## Known problems or uncertainties in this PR

There might be more elegant ways for e.g. suppressing PHP warnings triggered by test cases.

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
