### PR TITLE
Implement groups view layout and styling

### DIFF
--- a/resource/css/skosmos.css
+++ b/resource/css/skosmos.css
@@ -620,6 +620,19 @@ body {
     font-weight: bold;
   }
 
+  #tab-groups .sidebar-list .list-group-item .concept-label i {
+    color: var(--dark-color);
+    font-size: 14px;
+  }
+
+  #tab-groups .sidebar-list .list-group-item a.child-concept {
+    font-weight: normal !important;
+  }
+
+  #tab-groups .sidebar-list .list-group-item a.child-concept.selected {
+    font-weight: bold !important;
+  }
+
   .hierarchy-button {
     background-color: transparent;
     color: var(--vocab-text);
@@ -637,13 +650,15 @@ body {
     position: absolute;
     left: 11px;
     top: 7px;
+    z-index: 1;
+    font-size: 12px;
   }
 
   .hierarchy-button img {
     transform: rotate(-45deg);
     position: absolute;
     top: 9px;
-    left: 10px;
+    left: 11px;
     width: 7px;
     z-index: 1;
   }

--- a/resource/css/skosmos.css
+++ b/resource/css/skosmos.css
@@ -625,14 +625,6 @@ body {
     font-size: 14px;
   }
 
-  #tab-groups .sidebar-list .list-group-item a.child-concept {
-    font-weight: normal !important;
-  }
-
-  #tab-groups .sidebar-list .list-group-item a.child-concept.selected {
-    font-weight: bold !important;
-  }
-
   .hierarchy-button {
     background-color: transparent;
     color: var(--vocab-text);

--- a/resource/js/tab-alpha.js
+++ b/resource/js/tab-alpha.js
@@ -123,10 +123,10 @@ const tabAlphaApp = Vue.createApp({
 
       // get height and width of pagination and sidebar tabs elements if they exist
       const height = pagination && pagination.clientHeight + sidebarTabs.clientHeight
-      const width = pagination && pagination.clientWidth
+      const width = pagination && pagination.clientWidth - 1
 
       this.listStyle = {
-        height: 'calc(100% - ' + height + 'px)',
+        height: 'calc(100% - ' + height + 'px )',
         width: width + 'px'
       }
     }

--- a/resource/js/tab-groups.js
+++ b/resource/js/tab-groups.js
@@ -144,7 +144,12 @@ const tabGroupsApp = Vue.createApp({
       }
     },
     setListStyle () {
-      // TODO: set list style when mounting component and resizing window
+      const height = document.getElementById('sidebar-tabs').clientHeight
+      const width = document.getElementById('sidebar-tabs').clientWidth - 1
+      this.listStyle = {
+        height: 'calc( 100% - ' + height + 'px )',
+        width: width + 'px'
+      }
     },
     loadChildren (group) {
       // Load children only if group has children and they have not been loaded yet

--- a/resource/js/tab-groups.js
+++ b/resource/js/tab-groups.js
@@ -281,7 +281,7 @@ tabGroupsApp.component('tab-groups', {
       </button>
       <span class="concept-label" :class="{ 'last': isLast }">
         <i v-if="group.isGroup" class="property-hover fa-solid fa-layer-group"></i>
-        <a :class="{ 'selected': selectedGroup === group.uri, 'child-concept': !group.isGroup }"
+        <a :class="{ 'selected': selectedGroup === group.uri }"
           :href="getConceptURL(group.uri)"
           @click="handleClickGroupEvent($event, group)"
           aria-label="Go to the concept page"

--- a/resource/js/tab-groups.js
+++ b/resource/js/tab-groups.js
@@ -275,7 +275,8 @@ tabGroupsApp.component('tab-groups', {
         </template>
       </button>
       <span class="concept-label" :class="{ 'last': isLast }">
-        <a :class="{ 'selected': selectedGroup === group.uri }"
+        <i v-if="group.isGroup" class="property-hover fa-solid fa-layer-group"></i>
+        <a :class="{ 'selected': selectedGroup === group.uri, 'child-concept': !group.isGroup }"
           :href="getConceptURL(group.uri)"
           @click="handleClickGroupEvent($event, group)"
           aria-label="Go to the concept page"

--- a/resource/js/tab-hierarchy.js
+++ b/resource/js/tab-hierarchy.js
@@ -156,9 +156,9 @@ const tabHierApp = Vue.createApp({
     },
     setListStyle () {
       const height = document.getElementById('sidebar-tabs').clientHeight
-      const width = document.getElementById('sidebar-tabs').clientWidth
+      const width = document.getElementById('sidebar-tabs').clientWidth - 1
       this.listStyle = {
-        height: 'calc( 100% - ' + height + 'px)',
+        height: 'calc( 100% - ' + height + 'px )',
         width: width + 'px'
       }
     },


### PR DESCRIPTION
## Reasons for creating this PR

Groups view in the sidebar does not currently have correct styling and sizing in Skosmos 3. This PR addresses that.

## Link to relevant issue(s), if any

- Closes #1727
- Part of #1704

## Description of the changes in this PR

- Adds a new Font Awesome icon for all groups in group view
- Fixes sidebar width and height for groups view (+ width for other sidebar views)

Addresses requirements 3.1, 3.2, 3.4 in #1704

## Known problems or uncertainties in this PR

## Checklist

- [ ] phpUnit tests pass locally with my changes
- [ ] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [ ] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [ ] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
