### PR TITLE
Simplify search page URL construction

### DIFF
--- a/resource/js/vocab-search.js
+++ b/resource/js/vocab-search.js
@@ -172,11 +172,9 @@ const vocabSearch = Vue.createApp({
     gotoSearchPage () {
       if (!this.searchTerm) return
 
-      const currentVocab = window.SKOSMOS.vocab + '/' + window.SKOSMOS.lang + '/'
-      const vocabHref = window.location.href.substring(0, window.location.href.lastIndexOf(window.SKOSMOS.vocab)) + currentVocab
       const searchUrlParams = new URLSearchParams({ clang: window.SKOSMOS.content_lang, q: this.searchTerm })
       if (this.selectedLanguage === 'all') searchUrlParams.set('anylang', 'true')
-      const searchUrl = vocabHref + 'search?' + searchUrlParams.toString()
+      const searchUrl = window.SKOSMOS.vocab + '/' + window.SKOSMOS.lang + '/search?' + searchUrlParams.toString()
       window.location.href = searchUrl
     },
     changeLang (clang) {


### PR DESCRIPTION
## Reasons for creating this PR

When performing a search using the search widget, construction of the URL fails in some cases (see #1703). This PR fixes the bug by simplifying the URL construction, avoiding the use of string replace operations that caused the bug.

## Link to relevant issue(s), if any

- Closes #1703

## Description of the changes in this PR

* simplify search page URL construction, avoid string replace

## Known problems or uncertainties in this PR

I didn't make a Cypress test. I figured that since the bug is being removed by mostly removing code, there is no need for a new test. But you could argue otherwise.

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
