### PR TITLE
Upgrade to EasyRdf 1.14.0, fixing some mocked resources

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "version": "3.0-dev",
   "require": {
-    "sweetrdf/easyrdf": "1.13.*",
+    "sweetrdf/easyrdf": "1.14.0",
     "symfony/polyfill-php80": "1.*",
     "symfony/polyfill-php81": "1.*",
     "twig/twig": "3.14.*",

--- a/tests/ConceptMappingPropertyValueTest.php
+++ b/tests/ConceptMappingPropertyValueTest.php
@@ -81,8 +81,8 @@ class ConceptMappingPropertyValueTest extends PHPUnit\Framework\TestCase
         $mocksource = $this->getMockBuilder('EasyRdf\Resource')->disableOriginalConstructor()->getMock();
         $mockres = $this->getMockBuilder('EasyRdf\Resource')->disableOriginalConstructor()->getMock();
         $labelmap = array(
-          array('en', 'english'),
-          array(null, 'default')
+          array('en', [], 'english'),
+          array(null, [], 'default')
         );
         $mockres->method('label')->will($this->returnValueMap($labelmap));
         $mockres->method('getUri')->will($this->returnValue('http://thisdoesntexistatalland.sefsf/2j2h4/'));

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -599,8 +599,8 @@ test:ta125
     {
         $mockres = $this->getMockBuilder('EasyRdf\Resource')->disableOriginalConstructor()->getMock();
         $labelmap = array(
-          array('en', null),
-          array(null, 'test value')
+          array('en', [], null),
+          array(null, [], 'test value')
         );
         $mockres->method('label')->will($this->returnValueMap($labelmap));
         $this->assertEquals('test value', $this->model->getResourceLabel($mockres, 'en'));
@@ -613,8 +613,8 @@ test:ta125
     {
         $mockres = $this->getMockBuilder('EasyRdf\Resource')->disableOriginalConstructor()->getMock();
         $labelmap = array(
-          array('en', 'test value'),
-          array('fi', 'testiarvo')
+          array('en', [], 'test value'),
+          array('fi', [], 'testiarvo')
         );
         $mockres->method('label')->will($this->returnValueMap($labelmap));
         $this->assertEquals('test value', $this->model->getResourceLabel($mockres, 'en'));


### PR DESCRIPTION
## Reasons for creating this PR

We should use recent versions of EasyRdf (see #1700). This PR upgrades EasyRdf from 1.13.1 to 1.14.0, fixing some mock resources in the test suite according to changes in that release.

This isn't the latest version of EasyRdf, but the next release 1.14.1 changes some Accept headers used in SPARQL CONSTRUCT queries. It appears that those changes are not compatible with the (rather old) Jena 4.8.0 version of Fuseki we are using, so going any further probably requires upgrading Fuseki as well. The most recent EasyRdf release currently is 1.15.0.

## Link to relevant issue(s), if any

- Closes #1700 (maybe)

## Description of the changes in this PR

* bump the EasyRdf dependency to 1.14.0
* fix some mocked resources in tests

## Known problems or uncertainties in this PR

Is this enough for now, or should we aim for 1.14.1 or 1.15.0 (the current newest release)?

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
