### PR TITLE
Highlight currently selected concept in alphabetical list sidebar

### DIFF
--- a/resource/css/skosmos.css
+++ b/resource/css/skosmos.css
@@ -605,6 +605,7 @@ body {
     margin-left: 1px !important; /* add a 1px margin to offset missing border */
   }
 
+  #tab-alphabetical .sidebar-list .list-group-item a.selected,
   #tab-hierarchy .sidebar-list .list-group-item a.selected,
   #tab-groups .sidebar-list .list-group-item a.selected {
     color: var(--vocab-text) !important;


### PR DESCRIPTION
## Reasons for creating this PR

The currently selected concept in the alphabetical index sidebar should be highlighted according to the design spec.
This one line CSS change implements this (issue #1563 task 1a).

## Link to relevant issue(s), if any

- Part of #1563

## Description of the changes in this PR

Modify CSS to make sure the currently selected concept is highlighted in the alphabetical index.

## Known problems or uncertainties in this PR

None

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
