### PR TITLE
[WIP] Responsive layout for the concept page

### DIFF
--- a/resource/css/skosmos.css
+++ b/resource/css/skosmos.css
@@ -341,6 +341,10 @@ body {
 
   /* Main container
    *****************************************/
+  .container {
+    max-width: 1460px !important;
+  }
+
   #main-container {
     font-size: 16px;
   }
@@ -959,12 +963,6 @@ body {
     color: var(--vocab-link);
     text-decoration: underline var(--secondary-medium-color) solid;
     font-weight: 700;
-  }
-
-  @media (min-width: 1200px) {
-    .container {
-      max-width: 1460px !important;
-    }
   }
 
   #alphabetical-menu > .list-group > .list-group-item {

--- a/resource/css/skosmos.css
+++ b/resource/css/skosmos.css
@@ -716,7 +716,7 @@ body {
 
   #concept-heading {
     margin-top: 2rem;
-    padding-bottom: 4rem;
+    padding-bottom: 2.5rem;
   }
 
   .property {

--- a/resource/js/concept-mappings.js
+++ b/resource/js/concept-mappings.js
@@ -60,12 +60,12 @@ const conceptMappingsApp = Vue.createApp({
   template: `
     <div v-load-concept-page="loadMappings">
       <template v-if="loading">
-        <div class="main-content-section p-5">
+        <div class="main-content-section px-5 py-4">
           <i class="fa-solid fa-spinner fa-spin-pulse"></i>
         </div>
       </template>
       <template v-else-if="hasMappings">
-        <div class="main-content-section p-5">
+        <div class="main-content-section px-5 py-4">
           <concept-mappings :mappings="mappings" :customLabels="customLabels"></concept-mappings>
         </div>
       </template>
@@ -92,19 +92,19 @@ conceptMappingsApp.component('concept-mappings', {
   template: `
     <div class="row property prop-mapping" v-for="(mapping, label) in mappings">
       <template v-if="customLabels">
-        <div class="col-sm-4 px-0 property-label" :title="customLabels[mapping[0].type[0]][1] || mapping[0].description">
+        <div class="col-lg-4 ps-0 property-label" :title="customLabels[mapping[0].type[0]][1] || mapping[0].description">
           <h2>{{ customLabels[mapping[0].type[0]][0] }}</h2>
         </div>
       </template>
       <template v-else>
-        <div class="col-sm-4 px-0 property-label" :title="mapping[0].description"><h2>{{ label }}</h2></div>
+        <div class="col-lg-4 ps-0 property-label" :title="mapping[0].description"><h2>{{ label }}</h2></div>
       </template>
-      <div class="col-sm-8">
+      <div class="col-lg-8 gx-0 gx-lg-4">
         <div class="row mb-2" v-for="m in mapping">
-          <div class="col-sm-5 prop-mapping-label">
+          <div class="col-5 prop-mapping-label">
             <a :href="m.hrefLink">{{ m.prefLabel }}</a><span v-if="m.lang && m.lang !== this.content_lang"> ({{ m.lang }})</span>
           </div>
-          <div class="col-sm-7 prop-mapping-vocab">{{ m.vocabName }}</div>
+          <div class="col-7 prop-mapping-vocab">{{ m.vocabName }}</div>
         </div>
       </div>
     </div>

--- a/src/view/concept-card.inc.twig
+++ b/src/view/concept-card.inc.twig
@@ -27,7 +27,7 @@
       {% endif %}
 
       <div class="row" id="concept-heading">
-        <div class="col-sm-4 px-0" id="concept-property-label">
+        <div class="col-lg-4 ps-0" id="concept-property-label">
         {%- set label = custom_labels['skos:prefLabel']['label'][request.lang] -%}
         {%- if label -%}
           {{ label[:1]|upper ~ label[1:] }} {# Capitalizing labels #}
@@ -35,7 +35,7 @@
           {{ "skos:prefLabel" | trans }}
         {%- endif -%}
         </div>
-        <div class="col-sm-8" id="concept-label">
+        <div class="col-lg-8 gx-0 gx-lg-4" id="concept-label">
         {% if concept.hasXlLabel %}
           {% set descriptionId = 'concept-preflabel-xl' %}
           {{ include('xl-label.inc.twig', {xlLabel: concept.xlLabel, xlDescriptionId: descriptionId}) }}
@@ -63,7 +63,7 @@
 
       {% for property in concept.properties %}{% if property.getSubPropertyOf != 'skos:hiddenLabel' %}
       <div class="row property prop-{{property.ID}}">
-        <div class="col-sm-4 px-0 property-label"><h2>
+        <div class="col-lg-4 ps-0 property-label"><h2>
         {%- set label = custom_labels[property.type]['label'][request.lang] -%}
         {%- if label -%}
           {{ label[:1]|upper ~ label[1:] }} {# Capitalizing labels #}
@@ -71,7 +71,7 @@
           {{ property.label }}
         {%- endif -%}
         </h2></div>
-        <div class="col-sm-8 align-self-center property-value">
+        <div class="col-lg-8 gx-0 gx-lg-4 align-self-center property-value">
           <ul class="align-bottom">
           {% for propval in property.values %}
             {% if propval.uri and property.type != 'rdf:type' %} {# resources with URI #}
@@ -104,12 +104,12 @@
       {% set foreignLabels = concept.foreignLabels %}
       {% if foreignLabels %}
       <div class="row property prop-foreignlabels">
-        <div class="col-sm-4 px-0 property-label"><h2>{{ 'foreign prefLabels'|trans }}</h2></div>
-        <div class="col-sm-8" id="concept-other-languages">
+        <div class="col-lg-4 ps-0 property-label"><h2>{{ 'foreign prefLabels'|trans }}</h2></div>
+        <div class="col-lg-8 gx-0 gx-lg-4" id="concept-other-languages">
           {% for language,labels in foreignLabels %}
           <div class="row">
-            <div class="col-sm-7 order-last"><h3>{{ language }}</h3></div>
-            <div class="col-sm-5">
+            <div class="col-7 order-last"><h3>{{ language }}</h3></div>
+            <div class="col-5">
               <ul>
                 {% for value in labels.prefLabel|default([])|merge(labels.altLabel|default([])) %}
                 <li>
@@ -136,8 +136,8 @@
       </div>
       {% endif %}
       <div class="row property prop-uri">
-        <div class="col-sm-4 px-0 property-label"><h2>URI</h2></div>
-        <div class="col-sm-8">
+        <div class="col-lg-4 ps-0 property-label"><h2>URI</h2></div>
+        <div class="col-lg-8 gx-0 gx-lg-4">
           <span id="concept-uri"
                 class="user-select-all">{{ concept.uri }}</span><button
                   class="btn btn-default copy-clipboard px-1" type="button" id="copy-uri"
@@ -147,10 +147,10 @@
         </div>
       </div>
       <div class="row property prop-download">
-        <div class="col-sm-4 px-0 property-label">
+        <div class="col-lg-4 ps-0 property-label">
           <h2><i class="fa-solid fa-download"></i> {{ "Download this concept" | trans }}</h2>
         </div>
-        <div class="col-sm-8" id="download-links">
+        <div class="col-lg-8 gx-0 gx-lg-4" id="download-links">
           <ul>
             <li>
               <a class="me-3" href="rest/v1/{{ vocab.id }}/data?uri={{ concept.uri|url_encode }}&amp;format=application/rdf%2Bxml">RDF/XML</a>

--- a/src/view/concept-card.inc.twig
+++ b/src/view/concept-card.inc.twig
@@ -107,7 +107,7 @@
         <div class="col-lg-4 ps-0 property-label"><h2>{{ 'foreign prefLabels'|trans }}</h2></div>
         <div class="col-lg-8 gx-0 gx-lg-4" id="concept-other-languages">
           {% for language,labels in foreignLabels %}
-          <div class="row">
+          <div class="row mb-2">
             <div class="col-7 order-last"><h3>{{ language }}</h3></div>
             <div class="col-5">
               <ul>


### PR DESCRIPTION
## Reasons for creating this PR

The concept page renders badly in a narrow browser window - see #1739.
This PR contains fixes to make it more responsive. The main target is to make the concept page render sensibly in a half-width browser window, typically around 900px wide.

Here's how this looks currently in a 900px wide Firefox window:

![image](https://github.com/user-attachments/assets/42905e56-ce48-4054-8f6f-e5aabb3b5075)


## Link to relevant issue(s), if any

- Closes #1739

## Description of the changes in this PR

* avoid grey margins on the sides that take up extra space
* make property/value display on the concept page responsive (it will switch to another layout at the `lg` breakpoint i.e. below 992px)

## Known problems or uncertainties in this PR

n/a

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
