### PR TITLE
Implementing new and deprecated view basic functionality using Vue

### DIFF
--- a/resource/css/skosmos.css
+++ b/resource/css/skosmos.css
@@ -461,11 +461,11 @@ body {
     font-weight: bold;
   }
 
+  /*** Sidebar termpage & vocabpage ***/
   #sidebar {
     background-color: var(--vocab-bg);
   }
 
-  /*** Sidebar termpage & vocabpage ***/
   #main-container.vocabpage #sidebar-col, #main-container.termpage #sidebar-col {
     background-color: var(--vocab-bg);
     background-clip: content-box, padding-box;
@@ -555,6 +555,23 @@ body {
     font-weight: bold !important;
   }
 
+  .sidebar-list a.selected {
+    color: var(--vocab-text) !important;
+  }
+
+  /*** sidebar changes tab ***/
+  #tab-changes .sidebar-list h2 {
+    color: var(--vocab-text);
+    font-size: 20px;
+    font-weight: bold;
+    margin: 0;
+  }
+
+  /* All headings except first */
+  #tab-changes .sidebar-list li + li h2 {
+    margin-top: 1.5rem !important;
+  }
+
   /*** sidebar hierarchy and groups tabs ***/
   #tab-hierarchy .sidebar-list .list-group-item,
   #tab-groups .sidebar-list .list-group-item {
@@ -606,12 +623,6 @@ body {
   #tab-groups .sidebar-list .list-group-item span.last + ul > li  {
     border: none;
     margin-left: 1px !important; /* add a 1px margin to offset missing border */
-  }
-
-  #tab-alphabetical .sidebar-list .list-group-item a.selected,
-  #tab-hierarchy .sidebar-list .list-group-item a.selected,
-  #tab-groups .sidebar-list .list-group-item a.selected {
-    color: var(--vocab-text) !important;
   }
 
   #tab-hierarchy .sidebar-list .list-group-item .concept-notation,

--- a/resource/js/tab-changes.js
+++ b/resource/js/tab-changes.js
@@ -54,7 +54,14 @@ function startChangesApp () {
             const changesByDate = new Map()
             for (const concept of data.changeList) {
               const date = new Date(concept.date)
-              const key = date.toLocaleString(window.SKOSMOS.lang, { month: 'long', year: 'numeric' })
+              let key = date.toLocaleString(window.SKOSMOS.lang, { month: 'long', year: 'numeric' })
+
+              // Reverse Northern Sami word order (year month -> month year)
+              if (window.SKOSMOS.lang === 'se') {
+                key = key.split(' ').reverse().join(' ')
+              }
+              // Capitalize month name
+              key = key.charAt(0).toUpperCase() + key.slice(1)
 
               if (!changesByDate.get(key)) {
                 changesByDate.set(key, [])

--- a/resource/js/tab-changes.js
+++ b/resource/js/tab-changes.js
@@ -55,11 +55,6 @@ function startChangesApp () {
             for (const concept of data.changeList) {
               const date = new Date(concept.date)
               let key = date.toLocaleString(window.SKOSMOS.lang, { month: 'long', year: 'numeric' })
-
-              // Reverse Northern Sami word order (year month -> month year)
-              if (window.SKOSMOS.lang === 'se') {
-                key = key.split(' ').reverse().join(' ')
-              }
               // Capitalize month name
               key = key.charAt(0).toUpperCase() + key.slice(1)
 

--- a/resource/js/tab-changes.js
+++ b/resource/js/tab-changes.js
@@ -1,0 +1,176 @@
+/* global Vue, $t */
+/* global partialPageLoad, getConceptURL */
+
+function startChangesApp () {
+  const tabChangesApp = Vue.createApp({
+    data () {
+      return {
+        changedConcepts: new Map(),
+        selectedConcept: '',
+        loadingConcepts: false,
+        listStyle: {}
+      }
+    },
+    computed: {
+      loadingMessage () {
+        return $t('Loading more items')
+      }
+    },
+    provide () {
+      return {
+        partialPageLoad,
+        getConceptURL
+      }
+    },
+    mounted () {
+      // load changes if changes tab is active when the page is first opened (otherwise only load the changes when the tab is clicked)
+      if (document.querySelector('#changes > a').classList.contains('active')) {
+        this.loadChanges()
+      }
+    },
+    beforeUpdate () {
+      this.setListStyle()
+    },
+    methods: {
+      handleClickChangesEvent () {
+        // only load changes the first time the page is opened or if selected concept has changed
+        if (this.changedConcepts.length === 0 || this.selectedConcept !== window.SKOSMOS.uri) {
+          this.changedConcepts = new Map()
+          this.selectedConcept = ''
+          this.loadChanges()
+        }
+      },
+      loadChanges () {
+        this.loadingConcepts = true
+        fetch('rest/v1/' + window.SKOSMOS.vocab + '/new?lang=' + window.SKOSMOS.content_lang + '&limit=200')
+          .then(data => {
+            return data.json()
+          })
+          .then(data => {
+            console.log('data', data)
+
+            // Group concepts by month and year
+            // Using a map instead of an object because maps maintain original insertion order
+            const changesByDate = new Map()
+            for (const concept of data.changeList) {
+              const date = new Date(concept.date)
+              const key = date.toLocaleString(window.SKOSMOS.lang, { month: 'long', year: 'numeric' })
+
+              if (!changesByDate.get(key)) {
+                changesByDate.set(key, [])
+              }
+
+              changesByDate.get(key).push(concept)
+            }
+
+            this.changedConcepts = changesByDate
+            this.loadingConcepts = false
+            console.log('changes', this.changedConcepts)
+          })
+      },
+      setListStyle () {
+        const height = document.getElementById('sidebar-tabs').clientHeight
+        const width = document.getElementById('sidebar-tabs').clientWidth - 1
+        this.listStyle = {
+          height: 'calc( 100% - ' + height + 'px )',
+          width: width + 'px'
+        }
+      }
+    },
+    template: `
+      <div v-click-tab-changes="handleClickChangesEvent">
+        <tab-changes
+          :changed-concepts="changedConcepts"
+          :selected-concept="selectedConcept"
+          :loading-concepts="loadingConcepts"
+          :loading-message="loadingMessage"
+          :list-style="listStyle"
+          @select-concept="selectedConcept = $event"
+        ></tab-changes>
+      </div>
+    `
+  })
+
+  /* Custom directive used to add an event listener on clicks on the changes nav-item element */
+  tabChangesApp.directive('click-tab-changes', {
+    beforeMount: (el, binding) => {
+      el.clickTabEvent = event => {
+        binding.value() // calling the method given as the attribute value (loadChanges)
+      }
+      document.querySelector('#changes').addEventListener('click', el.clickTabEvent) // registering an event listener on clicks on the changes nav-item element
+    },
+    unmounted: el => {
+      document.querySelector('#changes').removeEventListener('click', el.clickTabEvent)
+    }
+  })
+
+  tabChangesApp.component('tab-changes', {
+    props: ['changedConcepts', 'selectedConcept', 'loadingConcepts', 'loadingMessage', 'listStyle'],
+    inject: ['partialPageLoad', 'getConceptURL'],
+    emits: ['selectConcept'],
+    methods: {
+      loadConcept (event, uri) {
+        partialPageLoad(event, getConceptURL(uri))
+        this.$emit('selectConcept', uri)
+      }
+    },
+    template: `
+      <div class="sidebar-list pt-3" :style="listStyle">
+        <template v-if="loadingConcepts">
+          <div>
+            {{ loadingMessage }} <i class="fa-solid fa-spinner fa-spin-pulse"></i>
+          </div>
+        </template>
+        <template v-else>
+          <ul class="list-group" v-if="changedConcepts.length !== 0">
+            <template v-for="[month, concepts] in changedConcepts">
+              <li class="list-group-item py-1 px-2">
+                <h2 class="pb-1">{{ month }}</h2>
+              </li>
+              <li v-for="concept in concepts" class="list-group-item py-1 px-2">
+                <template v-if="concept.replacedBy">
+                  <a :class="{ 'selected': selectedConcept === concept.uri }"
+                    :href="getConceptURL(concept.uri)"
+                    @click="loadConcept($event, concept.uri)"
+                    aria-label="go to the concept page"
+                  >
+                    <s>{{ concept.prefLabel }}</s>
+                  </a>
+                  <i class="fa-solid fa-arrow-right"></i>
+                  <a :class="{ 'selected': selectedConcept === concept.replacedBy }"
+                    :href="getConceptURL(concept.replacedBy)"
+                    @click="loadConcept($event, concept.replacedBy)"
+                    aria-label="go to the concept page"
+                  >
+                    {{ concept.replacingLabel }}
+                  </a>
+                </template>
+                <template v-else>
+                  <a :class="{ 'selected': selectedConcept === concept.uri }"
+                    :href="getConceptURL(concept.uri)"
+                    @click="loadConcept($event, concept.uri)"
+                    aria-label="go to the concept page"
+                  >
+                    {{ concept.prefLabel }}
+                  </a>
+                </template>
+              </li>
+            </template>
+          </ul>
+        </template>
+      </div>
+    `
+  })
+
+  tabChangesApp.mount('#tab-changes')
+}
+
+const waitForTranslationServiceTabChanges = () => {
+  if (typeof $t !== 'undefined') {
+    startChangesApp()
+  } else {
+    setTimeout(waitForTranslationServiceTabChanges, 50)
+  }
+}
+
+waitForTranslationServiceTabChanges()

--- a/src/view/scripts.inc.twig
+++ b/src/view/scripts.inc.twig
@@ -93,6 +93,7 @@ window.SKOSMOS = {
 <script src="resource/js/tab-alpha.js"></script>
 <script src="resource/js/tab-hierarchy.js"></script>
 <script src="resource/js/tab-groups.js"></script>
+<script src="resource/js/tab-changes.js"></script>
 <script src="resource/js/vocab-search.js"></script>
 
 <!-- Other (non-Vue) JS functionality -->

--- a/tests/cypress/template/sidebar-changes.cy.js
+++ b/tests/cypress/template/sidebar-changes.cy.js
@@ -1,0 +1,76 @@
+describe('New and removed view', () => {
+  it('Loads changes on tab open', () => {
+    // Go to changes vocab home page
+    cy.visit('/changes/en/')
+    // Click on changes tab
+    cy.get('#changes').click()
+    // Check that changes list exists and has the right concepts
+    cy.get('#tab-changes').find('.sidebar-list li a').should('have.length', 6).first().invoke('text').should('contain', 'No replacement')
+    // Check that loading spinner does not exist
+    cy.get('#tab-changes .sidebar-list i.fa-spinner').should('not.exist')
+  })
+  it('Loads changes on page load', () => {
+    // Go to home page of vocab with changes view as default sidebar view
+    cy.visit('/changesDefaultView/en/')
+    // Check that changes list exists and has the right concepts
+    cy.get('#tab-changes').find('.sidebar-list li a').should('have.length', 6).first().invoke('text').should('contain', 'No replacement')
+    // Check that loading spinner does not exist
+    cy.get('#tab-changes .sidebar-list i.fa-spinner').should('not.exist')
+  })
+  it('Groups concepts based on date in chronological order', () => {
+    // Go to home page of vocab with changes view as default sidebar view
+    cy.visit('/changesDefaultView/en/')
+    // Check that headings exist and are in chronological order
+    cy.get('#tab-changes').find('.sidebar-list li h2').should('have.length', 4).eq(0).invoke('text').should('contain', 'February 2021')
+    cy.get('#tab-changes').find('.sidebar-list li h2').eq(1).invoke('text').should('contain', 'January 2021')
+  })
+  it('Shows deprecated concepts', () => {
+    // Go to home page of vocab with changes view as default sidebar view
+    cy.visit('/changesDefaultView/en/')
+    // Check that an s element exists and has the correct label
+    cy.get('#tab-changes').find('.sidebar-list li a s').invoke('text').should('contain', 'Fourth date')
+  })
+  it('Displays concepts and headings in the correct language', () => {
+    // Go to YSO home page with UI language set to English and content language set to Finnish
+    cy.visit('/yso/en/?clang=fi')
+    // Click on changes tab
+    cy.get('#changes').click()
+    // Check that headings exist and are in the correct language
+    cy.get('#tab-changes').find('.sidebar-list li h2').eq(0).invoke('text').should('contain', 'September 2023')
+    // Check that concepts are in the correct language
+    cy.get('#tab-changes').find('.sidebar-list li a').eq(0).invoke('text').should('contain', 'irtolöydöt')
+  })
+  it('Performs partial page load when clicking on concept', () => {
+    // go to the YSO home page in English language
+    cy.visit('/yso/en/')
+    // Click on changes tab
+    cy.get('#changes').click()
+    // click on the link "Bell beaker culture" (should trigger partial page load)
+    cy.get('#tab-changes').contains('a', 'Bell beaker culture').click()
+
+    // check the concept prefLabel
+    cy.get('#concept-heading h1', {'timeout': 15000}).invoke('text').should('equal', 'Bell beaker culture')
+
+    // check that the SKOSMOS object matches the newly loaded concept
+    cy.window().then((win) => {
+      expect(win.SKOSMOS.uri).to.equal('http://www.yso.fi/onto/yso/p40009');
+      expect(win.SKOSMOS.prefLabels[0]['label']).to.equal("Bell beaker culture");
+    })
+
+    // check that we have some mappings
+    cy.get('#concept-mappings').should('not.be.empty')
+    // check that loading spinner does not exist
+    cy.get('#concept-mappings i.fa-spinner', {'timeout': 15000}).should('not.exist')
+
+    // check mapping property name
+    cy.get('.prop-mapping h2', {'timeout': 20000}).eq(0).contains('Closely matching concepts')
+    // check the mapping property values
+    cy.get('.prop-mapping').eq(0).find('.prop-mapping-label').eq(0).find('a').invoke('text').should('equal', 'Bell beaker culture')
+    cy.get('.prop-mapping').eq(0).find('.prop-mapping-label').eq(0).find('a').should('have.attr', 'href', 'http://id.loc.gov/authorities/subjects/sh87007797')
+    cy.get('.prop-mapping').eq(0).find('.prop-mapping-vocab').eq(0).contains('Library of Congress Subject Headings')
+    // check that mapping property has the right number of entries
+    cy.get('.prop-mapping').eq(0).find('.prop-mapping-label').should('have.length', 2)
+    // check that mappings have the right number of properties
+    cy.get('.prop-mapping h2').should('have.length', 2)
+  })
+})

--- a/tests/testconfig.ttl
+++ b/tests/testconfig.ttl
@@ -325,6 +325,15 @@
 	skosmos:showDeprecatedChanges true ;
 	skosmos:sparqlGraph <http://www.skosmos.skos/changes/> .
 
+:changesDefaultView a skosmos:Vocabulary, void:Dataset ;
+	dc11:title "A vocabulary for testing the change list creation with changes as default view"@en ;
+	dc:subject :cat_general ;
+	void:uriSpace "http://www.skosmos.skos/changes/";
+	skosmos:language "en";
+	skosmos:showDeprecatedChanges true ;
+    skosmos:defaultSidebarView "changes" ;
+	skosmos:sparqlGraph <http://www.skosmos.skos/changes/> .
+
 :prefix a skosmos:Vocabulary, void:Dataset ;
 	dc11:title "A vocabulary for testing custom prefixes"@en ;
 	dc:subject :cat_general ;


### PR DESCRIPTION
## Reasons for creating this PR

The new and deprecated view in the sidebar is not currently implemented in Skosmos 3. This PR adds basic functionality for it.

## Link to relevant issue(s), if any

- Closes #1746
- Part of #1735

## Description of the changes in this PR

- Load change list from API and group concepts by date
- Display changes in UI
- Add CSS styles for changes view + minor refactor to CSS
- Add cypress tests for changes view

Addresses requirements 3, 5, 6, 9, 12, 13, 16, 19 and 20 in #1735

## Known problems or uncertainties in this PR

This implementation uses the javascript function `toLocaleString` of `Date` objects to fetch month names. It seems to work correctly for Finnish, English and Swedish but it is unclear if it is sufficient for all languages.

## Checklist

- [ ] phpUnit tests pass locally with my changes
- [ ] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [ ] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [ ] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
