### PR TITLE
Responsive layout for the vocabulary home page + layout adjustments

### DIFF
--- a/resource/css/skosmos.css
+++ b/resource/css/skosmos.css
@@ -717,11 +717,18 @@ body {
   .main-content-section {
     background-color: var(--vocab-bg);
     margin-bottom: .2rem;
+    padding-left: 3.5rem;
+    padding-right: 3.5rem;
   }
 
   #concept-heading, #vocab-heading {
     margin-top: 2rem;
     padding-bottom: 2.5rem;
+  }
+
+  #vocab-heading, .vocab-statistics, #vocab-download-links {
+    margin-left: -.75rem;
+    margin-right: -.75rem;
   }
 
   .property {

--- a/resource/css/skosmos.css
+++ b/resource/css/skosmos.css
@@ -719,7 +719,7 @@ body {
     margin-bottom: .2rem;
   }
 
-  #concept-heading {
+  #concept-heading, #vocab-heading {
     margin-top: 2rem;
     padding-bottom: 2.5rem;
   }

--- a/resource/css/skosmos.css
+++ b/resource/css/skosmos.css
@@ -347,11 +347,16 @@ body {
 
   #main-container {
     font-size: 16px;
+    padding-top: 2.75rem;
   }
 
   #main-container h1 {
     font-family: var(--font-family-heading);
     font-weight: bold;
+  }
+
+  #main-container-row {
+    --bs-gutter-x: 2.25rem;
   }
 
   /***** Main container frontpage & frontpage one vocab *****/

--- a/resource/js/concept-mappings.js
+++ b/resource/js/concept-mappings.js
@@ -60,12 +60,12 @@ const conceptMappingsApp = Vue.createApp({
   template: `
     <div v-load-concept-page="loadMappings">
       <template v-if="loading">
-        <div class="main-content-section px-5 py-4">
+        <div class="main-content-section py-4">
           <i class="fa-solid fa-spinner fa-spin-pulse"></i>
         </div>
       </template>
       <template v-else-if="hasMappings">
-        <div class="main-content-section px-5 py-4">
+        <div class="main-content-section py-4">
           <concept-mappings :mappings="mappings" :customLabels="customLabels"></concept-mappings>
         </div>
       </template>

--- a/src/view/base-template.twig
+++ b/src/view/base-template.twig
@@ -93,12 +93,12 @@
     </div>
     {% endif %}
   </header>
-  <main id="main-container" class="{% if request.vocabid == '' or global_search %} frontpage{% elseif concept_uri != '' %} termpage{% elseif request.vocab != '' %} vocabpage{% if list_style %} {{ list_style }}{% endif %}{% endif %} py-5">
+  <main id="main-container" class="{% if request.vocabid == '' or global_search %} frontpage{% elseif concept_uri != '' %} termpage{% elseif request.vocab != '' %} vocabpage{% if list_style %} {{ list_style }}{% endif %}{% endif %}">
     <div class="container">
       <noscript>
         <strong>We're sorry but Skosmos doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>
       </noscript>
-      <div class="row" tabindex="-1">
+      <div id="main-container-row" class="row" tabindex="-1">
       {% block content %}
       {% endblock %}
       </div>

--- a/src/view/concept-card.inc.twig
+++ b/src/view/concept-card.inc.twig
@@ -1,6 +1,6 @@
 <div class="col-md-8" id="main-content">
 
-    <div class="main-content-section px-5 py-4">
+    <div class="main-content-section py-4">
 
       {% if visible_breadcrumbs and visible_breadcrumbs[0]|length > 1 %}
       <nav class="row" id="concept-breadcrumbs" aria-label='{{ "Breadcrumbs" | trans }}'>

--- a/src/view/vocab-info.inc.twig
+++ b/src/view/vocab-info.inc.twig
@@ -1,5 +1,5 @@
 <div class="col-md-8" id="main-content">
-  <div class="main-content-section px-5 py-4">
+  <div class="main-content-section py-4">
     <h1 id="vocab-heading">{{ "Vocabulary information" | trans }}</h1>
 
     {% set vocabInfo = vocab.info(request.contentLang) %}
@@ -10,7 +10,7 @@
     {% else %}
 
     {% for key, values in vocabInfo %}
-    <div class="row property g-0">
+    <div class="row property">
       <div class="col-lg-4 ps-0 property-label"><h2>{{ key | trans }}</h2></div>
       <div class="col-lg-8 gx-0 gx-lg-4 align-self-center property-value">
         <ul class="align-bottom">
@@ -45,7 +45,7 @@
     {% endif %}
 
     {% if vocab.config.dataURLs %}
-    <div class="row g-0 py-3">
+    <div class="row py-3" id="vocab-download-links">
       <div class="col-sm-12 px-0 property-label" id="download-links">
         <h2><i class="fa-solid fa-download"></i> {{ "Download this vocabulary:" | trans }}</h2>
         <ul class="d-inline">

--- a/src/view/vocab-info.inc.twig
+++ b/src/view/vocab-info.inc.twig
@@ -11,8 +11,8 @@
 
     {% for key, values in vocabInfo %}
     <div class="row property g-0">
-      <div class="col-sm-4 px-0 property-label"><h2>{{ key | trans }}</h2></div>
-      <div class="col-sm-8 align-self-center property-value">
+      <div class="col-lg-4 ps-0 property-label"><h2>{{ key | trans }}</h2></div>
+      <div class="col-lg-8 gx-0 gx-lg-4 align-self-center property-value">
         <ul class="align-bottom">
           {% for val in values %}
           <li>

--- a/src/view/vocab-info.inc.twig
+++ b/src/view/vocab-info.inc.twig
@@ -1,6 +1,6 @@
 <div class="col-md-8" id="main-content">
   <div class="main-content-section px-5 py-4">
-    <h1 class="pt-3 pb-5">{{ "Vocabulary information" | trans }}</h1>
+    <h1 id="vocab-heading">{{ "Vocabulary information" | trans }}</h1>
 
     {% set vocabInfo = vocab.info(request.contentLang) %}
     {% if not vocabInfo %}

--- a/src/view/vocab-search.twig
+++ b/src/view/vocab-search.twig
@@ -4,7 +4,7 @@
 {% block url %}{{ BaseHref }}{{ request.langurl }}{% endblock %}
 
 {% block content %}
-<main class="searchpage py-5" id="main-container" >
+<main class="searchpage" id="main-container">
   <div class="container">
     <div class="row">
       {% include "search-results-filter.inc.twig" %}


### PR DESCRIPTION
## Reasons for creating this PR

The vocabulary home page renders badly in a narrow browser window. This was noted in #1739 which was fixed in PR #1742, but only for the concept page. This PR does a similar adjustment to the vocabulary home page.

Additionally, this adjusts the gutters, padding and margins for both the vocabulary home page and the concept page so that they better match each other and the visual specification.

Here's how the vocabulary home page looks in a narrowish (~900px) browser window:

![image](https://github.com/user-attachments/assets/cf794a89-2a2b-4d6f-acb6-cbec1f78766f)

## Link to relevant issue(s), if any

- part of #1684 

## Description of the changes in this PR

- make the grey gutters between columns a bit larger, and the grey bar above main content a bit narrower, trying to match the visual spec (but this depends a lot on the browser; I mainly used Firefox)
- make property/value columns on the vocabulary home page responsive
- various small margin/padding/gutter adjustments, mainly for the vocabulary home page but also some for the concept page

## Known problems or uncertainties in this PR

I hope I didn't break layouts on other page types.

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
