### PR TITLE
Global Search twig-template

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Thesaurus and controlled vocabulary browser using SKOS and SPARQL",
   "type": "project",
   "license": "MIT",
-  "version": "3.0-dev",
+  "version": "v3.0-alpha.1",
   "require": {
     "sweetrdf/easyrdf": "1.13.*",
     "symfony/polyfill-php80": "1.*",

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Thesaurus and controlled vocabulary browser using SKOS and SPARQL",
   "type": "project",
   "license": "MIT",
-  "version": "v3.0-alpha.1",
+  "version": "3.0-alpha.1",
   "require": {
     "sweetrdf/easyrdf": "1.13.*",
     "symfony/polyfill-php80": "1.*",

--- a/resource/css/skosmos.css
+++ b/resource/css/skosmos.css
@@ -88,7 +88,7 @@ body {
   #main-container.global-search .list-group .fa-solid, #main-container.global-search .list-group .fa-regular {
     color: var(--vocab-text);
     font-size: 1.15rem;
-    width: 20px;
+    width: 1.5rem;
     text-align: center;
   }
 
@@ -191,8 +191,8 @@ body {
     font-family: var(--font-family-heading);
   }
 
-  #search-multi-vocab {
-    width: 800px;
+  #global-search-wrapper {
+    max-width: 1200px;
   }
 
   #search-wrapper {

--- a/resource/css/skosmos.css
+++ b/resource/css/skosmos.css
@@ -79,12 +79,12 @@ body {
     margin: 0 5px;
   }
 
-  #main-container.searchpage .fa-arrow-right, #main-container.global-search .fa-arrow-right {
+  #main-container.vocab-search .fa-arrow-right, #main-container.global-search .fa-arrow-right {
     color: var(--vocab-text);
     font-size: .85rem;
   }
 
-  #main-container.searchpage .list-group .fa-solid, #main-container.searchpage .list-group .fa-regular,
+  #main-container.vocab-search .list-group .fa-solid, #main-container.vocab-search .list-group .fa-regular,
   #main-container.global-search .list-group .fa-solid, #main-container.global-search .list-group .fa-regular {
     color: var(--vocab-text);
     font-size: 1.15rem;

--- a/resource/css/skosmos.css
+++ b/resource/css/skosmos.css
@@ -79,12 +79,13 @@ body {
     margin: 0 5px;
   }
 
-  #main-container.vocab-search  .fa-arrow-right {
+  #main-container.searchpage .fa-arrow-right, #main-container.global-search .fa-arrow-right {
     color: var(--vocab-text);
     font-size: .85rem;
   }
 
-  #main-container.vocab-search .list-group .fa-solid, #main-container.vocab-search  .list-group .fa-regular {
+  #main-container.searchpage .list-group .fa-solid, #main-container.searchpage .list-group .fa-regular,
+  #main-container.global-search .list-group .fa-solid, #main-container.global-search .list-group .fa-regular {
     color: var(--vocab-text);
     font-size: 1.15rem;
     width: 20px;
@@ -480,11 +481,11 @@ body {
   }
 
   /***** Main container vocab-home & concept & vocab-search pages *****/
-  #main-container.vocab-home, #main-container.concept, #main-container.vocab-search  {
+  #main-container.vocab-home, #main-container.concept, #main-container.vocab-search,  #main-container.global-search  {
     background-color: var(--main-bg-2);
   }
 
-  #main-container.vocab-home a, #main-container.concept a, #main-container.vocab-search a {
+  #main-container.vocab-home a, #main-container.concept a, #main-container.vocab-search a, #main-container.global-search a {
     color: var(--vocab-link);
     text-decoration: none;
     font-weight: bold;

--- a/resource/css/skosmos.css
+++ b/resource/css/skosmos.css
@@ -191,10 +191,6 @@ body {
     font-family: var(--font-family-heading);
   }
 
-  #global-search-wrapper {
-    max-width: 1200px;
-  }
-
   #search-wrapper {
     color: var(--vocab-text);
     float: right;

--- a/resource/css/skosmos.css
+++ b/resource/css/skosmos.css
@@ -968,6 +968,10 @@ body {
     font-style: italic;  
   }
 
+  .search-result-term a {
+    font-size: 1.5rem;
+  }
+
   /***** Main container about & feedback pages *****/
   #main-container.about, #main-container.feedback {
     background-color: var(--main-bg-3);

--- a/resource/css/skosmos.css
+++ b/resource/css/skosmos.css
@@ -907,6 +907,8 @@ body {
   .search-result-term a {
     font-family: var(--font-family-heading);
     text-decoration: none;
+    font-size: 1.5rem;
+
   }
 
   .search-result .list-group-item {
@@ -962,10 +964,6 @@ body {
   
   .altLabel.proplabel {
     font-style: italic;  
-  }
-
-  .search-result-term a {
-    font-size: 1.5rem;
   }
 
   /***** Main container about & feedback pages *****/

--- a/src/controller/WebController.php
+++ b/src/controller/WebController.php
@@ -384,7 +384,7 @@ class WebController extends Controller
                 'rest' => $parameters->getOffset() > 0,
                 'global_search' => true,
                 'search_failed' => $errored,
-                'term' => $request->getQueryParamRaw('q'),
+                'term' => $request->getQueryParamRaw('query'),
                 'lang_list' => $langList,
                 'vocabs' => str_replace(' ', '+', $vocabs),
                 'vocab_list' => $vocabList,

--- a/src/controller/WebController.php
+++ b/src/controller/WebController.php
@@ -384,7 +384,7 @@ class WebController extends Controller
                 'rest' => $parameters->getOffset() > 0,
                 'global_search' => true,
                 'search_failed' => $errored,
-                'term' => $request->getQueryParamRaw('query'),
+                'term' => $request->getQueryParamRaw('q'),
                 'lang_list' => $langList,
                 'vocabs' => str_replace(' ', '+', $vocabs),
                 'vocab_list' => $vocabList,

--- a/src/controller/WebController.php
+++ b/src/controller/WebController.php
@@ -386,7 +386,7 @@ class WebController extends Controller
                 'search_failed' => $errored,
                 'term' => $request->getQueryParamRaw('q'),
                 'lang_list' => $langList,
-                'vocabs' => str_replace(' ', '+', $vocabs),
+                'vocabs' => isset($vocabs) ? str_replace(' ', '+', $vocabs) : null,
                 'vocab_list' => $vocabList,
                 'sorted_vocabs' => $sortedVocabs,
                 'request' => $request,

--- a/src/view/global-search.twig
+++ b/src/view/global-search.twig
@@ -1,0 +1,21 @@
+{% set pageType = 'global-search' %}
+{% extends "base-template.twig" %}
+{% block title %}'{{ term }}' - {{ "Search results" | trans }} - {{ GlobalConfig.serviceName }}{% endblock %}
+{% block url %}{{ BaseHref }}{{ request.langurl }}{% endblock %}
+
+{% block content %}
+<div class="container">
+  <div class="row">
+    <div id="main-content">
+      <div class="p-4 pt-4" id="search-results">
+        <div class="search-count">
+          <p class="py-2">
+            <span class="fw-bold">{{ "%search_count% results for '%term%'" | trans({'%search_count%': search_count, '%term%' : term}) }}</span>
+          </p>
+        </div>
+	      {% include "search-results.inc.twig" %}
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/src/view/global-search.twig
+++ b/src/view/global-search.twig
@@ -1,6 +1,6 @@
 {% set pageType = 'global-search' %}
 {% extends "base-template.twig" %}
-{% block title %}'{{ term }}' - {{ "Search results" | trans }} - {{ GlobalConfig.serviceName }}{% endblock %}
+{% block title %}'{{ term }}' - {{ GlobalConfig.serviceName }}{% endblock %}
 {% block url %}{{ BaseHref }}{{ request.langurl }}{% endblock %}
 
 {% block content %}

--- a/src/view/search-results.inc.twig
+++ b/src/view/search-results.inc.twig
@@ -39,33 +39,31 @@
   {%- elseif property.type == 'skos:note' -%}<i class="property-hover fa-solid fa-note-sticky"></i>
   {%- else -%}<i class="property-hover fa-solid fa-globe"></i>
   {%- endif -%}
-      </span>
-    {%- for propval in property.values -%} {# loop through ConceptPropertyValue objects #}
-      {%~ set outerLast = loop.last ~%}
-        {%- if propval.uri ~%} {# resources with URI #}
-          {%- if propval.label ~%}
-            {%- if propval.exvocab and propval.exvocab != propval.vocab ~%}{# if the property is located in a another vocabulary #}{{ propval.label }}
-            {% else %}
-            {{ propval.label(request.contentLang) }}
-            {%- endif -%}
-          {%- if propval.lang and (propval.lang != request.lang) or explicit_langcodes %} ({{ propval.lang }}){%~ endif -%}{%- if not loop.last ~%}, {%~ endif ~%}
-        {%~ endif -%}
-        {%~ else ~%} {# Literals (no URI), eg. alternative labels as properties #}
-        <span class="{%~ if propval.type == 'skos:altLabel' %}altLabel proplabel{% endif ~%}">{{ propval.label }}{%- if not loop.last -%}, {% endif %}</span>
-      {%~ endif %}
-    {%- endfor %}
+      &nbsp;</span>
+  {%- for propval in property.values -%} {# loop through ConceptPropertyValue objects #}
+    {%~ set outerLast = loop.last ~%}
+    {%- if propval.uri -%} {# resources with URI #}
+      {%- if propval.label ~%}
+        {%- if propval.exvocab and propval.exvocab != propval.vocab ~%}{# if the property is located in a another vocabulary #}{{ propval.label }}
+        {%- else -%}{{ propval.label(request.contentLang) }}
+        {%- endif -%}
+        {%- if propval.lang and (propval.lang != request.lang) or explicit_langcodes %} ({{ propval.lang }}){%~ endif -%}{%- if not loop.last ~%}, {%~ endif ~%}
+      {%~ endif -%}
+    {%- else -%}{# Literals (no URI), eg. alternative labels as properties #}<span class="{%~ if propval.type == 'skos:altLabel' %}altLabel proplabel{% endif ~%}">{{ propval.label }}{%- if not loop.last -%}, {%- endif -%}</span>
+    {%~ endif -%}
+  {%- endfor -%}
     </li>
     {%~ endif ~%}
   {%~ endfor ~%}
-  {%~ set foreignLabels = concept.foreignLabels ~%}
-  {%~ if foreignLabels  ~%}
+  {%- set foreignLabels = concept.foreignLabels -%}
+  {%~ if foreignLabels ~%}
   <li class="list-group-item px-0 py-1">
-    <span class="skosmos-tooltip" data-title="foreign prefLabel help"><i class="property-hover fa-solid fa-globe"></i></span>
+    <span class="skosmos-tooltip" data-title="foreign prefLabel help"><i class="property-hover fa-solid fa-globe"></i>&nbsp;</span>
     {%-  for langstring, labels in foreignLabels  ~%}
       {%~ for label in labels.prefLabel|default([])|merge(labels.altLabel|default([])) ~%}
-    <span class="{% if label.type == 'skos:prefLabel' %}prefLabel{% elseif label.type == 'skos:altLabel' %}altLabel{% endif %} proplabel">{{ label }}</span>{%~ if label.lang %} ({{ label.lang }}){% endif ~%}{%- if loop.last == false %}, {% endif -%}
+    <span class="{% if label.type == 'skos:prefLabel' %}prefLabel{% elseif label.type == 'skos:altLabel' %}altLabel{% endif %} proplabel">{{ label }}</span>{%~ if label.lang %} ({{ label.lang }}){% endif ~%}{%- if not loop.last %}, {%- endif -%}
       {%~ endfor ~%}
-      {%- if loop.last == false -%}, {%- endif -%}
+      {%- if not loop.last -%}, {%- endif -%}
     {%~ endfor ~%}
   </li>
 {% endif ~%}
@@ -77,24 +75,22 @@
       {%~ if property.type in concept.vocab.config.additionalSearchProperties ~%}
       <li class="list-group-item px-0 py-1">
         <span class="skosmos-tooltip" data-title="{{ property.type }}">
-          <i class="property-hover fa-solid fa-globe"></i>
+          <i class="property-hover fa-solid fa-globe"></i>&nbsp;
         </span>
-          {%- for propval in property.values -%} {# loop through ConceptMappingPropertyValue objects #}
-            {%- if propval.exVocab -%}<span class="redirected-vocab-id prefLabel">{{ propval.exVocab.shortName }}: </span>{%- endif -%}{{ propval.label(request.contentLang) }}
-            {%- if propval.label(request.contentLang).lang != request.contentLang -%} ({{ propval.label(request.contentLang).lang }}){%- endif -%}{%- if loop.last == false -%}, {% endif %}
+          {%- for propval in property.values -%}{# loop through ConceptMappingPropertyValue objects #}{%- if propval.exVocab -%}<span class="redirected-vocab-id prefLabel">{{ propval.exVocab.shortName }}: </span>{%- endif -%}{{ propval.label(request.contentLang) }}
+            {%- if propval.label(request.contentLang).lang != request.contentLang -%} ({{ propval.label(request.contentLang).lang }}){%- endif -%}{%- if not loop.last -%}, {%- endif -%}
           {% endfor %}
       </li>
       {%~ endif ~%}
     {%~ endfor ~%}
   {%~ endif ~%}
 {%~ endif -%}
-{%- for property in conceptProperties ~%} {# loop through ConceptProperty objects #}
-  {%- if property.type == 'rdf:type' ~%}
+{%- for property in conceptProperties ~%}{# loop through ConceptProperty objects #}{%- if property.type == 'rdf:type' ~%}
   <li class="list-group-item px-0 py-1">
     <span class="skosmos-tooltip" data-title="concept_types">
-      <i class="property-hover fa-solid fa-arrows-to-circle"></i>
+      <i class="property-hover fa-solid fa-arrows-to-circle"></i>&nbsp;
     </span>
-    {%- for propval in property.values %}{{ propval.label | trans }}{% if loop.last == false %}, {% endif %}{% endfor %}
+    {%- for propval in property.values %}{{ propval.label | trans }}{%- if not loop.last -%}, {%- endif -%}{% endfor %}
 
   </li>
   {%~ endif -%}

--- a/src/view/search-results.inc.twig
+++ b/src/view/search-results.inc.twig
@@ -59,11 +59,12 @@
   {%~ if foreignLabels ~%}
   <li class="list-group-item px-0 py-1">
     <span class="skosmos-tooltip" data-title="foreign prefLabel help"><i class="property-hover fa-solid fa-globe"></i>&nbsp;</span>
-    {%-  for langstring, labels in foreignLabels  ~%}
-      {%~ for label in labels.prefLabel|default([])|merge(labels.altLabel|default([])) ~%}
-    <span class="{% if label.type == 'skos:prefLabel' %}prefLabel{% elseif label.type == 'skos:altLabel' %}altLabel{% endif %} proplabel">{{ label }}</span>{%~ if label.lang %} ({{ label.lang }}){% endif ~%}{%- if not loop.last %}, {%- endif -%}
+    {%-  for langstring, labels in foreignLabels -%}
+      {%- for label in labels.prefLabel|default([])|merge(labels.altLabel|default([])) -%}
+    <span class="{% if label.type == 'skos:prefLabel' %}prefLabel{% elseif label.type == 'skos:altLabel' %}altLabel{% endif %} proplabel">{{ label }}</span>
+        {%- if label.lang %} ({{ label.lang }}){% endif %}{% if not loop.last %}, {% endif -%}
       {%~ endfor ~%}
-      {%- if not loop.last -%}, {%- endif -%}
+      {%- if not loop.last %}, {% endif -%}
     {%~ endfor ~%}
   </li>
 {% endif ~%}
@@ -75,23 +76,24 @@
       {%~ if property.type in concept.vocab.config.additionalSearchProperties ~%}
       <li class="list-group-item px-0 py-1">
         <span class="skosmos-tooltip" data-title="{{ property.type }}">
-          <i class="property-hover fa-solid fa-globe"></i>&nbsp;
-        </span>
-          {%- for propval in property.values -%}{# loop through ConceptMappingPropertyValue objects #}{%- if propval.exVocab -%}<span class="redirected-vocab-id prefLabel">{{ propval.exVocab.shortName }}: </span>{%- endif -%}{{ propval.label(request.contentLang) }}
-            {%- if propval.label(request.contentLang).lang != request.contentLang -%} ({{ propval.label(request.contentLang).lang }}){%- endif -%}{%- if not loop.last -%}, {%- endif -%}
+          <i class="property-hover fa-solid fa-globe"></i>&nbsp;</span>
+          {%- for propval in property.values %}
+            {#- loop through ConceptMappingPropertyValue objects -#}
+            {%- if propval.exVocab -%}<span class="redirected-vocab-id prefLabel">{{ propval.exVocab.shortName }}: </span>{% endif %}{{ propval.label(request.contentLang) }}
+            {%- if propval.label(request.contentLang).lang != request.contentLang ~%} ({{ propval.label(request.contentLang).lang }}){%- endif -%}{%- if not loop.last %}, {% endif -%}
           {% endfor %}
       </li>
       {%~ endif ~%}
     {%~ endfor ~%}
   {%~ endif ~%}
 {%~ endif -%}
-{%- for property in conceptProperties ~%}{# loop through ConceptProperty objects #}{%- if property.type == 'rdf:type' ~%}
+{%- for property in conceptProperties ~%}
+  {#- loop through ConceptProperty objects -#}
+  {%- if property.type == 'rdf:type' ~%}
   <li class="list-group-item px-0 py-1">
     <span class="skosmos-tooltip" data-title="concept_types">
-      <i class="property-hover fa-solid fa-arrows-to-circle"></i>&nbsp;
-    </span>
-    {%- for propval in property.values %}{{ propval.label | trans }}{%- if not loop.last -%}, {%- endif -%}{% endfor %}
-
+      <i class="property-hover fa-solid fa-arrows-to-circle"></i>&nbsp;</span>
+    {%- for propval in property.values %}{{ propval.label | trans }}{% if not loop.last %}, {% endif %}{% endfor -%}
   </li>
   {%~ endif -%}
 {%~ endfor -%}

--- a/tests/cypress/template/global-search.cy.js
+++ b/tests/cypress/template/global-search.cy.js
@@ -27,7 +27,7 @@ describe('Global search page', () => {
   })
   it('Contains correct amount of search results ', () => {
       const count = 1;
-      const searchCountTitle = `${count} results for \'${term}\'`;
+      const searchCountTitle = `${count} results for '${term}'`;
       cy.visit(`/en/search?clang=en&q=${term}`)
 
       //Check that the search count is correct

--- a/tests/cypress/template/global-search.cy.js
+++ b/tests/cypress/template/global-search.cy.js
@@ -3,7 +3,7 @@ describe('Global search page', () => {
   it('Contains title and title metadata', () => {
       cy.visit(`/en/search?clang=en&q=${term}`)
 
-      const expectedTitle = "'bass' - Search results - Skosmos being tested"
+      const expectedTitle = "'bass' - Skosmos being tested"
       // check that the page has a HTML title
       cy.get('title').invoke('text').should('equal', expectedTitle)
       // check that the page has title metadata

--- a/tests/cypress/template/global-search.cy.js
+++ b/tests/cypress/template/global-search.cy.js
@@ -1,3 +1,57 @@
 describe('Global search page', () => {
-  it('no-op test', () => {})
+  const term = 'bass';
+  it('Contains title and title metadata', () => {
+      cy.visit(`/en/search?clang=en&q=${term}`)
+
+      const expectedTitle = "'bass' - Search results - Skosmos being tested"
+      // check that the page has a HTML title
+      cy.get('title').invoke('text').should('equal', expectedTitle)
+      // check that the page has title metadata
+      cy.get('head meta[name="title"]').should('have.attr', 'content', expectedTitle);
+      cy.get('head meta[property="og:title"]').should('have.attr', 'content', expectedTitle);
+  })
+  it('Contains site name metadata', () => {
+      cy.visit(`/en/search?clang=en&q=${term}`)
+
+      const expectedSiteName = 'Skosmos being tested'
+      // check that the page has site name metadata
+      cy.get('head meta[property="og:site_name"]').should('have.attr', 'content', expectedSiteName);
+  })
+  it('Contains canonical URL metadata', () => {
+      cy.visit(`/en/search?clang=en&q=${term}`)
+
+    const expectedUrl = Cypress.config('baseUrl') + `en/search?clang=en&q=${term}`
+    // check that the page has canonical URL metadata
+    cy.get('link[rel="canonical"]').should('have.attr', 'href', expectedUrl);
+    cy.get('head meta[property="og:url"]').should('have.attr', 'content', expectedUrl);
+  })
+  it('Contains correct amount of search results ', () => {
+      const count = 1;
+      const searchCountTitle = `${count} results for \'${term}\'`;
+      cy.visit(`/en/search?clang=en&q=${term}`)
+
+      //Check that the search count is correct
+      cy.get('.search-count > p > span').invoke('text').should('contain', searchCountTitle);
+
+      //Check that search count matces the number of results
+      cy.get('div.search-result').should('have.length', count)
+
+  })
+  it('Search results contains correct info', () => {
+      cy.visit(`/en/search?clang=en&q=${term}`)
+
+      //Check that there is a search result that contains a type icon
+      cy.get('div.search-result > ul > li > span > i.property-hover.fa-solid.fa-arrows-to-circle')
+
+      //Check that there is correct amount of different properties for the search result
+      cy.get('div.search-result > ul > li').should('have.length', 3)
+
+      //Check the order of search result properties
+      cy.get('div.search-result > ul').within(() => {
+        cy.get('li').eq(0).invoke('text').should('contain', 'Fish')
+        cy.get('li').eq(1).invoke('text').should('contain', 'Test class')
+        cy.get('li').eq(2).invoke('text').should('contain', 'http://www.skosmos.skos/test/ta116')
+      })
+
+  })
 })


### PR DESCRIPTION
## Reasons for creating this PR

## Link to relevant issue(s), if any

- Closes #1745 

## Description of the changes in this PR

* This PR implements the twig template for global search
* In the absence of a search field, the result page can be tested by visiting `[Skosmos-home]/en/search?clang=en&q=kissa`

## Known problems or uncertainties in this PR

* The PR would greatly benefit from being rebased on PRs #1744  and #1756 after they have been merged

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [X] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [X] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
