### PR TITLE
Fix scrollbar styling and visibility

### DIFF
--- a/resource/css/skosmos.css
+++ b/resource/css/skosmos.css
@@ -292,6 +292,7 @@ body {
     }
   } 
 
+  /* Setting scrollbar style for Webkit based browsers (Chrome, Safari, Edge, etc) */
   #search-wrapper ul::-webkit-scrollbar {
     -webkit-appearance: none;
     -moz-appearance: none;
@@ -575,6 +576,7 @@ body {
     }
   } 
 
+  /* Setting scrollbar style for Webkit based browsers (Chrome, Safari, Edge, etc) */
   .sidebar-list::-webkit-scrollbar {
     -webkit-appearance: none;
     -moz-appearance: none;

--- a/resource/css/skosmos.css
+++ b/resource/css/skosmos.css
@@ -282,7 +282,7 @@ body {
     padding-top: 0rem;
     padding-bottom: 0rem;
     max-height: 50vh;
-    overflow-y: scroll;
+    overflow-y: auto;
   }
 
   /* Setting scrollbar style separately in Firefox */

--- a/resource/css/skosmos.css
+++ b/resource/css/skosmos.css
@@ -282,7 +282,34 @@ body {
     padding-top: 0rem;
     padding-bottom: 0rem;
     max-height: 50vh;
-    overflow-y: auto;
+    overflow-y: scroll;
+  }
+
+  /* Setting scrollbar style separately in Firefox */
+  @-moz-document url-prefix() {
+    #search-wrapper ul {
+      scrollbar-color: var(--sidebar-scrollbar-thumb) var(--search-dropdown-bg);
+    }
+  } 
+
+  #search-wrapper ul::-webkit-scrollbar {
+    -webkit-appearance: none;
+    -moz-appearance: none;
+  }
+
+  #search-wrapper ul::-webkit-scrollbar:vertical {
+      width: 15px;
+  }
+
+  #search-wrapper ul::-webkit-scrollbar-thumb {
+      border-radius: 0px;
+      border: 1px solid var(--sidebar-scrollbar-thumb);
+      background-color: var(--sidebar-scrollbar-thumb);
+  }
+
+  #search-wrapper ul::-webkit-scrollbar-track { 
+      background-color: var(--search-dropdown-bg); 
+      border-radius: 0px; 
   }
 
   #search-wrapper .autocomplete {
@@ -538,16 +565,34 @@ body {
   .sidebar-list {
     padding: 2rem 1rem 0 1rem;
     overflow-y: scroll;
-    scrollbar-color: var(--sidebar-scrollbar-thumb) var(--sidebar-scrollbar-bg);
     position: absolute;
   }
 
+  /* Setting scrollbar style separately in Firefox */
+  @-moz-document url-prefix() {
+    .sidebar-list {
+      scrollbar-color: var(--sidebar-scrollbar-thumb) var(--search-dropdown-bg);
+    }
+  } 
+
   .sidebar-list::-webkit-scrollbar {
-    background: var(--sidebar-scrollbar-bg);
+    -webkit-appearance: none;
+    -moz-appearance: none;
+  }
+
+  .sidebar-list::-webkit-scrollbar:vertical {
+      width: 15px;
   }
 
   .sidebar-list::-webkit-scrollbar-thumb {
-    background: var(--sidebar-scrollbar-thumb);
+      border-radius: 0px;
+      border: 1px solid var(--sidebar-scrollbar-thumb);
+      background-color: var(--sidebar-scrollbar-thumb);
+  }
+
+  .sidebar-list::-webkit-scrollbar-track { 
+      background-color: var(--sidebar-scrollbar-bg);
+      border-radius: 0px; 
   }
 
   .sidebar-list .list-group-item {


### PR DESCRIPTION
## Reasons for creating this PR

Scrollbars are not visible by default in browsers on Mac in Skosmos 3. This PR adds a permanent scrollbar to sidebar and searchbar in Webkit based browsers.

## Link to relevant issue(s), if any

- Closes #1738

## Description of the changes in this PR

- Add scrollbar styling for searchbar in Webkit browsers
- Add separate scrollbar styling in Firefox for searchbar and sidebar

## Known problems or uncertainties in this PR

Styling seems to not be applied at all in Firefox on Windows 11. In Firefox on Mac, the scrollbar seems to only be visible when elements are scrolled. Though, fixing the issue on Mac does not seem to be currently possible.

## Checklist

- [ ] phpUnit tests pass locally with my changes
- [ ] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [ ] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [ ] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
