### PR TITLE
Fixed dropdown menu width

### DIFF
--- a/resource/js/vocab-search.js
+++ b/resource/js/vocab-search.js
@@ -257,7 +257,7 @@ function startVocabSearchApp () {
               @keyup.enter="gotoSearchPage()"
               @click="showAutoComplete()">
             <ul id="search-autocomplete-results"
-                class="dropdown-menu"
+                class="dropdown-menu w-100"
                 :class="{ 'show': showDropdown }"
                 aria-labelledby="search-field">
               <li class="autocomplete-result container" v-for="result in renderedResultsList"


### PR DESCRIPTION
## Reasons for creating this PR

A recent review showed weird behaviour in the search bar autocomplete, screenshots in the related issue.

## Link to relevant issue(s), if any

- Closes #1761 

## Description of the changes in this PR

Apparently this was a regression caused by a recent [commit](https://github.com/NatLibFi/Skosmos/commit/1c8f581da9a53a290617a172c96c949dc7b9eade?w=1#diff-c65cc69617047bb6f29cd50c68fa896315f1e5cb6edd4ff05e86d3ade2e2c813L253) with some sort of difficulties with merge (vocab-search.js, line -253, +260)

This PR reverts to the previous situation.

## Known problems or uncertainties in this PR

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
