### PR TITLE
Implement infinite scrolling in new and deprecated view

### DIFF
--- a/resource/css/skosmos.css
+++ b/resource/css/skosmos.css
@@ -624,6 +624,10 @@ body {
     margin-top: 1.5rem !important;
   }
 
+  #tab-changes .sidebar-list s {
+    text-decoration: 1px var(--vocab-text) line-through;
+  }
+
   /*** sidebar hierarchy and groups tabs ***/
   #tab-hierarchy .sidebar-list .list-group-item,
   #tab-groups .sidebar-list .list-group-item {

--- a/resource/js/tab-changes.js
+++ b/resource/js/tab-changes.js
@@ -8,6 +8,7 @@ function startChangesApp () {
         changedConcepts: new Map(),
         selectedConcept: '',
         loadingConcepts: false,
+        loadingMoreConcepts: false,
         currentOffset: 0,
         listStyle: {}
       }
@@ -78,6 +79,7 @@ function startChangesApp () {
           })
       },
       loadMoreChanges () {
+        this.loadingMoreConcepts = true
         // Remove scrolling event listener while new changes are loaded
         this.$refs.tabChanges.$refs.list.removeEventListener('scroll', this.handleScrollEvent)
         fetch('rest/v1/' + window.SKOSMOS.vocab + '/new?lang=' + window.SKOSMOS.content_lang + '&limit=200&offset=' + this.currentOffset)
@@ -102,6 +104,7 @@ function startChangesApp () {
             }
 
             this.currentOffset += 200
+            this.loadingMoreConcepts = false
             // Add scrolling event listener back if more changes were loaded
             if (data.changeList.length > 0) {
               this.$refs.tabChanges.$refs.list.addEventListener('scroll', this.handleScrollEvent)
@@ -130,6 +133,7 @@ function startChangesApp () {
           :changed-concepts="changedConcepts"
           :selected-concept="selectedConcept"
           :loading-concepts="loadingConcepts"
+          :loading-more-concepts="loadingMoreConcepts"
           :loading-message="loadingMessage"
           :list-style="listStyle"
           @select-concept="selectedConcept = $event"
@@ -153,7 +157,7 @@ function startChangesApp () {
   })
 
   tabChangesApp.component('tab-changes', {
-    props: ['changedConcepts', 'selectedConcept', 'loadingConcepts', 'loadingMessage', 'listStyle'],
+    props: ['changedConcepts', 'selectedConcept', 'loadingConcepts', 'loadingMoreConcepts', 'loadingMessage', 'listStyle'],
     inject: ['partialPageLoad', 'getConceptURL'],
     emits: ['selectConcept'],
     methods: {
@@ -202,6 +206,11 @@ function startChangesApp () {
                     {{ concept.prefLabel }}
                   </a>
                 </template>
+              </li>
+            </template>
+            <template v-if="loadingMoreConcepts">
+              <li class="list-group-item py-1 px-2">
+                {{ this.loadingMessage }} <i class="fa-solid fa-spinner fa-spin-pulse"></i>
               </li>
             </template>
           </ul>

--- a/tests/cypress/template/sidebar-changes.cy.js
+++ b/tests/cypress/template/sidebar-changes.cy.js
@@ -40,6 +40,20 @@ describe('New and removed view', () => {
     // Check that concepts are in the correct language
     cy.get('#tab-changes').find('.sidebar-list li a').eq(0).invoke('text').should('contain', 'irtolöydöt')
   })
+  it('Loads concepts on scroll', () => {
+    // Go to YSO vocab home page
+    cy.visit('/yso/en/')
+    // click on changes tab
+    cy.get('#changes').click()
+    // Scroll to the bottom of sidebar list
+    cy.get('#tab-changes').find('.sidebar-list').scrollTo('bottom')
+    // Check that loading spinner exists
+    cy.get('#tab-changes .sidebar-list i.fa-spinner')
+    // Check that new concepts have been loaded
+    cy.get('#tab-changes').find('.sidebar-list li').should('have.length.gt', 200, {'timeout': 20000})
+    // Check that loading spinner does not exist
+    cy.get('#tab-changes .sidebar-list i.fa-spinner').should('not.exist')
+  })
   it('Performs partial page load when clicking on concept', () => {
     // go to the YSO home page in English language
     cy.visit('/yso/en/')


### PR DESCRIPTION
## Reasons for creating this PR

Changes view in sidebar does not currently load more concepts as the list is scrolled in Skosmos 3. This PR adds functionality to address this.

## Link to relevant issue(s), if any

- Closes #1765
- Part of #1735

## Description of the changes in this PR

- Add an event listener for scrolling changes list
- Load more concepts when list is scrolled to the bottom
- Add spinners when loading content
- Add a cypress test for loading new changes
- Add dark color to deprecated concepts' line throughs

Addresses requirement 7 in #1735

## Known problems or uncertainties in this PR

## Checklist

- [ ] phpUnit tests pass locally with my changes
- [ ] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [ ] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [ ] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
