### PR TITLE
Add wrapper scripts for common translation operations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ tests/cypress/screenshots/
 /.idea
 *.swp
 var/
+.env.local

--- a/bin/extract-translations
+++ b/bin/extract-translations
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Get the directory containing this script
+SCRIPT_DIR=$(dirname "$0")
+
+# Run the Symfony console command to extract messages from code and save them into the English message file
+${SCRIPT_DIR}/console translation:extract --force en --format json --prefix ""

--- a/bin/pull-translations
+++ b/bin/pull-translations
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Get the directory containing this script
+SCRIPT_DIR=$(dirname "$0")
+
+# Build the base command to pull translations from Lokalise into the message files
+CMD="${SCRIPT_DIR}/console translation:pull lokalise --domains messages --format json"
+
+# Add language parameter if provided (this will restrict the pull to a single language)
+if [ $# -eq 1 ]; then
+    CMD+=" --locales $1"
+fi
+
+# Execute the command
+$CMD

--- a/bin/push-translations
+++ b/bin/push-translations
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Get the directory containing this script
+SCRIPT_DIR=$(dirname "$0")
+
+# Run the Symfony console command to push current English language messages to Lokalise
+${SCRIPT_DIR}/console translation:push lokalise --domains messages --locales en --force


### PR DESCRIPTION
## Reasons for creating this PR

While reviewing the [documentation for translations in Skosmos 3](https://github.com/NatLibFi/Skosmos/wiki/Translation-for-Skosmos-3), it became apparent that the current commands for common operations such as extract, pull and push are quite unwieldy. This PR adds wrapper shell scripts that make them much easier.

## Link to relevant issue(s), if any

- part of #1712

## Description of the changes in this PR

- add .env.local into .gitignore (commonly used to hold Lokalise API keys that shouldn't be committed to version control)
- add the scripts extract-translations, push-translations and pull-translations

## Known problems or uncertainties in this PR

The [documentation](https://github.com/NatLibFi/Skosmos/wiki/Translation-for-Skosmos-3) needs to be updated as well so it encourages using these scripts.

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
