### PR TITLE
implement event listener for notifying when translations are ready

### DIFF
--- a/resource/js/tab-alpha.js
+++ b/resource/js/tab-alpha.js
@@ -1,4 +1,4 @@
-/* global Vue, $t */
+/* global Vue, $t, onTranslationReady */
 /* global partialPageLoad, getConceptURL, fetchWithAbort */
 
 function startAlphaApp () {
@@ -245,12 +245,4 @@ function startAlphaApp () {
   tabAlphaApp.mount('#tab-alphabetical')
 }
 
-const waitForTranslationServiceTabAlpha = () => {
-  if (typeof $t !== 'undefined') {
-    startAlphaApp()
-  } else {
-    setTimeout(waitForTranslationServiceTabAlpha, 50)
-  }
-}
-
-waitForTranslationServiceTabAlpha()
+onTranslationReady(startAlphaApp)

--- a/resource/js/tab-changes.js
+++ b/resource/js/tab-changes.js
@@ -1,4 +1,4 @@
-/* global Vue, $t */
+/* global Vue, $t, onTranslationReady */
 /* global partialPageLoad, getConceptURL */
 
 function startChangesApp () {
@@ -167,12 +167,4 @@ function startChangesApp () {
   tabChangesApp.mount('#tab-changes')
 }
 
-const waitForTranslationServiceTabChanges = () => {
-  if (typeof $t !== 'undefined') {
-    startChangesApp()
-  } else {
-    setTimeout(waitForTranslationServiceTabChanges, 50)
-  }
-}
-
-waitForTranslationServiceTabChanges()
+onTranslationReady(startChangesApp)

--- a/resource/js/tab-hierarchy.js
+++ b/resource/js/tab-hierarchy.js
@@ -1,4 +1,4 @@
-/* global Vue, $t */
+/* global Vue, $t, onTranslationReady */
 /* global partialPageLoad, getConceptURL */
 
 function startHierarchyApp () {
@@ -368,12 +368,4 @@ function startHierarchyApp () {
   tabHierApp.mount('#tab-hierarchy')
 }
 
-const waitForTranslationServiceTabHierarchy = () => {
-  if (typeof $t !== 'undefined') {
-    startHierarchyApp()
-  } else {
-    setTimeout(waitForTranslationServiceTabHierarchy, 50)
-  }
-}
-
-waitForTranslationServiceTabHierarchy()
+onTranslationReady(startHierarchyApp)

--- a/resource/js/term-counts.js
+++ b/resource/js/term-counts.js
@@ -1,4 +1,4 @@
-/* global Vue, $t */
+/* global Vue, $t, onTranslationReady */
 
 function startTermCountsApp () {
   const termCountsApp = Vue.createApp({
@@ -69,12 +69,4 @@ function startTermCountsApp () {
   termCountsApp.mount('#term-counts')
 }
 
-function waitForTermTranslationService () {
-  if (typeof $t !== 'undefined') {
-    startTermCountsApp()
-  } else {
-    setTimeout(waitForTermTranslationService, 50)
-  }
-}
-
-waitForTermTranslationService()
+onTranslationReady(startTermCountsApp)

--- a/resource/js/translation-service.js
+++ b/resource/js/translation-service.js
@@ -26,7 +26,13 @@
   }
 
   onTranslationReady = function (callback) {
-    translationCallbacks.push(callback)
+    if (typeof $t !== 'undefined') {
+      // translation service is ready, call callback immediately
+      callback()
+    } else {
+      // translation service not yet ready, add callback to queue
+      translationCallbacks.push(callback)
+    }
   }
 
   await initializeTranslations(window.SKOSMOS.lang || 'en')

--- a/resource/js/translation-service.js
+++ b/resource/js/translation-service.js
@@ -1,7 +1,9 @@
-/* global $t:writable */
-/* exported $t */
+/* global $t:writable, onTranslationReady:writable */
+/* exported $t, onTranslationReady */
 
 (async function () {
+  const translationCallbacks = []
+
   async function loadLocaleMessages (locale) {
     const messages = {}
     try {
@@ -20,6 +22,11 @@
     $t = function (key) {
       return translations[key] || key
     }
+    translationCallbacks.forEach(callback => callback())
+  }
+
+  onTranslationReady = function (callback) {
+    translationCallbacks.push(callback)
   }
 
   await initializeTranslations(window.SKOSMOS.lang || 'en')

--- a/resource/js/vocab-counts.js
+++ b/resource/js/vocab-counts.js
@@ -1,4 +1,4 @@
-/* global Vue, $t */
+/* global Vue, $t, onTranslationReady */
 
 function startResourceCountsApp () {
   const resourceCountsApp = Vue.createApp({
@@ -76,12 +76,4 @@ function startResourceCountsApp () {
   resourceCountsApp.mount('#resource-counts')
 }
 
-const waitForTranslationServiceVocabCounts = () => {
-  if (typeof $t !== 'undefined') {
-    startResourceCountsApp()
-  } else {
-    setTimeout(waitForTranslationServiceVocabCounts, 50)
-  }
-}
-
-waitForTranslationServiceVocabCounts()
+onTranslationReady(startResourceCountsApp)

--- a/resource/js/vocab-search.js
+++ b/resource/js/vocab-search.js
@@ -1,4 +1,4 @@
-/* global Vue, $t */
+/* global Vue, $t, onTranslationReady */
 
 function startVocabSearchApp () {
   const vocabSearch = Vue.createApp({
@@ -370,12 +370,4 @@ function startVocabSearchApp () {
   vocabSearch.mount('#search-vocab')
 }
 
-const waitForTranslationServiceVocabSearch = () => {
-  if (typeof $t !== 'undefined') {
-    startVocabSearchApp()
-  } else {
-    setTimeout(waitForTranslationServiceVocabSearch, 50)
-  }
-}
-
-waitForTranslationServiceVocabSearch()
+onTranslationReady(startVocabSearchApp)


### PR DESCRIPTION
## Reasons for creating this PR

Smarter event handling for frontend components that need to be initialized only after the translation service is ready.

See #1771

## Link to relevant issue(s), if any

- Closes #1771

## Description of the changes in this PR

- add onTranslationReady function for registering event handlers that should be called when translations are ready
- use onTranslationReady in Vue components instead of stupid polling boilerplate code

## Known problems or uncertainties in this PR

n/a

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
