### PR TITLE
Translations of Aria labels in vocab search Vue component

### DIFF
--- a/resource/js/vocab-search.js
+++ b/resource/js/vocab-search.js
@@ -20,6 +20,15 @@ function startVocabSearchApp () {
       },
       noResults () {
         return $t('No results')
+      },
+      selectSearchLanguageAriaMessage () {
+        return $t('Select search language')
+      },
+      textInputWithDropdownButtonAriaMessage () {
+        return $t('Text input with dropdown button')
+      },
+      searchAriaMessage () {
+        return $t('Search')
       }
     },
     mounted () {
@@ -223,7 +232,7 @@ function startVocabSearchApp () {
             role="button"
             data-bs-toggle="dropdown"
             aria-expanded="false"
-            aria-label="Select search language"
+            :aria-label="selectSearchLanguageAriaMessage"
             v-if="languageStrings">
             {{ languageStrings[selectedLanguage] }}
             <i class="fa-solid fa-chevron-down"></i>
@@ -249,7 +258,7 @@ function startVocabSearchApp () {
               id="search-field"
               autocomplete="off"
               data-bs-toggle=""
-              aria-label="Text input with dropdown button"
+              :aria-label="textInputWithDropdownButtonAriaMessage"
               :placeholder="searchPlaceholder"
               v-click-outside="hideAutoComplete"
               v-model="searchTerm"
@@ -344,7 +353,7 @@ function startVocabSearchApp () {
           <button id="clear-button" class="btn btn-danger" type="clear" v-if="searchTerm" @click="resetSearchTermAndHideDropdown()">
             <i class="fa-solid fa-xmark"></i>
           </button>
-          <button id="search-button" class="btn btn-outline-secondary" aria-label="Search" @click="gotoSearchPage()">
+          <button id="search-button" class="btn btn-outline-secondary" :aria-label="searchAriaMessage" @click="gotoSearchPage()">
             <i class="fa-solid fa-magnifying-glass"></i>
           </button>
         </div>

--- a/resource/translations/messages.en.json
+++ b/resource/translations/messages.en.json
@@ -220,5 +220,7 @@
     "Go to the concept page": "Go to the concept page",
     "Download this concept": "Download this concept",
     "Concept %term% in vocabulary %vocab%": "Concept %term% in vocabulary %vocab%",
-    "More information about this term": "More information about this term"
+    "More information about this term": "More information about this term",
+    "Select search language": "Select search language",
+    "Text input with dropdown button": "Text input with dropdown button"
 }

--- a/resource/translations/messages.fi.json
+++ b/resource/translations/messages.fi.json
@@ -1,4 +1,6 @@
 {
+    "Select search language": "Valitse hakukieli",
+    "Text input with dropdown button": "Tekstinsy\u00f6tt\u00f6 pudotusvalikolla",
     "Open": "Avaa",
     "%search_count% results for '%term%'": "%search_count% tulosta haulle '%term%'",
     "404 Error: The page %requested_page% cannot be found.": "Virhe 404: Sivua %requested_page% ei l\u00f6ydy.",

--- a/resource/translations/messages.sv.json
+++ b/resource/translations/messages.sv.json
@@ -1,4 +1,6 @@
 {
+    "Select search language": "V\u00e4lj s\u00f6kspr\u00e5k",
+    "Text input with dropdown button": "Textinmatning med rullgardinsmeny",
     "Open": "\u00d6ppna",
     "%search_count% results for '%term%'": "%search_count% s\u00f6kresultat f\u00f6r '%term%'",
     "404 Error: The page %requested_page% cannot be found.": "Fel 404: Sidan %requested_page% finns inte.",

--- a/tests/cypress/template/vocab-search-bar.cy.js
+++ b/tests/cypress/template/vocab-search-bar.cy.js
@@ -250,9 +250,9 @@ describe('Vocab search bar', () => {
       // go to YSO vocab front page in Finnish
       cy.visit('/yso/fi/')
       // Check that language selector has correct Aria label
-      cy.get('#language-selector button').should('have.attr', 'aria-label', 'Select search language')
+      cy.get('#language-selector button').should('have.attr', 'aria-label', 'Valitse hakukieli')
       // Check that search field has correct Aria label
-      cy.get('#search-field').should('have.attr', 'aria-label', 'Text input with dropdown button')
+      cy.get('#search-field').should('have.attr', 'aria-label', 'Tekstinsyöttö pudotusvalikolla')
       // Check that search field has correct Aria label
       cy.get('#search-button').should('have.attr', 'aria-label', 'Hae')
       // Check that search field has correct placeholder
@@ -266,9 +266,9 @@ describe('Vocab search bar', () => {
       // go to YSO vocab front page in Swedish
       cy.visit('/yso/sv/')
       // Check that language selector has correct Aria label
-      cy.get('#language-selector button').should('have.attr', 'aria-label', 'Select search language')
+      cy.get('#language-selector button').should('have.attr', 'aria-label', 'Välj sökspråk')
       // Check that search field has correct Aria label
-      cy.get('#search-field').should('have.attr', 'aria-label', 'Text input with dropdown button')
+      cy.get('#search-field').should('have.attr', 'aria-label', 'Textinmatning med rullgardinsmeny')
       // Check that search field has correct Aria label
       cy.get('#search-button').should('have.attr', 'aria-label', 'Sök')
       // Check that search field has correct placeholder

--- a/tests/cypress/template/vocab-search-bar.cy.js
+++ b/tests/cypress/template/vocab-search-bar.cy.js
@@ -212,20 +212,73 @@ describe('Vocab search bar', () => {
         cy.get('li').last().find('b').eq(0).should('have.text', '51')
       })
     })
-      it('Long autocomplete result list should have a scroll bar', () => {
-        // go to YSO vocab front page
-        cy.visit('/yso/fi/')
+    it('Long autocomplete result list should have a scroll bar', () => {
+      // go to YSO vocab front page
+      cy.visit('/yso/fi/')
 
-        // resize the window to smaller size
-        cy.viewport(1200, 600)
+      // resize the window to smaller size
+      cy.viewport(1200, 600)
 
-        // type a search term and wait for the autocomplete to appear
-        cy.get('#search-field').type('mu')
-        cy.get('#search-autocomplete-results').should('be.visible')
+      // type a search term and wait for the autocomplete to appear
+      cy.get('#search-field').type('mu')
+      cy.get('#search-autocomplete-results').should('be.visible')
 
-        // the result list should have a CSS-based scroll
-        cy.get('#search-autocomplete-results').should('have.css', 'overflow-y', 'auto')
-        cy.get('#search-autocomplete-results').should('have.css', 'max-height', '300px')
-      });
+      // the result list should have a CSS-based scroll
+      cy.get('#search-autocomplete-results').should('have.css', 'overflow-y', 'auto')
+      cy.get('#search-autocomplete-results').should('have.css', 'max-height', '300px')
+    })
   });
+
+  describe('Translations', () => {
+    it('Has correct translations', () => {
+      // go to YSO vocab front page in English
+      cy.visit('/yso/en/')
+      // Check that language selector has correct Aria label
+      cy.get('#language-selector button').should('have.attr', 'aria-label', 'Select search language')
+      // Check that search field has correct Aria label
+      cy.get('#search-field').should('have.attr', 'aria-label', 'Text input with dropdown button')
+      // Check that search field has correct Aria label
+      cy.get('#search-button').should('have.attr', 'aria-label', 'Search')
+      // Check that search field has correct placeholder
+      cy.get('#search-field').should('have.attr', 'placeholder', 'Search...')
+      // Check that search results have correct message when no results were found
+      cy.get('#search-field').type('No results')
+      cy.get('#search-autocomplete-results').within(() => {
+        cy.get('li').eq(0).invoke('text').should('contain', 'No results') // the single result should display a no results message
+      })
+
+      // go to YSO vocab front page in Finnish
+      cy.visit('/yso/fi/')
+      // Check that language selector has correct Aria label
+      cy.get('#language-selector button').should('have.attr', 'aria-label', 'Select search language')
+      // Check that search field has correct Aria label
+      cy.get('#search-field').should('have.attr', 'aria-label', 'Text input with dropdown button')
+      // Check that search field has correct Aria label
+      cy.get('#search-button').should('have.attr', 'aria-label', 'Hae')
+      // Check that search field has correct placeholder
+      cy.get('#search-field').should('have.attr', 'placeholder', 'Hae...')
+      // Check that search results have correct message when no results were found
+      cy.get('#search-field').type('No results')
+      cy.get('#search-autocomplete-results').within(() => {
+        cy.get('li').eq(0).invoke('text').should('contain', 'Ei tuloksia') // the single result should display a no results message
+      })
+
+      // go to YSO vocab front page in Swedish
+      cy.visit('/yso/sv/')
+      // Check that language selector has correct Aria label
+      cy.get('#language-selector button').should('have.attr', 'aria-label', 'Select search language')
+      // Check that search field has correct Aria label
+      cy.get('#search-field').should('have.attr', 'aria-label', 'Text input with dropdown button')
+      // Check that search field has correct Aria label
+      cy.get('#search-button').should('have.attr', 'aria-label', 'Sök')
+      // Check that search field has correct placeholder
+      cy.get('#search-field').should('have.attr', 'placeholder', 'Sök...')
+      // Check that search results have correct message when no results were found
+      cy.get('#search-field').type('No results')
+      cy.get('#search-autocomplete-results').within(() => {
+        cy.get('li').eq(0).invoke('text').should('contain', 'Inga sökresultat') // the single result should display a no results message
+      })
+
+    })
+  })
 })


### PR DESCRIPTION
## Reasons for creating this PR

Aria tags are not currently translated in the search-vocab Vue component. This PR adds the translations.

## Link to relevant issue(s), if any

- Closes #1767
- Part of #1712

## Description of the changes in this PR

- Add translations to vocab-search Vue component
- Add new translation messages to translation files
- Add cypress tests for translations

## Known problems or uncertainties in this PR

## Checklist

- [ ] phpUnit tests pass locally with my changes
- [ ] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [ ] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [ ] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
