### PR TITLE
Translations of Aria labels in new and deprecated view

### DIFF
--- a/resource/js/tab-changes.js
+++ b/resource/js/tab-changes.js
@@ -16,6 +16,9 @@ function startChangesApp () {
     computed: {
       loadingMessage () {
         return $t('Loading more items')
+      },
+      toConceptPageAriaMessage () {
+        return $t('Go to the concept page')
       }
     },
     provide () {
@@ -135,6 +138,7 @@ function startChangesApp () {
           :loading-concepts="loadingConcepts"
           :loading-more-concepts="loadingMoreConcepts"
           :loading-message="loadingMessage"
+          :to-concept-page-aria-message="toConceptPageAriaMessage"
           :list-style="listStyle"
           @select-concept="selectedConcept = $event"
           ref="tabChanges"
@@ -157,7 +161,7 @@ function startChangesApp () {
   })
 
   tabChangesApp.component('tab-changes', {
-    props: ['changedConcepts', 'selectedConcept', 'loadingConcepts', 'loadingMoreConcepts', 'loadingMessage', 'listStyle'],
+    props: ['changedConcepts', 'selectedConcept', 'loadingConcepts', 'loadingMoreConcepts', 'loadingMessage', 'toConceptPageAriaMessage', 'listStyle'],
     inject: ['partialPageLoad', 'getConceptURL'],
     emits: ['selectConcept'],
     methods: {
@@ -184,7 +188,7 @@ function startChangesApp () {
                   <a :class="{ 'selected': selectedConcept === concept.uri }"
                     :href="getConceptURL(concept.uri)"
                     @click="loadConcept($event, concept.uri)"
-                    aria-label="go to the concept page"
+                    :aria-label="toConceptPageAriaMessage"
                   >
                     <s>{{ concept.prefLabel }}</s>
                   </a>
@@ -192,7 +196,7 @@ function startChangesApp () {
                   <a :class="{ 'selected': selectedConcept === concept.replacedBy }"
                     :href="getConceptURL(concept.replacedBy)"
                     @click="loadConcept($event, concept.replacedBy)"
-                    aria-label="go to the concept page"
+                    :aria-label="toConceptPageAriaMessage"
                   >
                     {{ concept.replacingLabel }}
                   </a>
@@ -201,7 +205,7 @@ function startChangesApp () {
                   <a :class="{ 'selected': selectedConcept === concept.uri }"
                     :href="getConceptURL(concept.uri)"
                     @click="loadConcept($event, concept.uri)"
-                    aria-label="go to the concept page"
+                    :aria-label="toConceptPageAriaMessage"
                   >
                     {{ concept.prefLabel }}
                   </a>

--- a/tests/cypress/template/sidebar-changes.cy.js
+++ b/tests/cypress/template/sidebar-changes.cy.js
@@ -87,4 +87,27 @@ describe('New and removed view', () => {
     // check that mappings have the right number of properties
     cy.get('.prop-mapping h2').should('have.length', 2)
   })
+  it('Has correct translations', () => {
+    // go to YSO vocab front page in English
+    cy.visit('/yso/en/')
+    // Click on changes tab
+    cy.get('#changes').click()
+    // Check that concepts have correct Aria labels
+    cy.get('#tab-changes').find('.sidebar-list li a').eq(0).should('have.attr', 'aria-label', 'Go to the concept page')
+
+    // go to YSO vocab front page in Finnish
+    cy.visit('/yso/fi/')
+    // Click on changes tab
+    cy.get('#changes').click()
+    // Check that concepts have correct Aria labels
+    cy.get('#tab-changes').find('.sidebar-list li a').eq(0).should('have.attr', 'aria-label', 'Mene käsitesivulle')
+
+    // go to YSO vocab front page in Swedish
+    cy.visit('/yso/sv/')
+    // Click on changes tab
+    cy.get('#changes').click()
+    // Check that concepts have correct Aria labels
+    cy.get('#tab-changes').find('.sidebar-list li a').eq(0).should('have.attr', 'aria-label', 'Gå till begreppssidan')
+
+  })  
 })


### PR DESCRIPTION
## Reasons for creating this PR

Aria tags are not currently translated in the changes-tab Vue component in Skosmos 3. This PR adds the translations.

## Link to relevant issue(s), if any

- Closes #1768
- Part of #1712

## Description of the changes in this PR

- Add translations to changes-tab Vue component
- Add cypress tests for translations

## Known problems or uncertainties in this PR

## Checklist

- [ ] phpUnit tests pass locally with my changes
- [ ] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [ ] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [ ] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
