### PR TITLE
Translations in groups view

### DIFF
--- a/resource/js/tab-groups.js
+++ b/resource/js/tab-groups.js
@@ -1,7 +1,7 @@
 /* global Vue, $t, onTranslationReady */
 /* global partialPageLoad, getConceptURL */
 
-function startHierarchyApp () {
+function startGroupsApp () {
   const tabGroupsApp = Vue.createApp({
     data () {
       return {
@@ -326,4 +326,4 @@ function startHierarchyApp () {
   tabGroupsApp.mount('#tab-groups')
 }
 
-onTranslationReady(startHierarchyApp)
+onTranslationReady(startGroupsApp)

--- a/resource/js/tab-groups.js
+++ b/resource/js/tab-groups.js
@@ -1,310 +1,329 @@
-/* global Vue */
+/* global Vue, $t, onTranslationReady */
 /* global partialPageLoad, getConceptURL */
 
-const tabGroupsApp = Vue.createApp({
-  data () {
-    return {
-      groups: [],
-      selectedGroup: '',
-      loadingGroups: true,
-      loadingChildren: [],
-      listStyle: {}
-    }
-  },
-  provide () {
-    return {
-      partialPageLoad,
-      getConceptURL,
-      showNotation: window.SKOSMOS.showNotation
-    }
-  },
-  mounted () {
-    // Load groups if groups tab is active when the page is first opened (otherwise only load groups when the tab is clicked)
-    if (document.querySelector('#groups > a').classList.contains('active')) {
-      this.loadGroups()
-    }
-  },
-  beforeUpdate () {
-    this.setListStyle()
-  },
-  methods: {
-    handleClickGroupsEvent () {
-      // Only load groups if groups tab is available
-      if (!document.querySelector('#groups > a').classList.contains('disabled')) {
+function startHierarchyApp () {
+  const tabGroupsApp = Vue.createApp({
+    data () {
+      return {
+        groups: [],
+        selectedGroup: '',
+        loadingGroups: true,
+        loadingChildren: [],
+        listStyle: {}
+      }
+    },
+    provide () {
+      return {
+        partialPageLoad,
+        getConceptURL,
+        showNotation: window.SKOSMOS.showNotation
+      }
+    },
+    computed: {
+      openAriaMessage () {
+        return $t('Open')
+      },
+      goToTheConceptPageAriaMessage () {
+        return $t('Go to the concept page')
+      }
+    },
+    mounted () {
+      // Load groups if groups tab is active when the page is first opened (otherwise only load groups when the tab is clicked)
+      if (document.querySelector('#groups > a').classList.contains('active')) {
         this.loadGroups()
       }
     },
-    loadGroups () {
-      this.loadingGroups = true
-      fetch('rest/v1/' + window.SKOSMOS.vocab + '/groups/?lang=' + window.SKOSMOS.content_lang)
-        .then(data => {
-          return data.json()
-        })
-        .then(data => {
-          console.log('groups data', data)
-
-          this.groups = []
-
-          const groups = data.groups
-          const result = []
-
-          // Map groups by uri with group properties for easy lookup
-          const uriMap = new Map()
-          for (const group of groups) {
-            uriMap.set(group.uri, { ...group, childGroups: [], isOpen: false, isGroup: true })
-          }
-
-          // Iterate through groups and set child groups in uriMap
-          for (const group of groups) {
-            if (group.childGroups) {
-              for (const childUri of group.childGroups) {
-                const child = uriMap.get(childUri)
-                if (child) {
-                  uriMap.get(group.uri).childGroups.push(child)
-                }
-              }
-            }
-
-            // Add top level groups to result list
-            if (!groups.some(other => other.childGroups?.includes(group.uri))) {
-              result.push(uriMap.get(group.uri))
-            }
-          }
-
-          return { result, uriMap }
-        })
-        .then(({ result, uriMap }) => {
-          // Check that we are on a group page
-          if (uriMap.has(window.SKOSMOS.uri)) {
-            this.selectedGroup = window.SKOSMOS.uri
-
-            // Only load members if selected group has members
-            if (uriMap.get(this.selectedGroup).hasMembers) {
-              fetch('rest/v1/' + window.SKOSMOS.vocab + '/groupMembers/?lang=' + window.SKOSMOS.content_lang + '&uri=' + this.selectedGroup)
-                .then(data => {
-                  return data.json()
-                })
-                .then(data => {
-                  console.log('members data', data)
-                  // Filter out existing groups from members list and add the correct properties
-                  const members = data.members
-                    .filter(m => !uriMap.has(m.uri))
-                    .map(m => {
-                      return { ...m, childGroups: [], isOpen: false, isGroup: false }
-                    })
-
-                  // Set isOpen to true for the selected group and its parents and add child members to selected group
-                  this.setIsOpenAndAddMembers(result, this.selectedGroup, members)
-
-                  this.groups = result
-                  this.loadingGroups = false
-                  console.log('groups', this.groups)
-                })
-            } else {
-              // If selected group has no members, set isOpen for the group and its parents
-              this.setIsOpenAndAddMembers(result, this.selectedGroup, [])
-
-              this.groups = result
-              this.loadingGroups = false
-              console.log('groups', this.groups)
-            }
-          } else {
-            // If we are on vocab home page, simply set groups to result
-            this.groups = result
-            this.loadingGroups = false
-            console.log('groups', this.groups)
-          }
-        })
+    beforeUpdate () {
+      this.setListStyle()
     },
-    setIsOpenAndAddMembers (tree, selectedGroup, members) {
-      // Recursive function to find selected group and set its properties
-      const findAndSet = node => {
-        if (node.uri === selectedGroup) {
-          // If selected group was found, set this group to open, add members to it and return true
-          node.isOpen = true
-          node.childGroups.push(...members)
-          return true
+    methods: {
+      handleClickGroupsEvent () {
+        // Only load groups if groups tab is available
+        if (!document.querySelector('#groups > a').classList.contains('disabled')) {
+          this.loadGroups()
         }
-
-        for (const child of node.childGroups) {
-          // Recursively call findAndSet for all children
-          if (findAndSet(child)) {
-            // If selected group was found in children, set this group to open and return true
-            node.isOpen = true
-            return true
-          }
-        }
-
-        // If selected group was not found, return false
-        return false
-      }
-
-      for (const root of tree) {
-        findAndSet(root)
-      }
-    },
-    setListStyle () {
-      const height = document.getElementById('sidebar-tabs').clientHeight
-      const width = document.getElementById('sidebar-tabs').clientWidth - 1
-      this.listStyle = {
-        height: 'calc( 100% - ' + height + 'px )',
-        width: width + 'px'
-      }
-    },
-    loadChildren (group) {
-      // Load children only if group has children and they have not been loaded yet
-      if (group.childGroups.length === 0 && group.hasMembers) {
-        this.loadingChildren.push(group)
-        fetch('rest/v1/' + window.SKOSMOS.vocab + '/groupMembers/?lang=' + window.SKOSMOS.content_lang + '&uri=' + group.uri)
+      },
+      loadGroups () {
+        this.loadingGroups = true
+        fetch('rest/v1/' + window.SKOSMOS.vocab + '/groups/?lang=' + window.SKOSMOS.content_lang)
           .then(data => {
             return data.json()
           })
           .then(data => {
-            console.log('data', data)
-            for (const m of data.members) {
-              group.childGroups.push({ ...m, childGroups: [], isOpen: false, isGroup: false })
+            console.log('groups data', data)
+
+            this.groups = []
+
+            const groups = data.groups
+            const result = []
+
+            // Map groups by uri with group properties for easy lookup
+            const uriMap = new Map()
+            for (const group of groups) {
+              uriMap.set(group.uri, { ...group, childGroups: [], isOpen: false, isGroup: true })
             }
-            this.loadingChildren = this.loadingChildren.filter(x => x !== group)
-            console.log('groups', this.groups)
+
+            // Iterate through groups and set child groups in uriMap
+            for (const group of groups) {
+              if (group.childGroups) {
+                for (const childUri of group.childGroups) {
+                  const child = uriMap.get(childUri)
+                  if (child) {
+                    uriMap.get(group.uri).childGroups.push(child)
+                  }
+                }
+              }
+
+              // Add top level groups to result list
+              if (!groups.some(other => other.childGroups?.includes(group.uri))) {
+                result.push(uriMap.get(group.uri))
+              }
+            }
+
+            return { result, uriMap }
           })
+          .then(({ result, uriMap }) => {
+            // Check that we are on a group page
+            if (uriMap.has(window.SKOSMOS.uri)) {
+              this.selectedGroup = window.SKOSMOS.uri
+
+              // Only load members if selected group has members
+              if (uriMap.get(this.selectedGroup).hasMembers) {
+                fetch('rest/v1/' + window.SKOSMOS.vocab + '/groupMembers/?lang=' + window.SKOSMOS.content_lang + '&uri=' + this.selectedGroup)
+                  .then(data => {
+                    return data.json()
+                  })
+                  .then(data => {
+                    console.log('members data', data)
+                    // Filter out existing groups from members list and add the correct properties
+                    const members = data.members
+                      .filter(m => !uriMap.has(m.uri))
+                      .map(m => {
+                        return { ...m, childGroups: [], isOpen: false, isGroup: false }
+                      })
+
+                    // Set isOpen to true for the selected group and its parents and add child members to selected group
+                    this.setIsOpenAndAddMembers(result, this.selectedGroup, members)
+
+                    this.groups = result
+                    this.loadingGroups = false
+                    console.log('groups', this.groups)
+                  })
+              } else {
+                // If selected group has no members, set isOpen for the group and its parents
+                this.setIsOpenAndAddMembers(result, this.selectedGroup, [])
+
+                this.groups = result
+                this.loadingGroups = false
+                console.log('groups', this.groups)
+              }
+            } else {
+              // If we are on vocab home page, simply set groups to result
+              this.groups = result
+              this.loadingGroups = false
+              console.log('groups', this.groups)
+            }
+          })
+      },
+      setIsOpenAndAddMembers (tree, selectedGroup, members) {
+        // Recursive function to find selected group and set its properties
+        const findAndSet = node => {
+          if (node.uri === selectedGroup) {
+            // If selected group was found, set this group to open, add members to it and return true
+            node.isOpen = true
+            node.childGroups.push(...members)
+            return true
+          }
+
+          for (const child of node.childGroups) {
+            // Recursively call findAndSet for all children
+            if (findAndSet(child)) {
+              // If selected group was found in children, set this group to open and return true
+              node.isOpen = true
+              return true
+            }
+          }
+
+          // If selected group was not found, return false
+          return false
+        }
+
+        for (const root of tree) {
+          findAndSet(root)
+        }
+      },
+      setListStyle () {
+        const height = document.getElementById('sidebar-tabs').clientHeight
+        const width = document.getElementById('sidebar-tabs').clientWidth - 1
+        this.listStyle = {
+          height: 'calc( 100% - ' + height + 'px )',
+          width: width + 'px'
+        }
+      },
+      loadChildren (group) {
+        // Load children only if group has children and they have not been loaded yet
+        if (group.childGroups.length === 0 && group.hasMembers) {
+          this.loadingChildren.push(group)
+          fetch('rest/v1/' + window.SKOSMOS.vocab + '/groupMembers/?lang=' + window.SKOSMOS.content_lang + '&uri=' + group.uri)
+            .then(data => {
+              return data.json()
+            })
+            .then(data => {
+              console.log('data', data)
+              for (const m of data.members) {
+                group.childGroups.push({ ...m, childGroups: [], isOpen: false, isGroup: false })
+              }
+              this.loadingChildren = this.loadingChildren.filter(x => x !== group)
+              console.log('groups', this.groups)
+            })
+        }
       }
-    }
-  },
-  template: `
-    <div v-click-tab-groups="handleClickGroupsEvent" v-resize-window="setListStyle">
-      <div id="groups-list" class="sidebar-list p-0" :style="listStyle">
-        <ul v-if="!loadingGroups" class="list-group">
-          <tab-groups-wrapper
-            :groups="groups"
-            :selectedGroup="selectedGroup"
-            :loadingChildren="loadingChildren"
-            @load-children="loadChildren($event)"
-            @select-group="selectedGroup = $event"
-          ></tab-groups-wrapper>
-        </ul>
-        <i v-else class="fa-solid fa-spinner fa-spin-pulse"></i>
+    },
+    template: `
+      <div v-click-tab-groups="handleClickGroupsEvent" v-resize-window="setListStyle">
+        <div id="groups-list" class="sidebar-list p-0" :style="listStyle">
+          <ul v-if="!loadingGroups" class="list-group">
+            <tab-groups-wrapper
+              :groups="groups"
+              :selectedGroup="selectedGroup"
+              :loadingChildren="loadingChildren"
+              :openAriaMessage="openAriaMessage"
+              :goToTheConceptPageAriaMessage="goToTheConceptPageAriaMessage"
+              @load-children="loadChildren($event)"
+              @select-group="selectedGroup = $event"
+            ></tab-groups-wrapper>
+          </ul>
+          <i v-else class="fa-solid fa-spinner fa-spin-pulse"></i>
+        </div>
       </div>
-    </div>
-  `
-})
+    `
+  })
 
-/* Custom directive used to add an event listener on clicks on the groups nav-item element */
-tabGroupsApp.directive('click-tab-groups', {
-  beforeMount: (el, binding) => {
-    el.clickTabEvent = event => {
-      binding.value() // calling the method given as the attribute value (handleClickGroupsEvent)
+  /* Custom directive used to add an event listener on clicks on the groups nav-item element */
+  tabGroupsApp.directive('click-tab-groups', {
+    beforeMount: (el, binding) => {
+      el.clickTabEvent = event => {
+        binding.value() // calling the method given as the attribute value (handleClickGroupsEvent)
+      }
+      document.querySelector('#groups').addEventListener('click', el.clickTabEvent) // registering an event listener on clicks on the groups nav-item element
+    },
+    unmounted: el => {
+      document.querySelector('#groups').removeEventListener('click', el.clickTabEvent)
     }
-    document.querySelector('#groups').addEventListener('click', el.clickTabEvent) // registering an event listener on clicks on the groups nav-item element
-  },
-  unmounted: el => {
-    document.querySelector('#groups').removeEventListener('click', el.clickTabEvent)
-  }
-})
+  })
 
-/* Custom directive used to add an event listener on resizing the window */
-tabGroupsApp.directive('resize-window', {
-  beforeMount: (el, binding) => {
-    el.resizeWindowEvent = event => {
-      binding.value() // calling the method given as the attribute value (setListStyle)
+  /* Custom directive used to add an event listener on resizing the window */
+  tabGroupsApp.directive('resize-window', {
+    beforeMount: (el, binding) => {
+      el.resizeWindowEvent = event => {
+        binding.value() // calling the method given as the attribute value (setListStyle)
+      }
+      window.addEventListener('resize', el.resizeWindowEvent) // registering an event listener on resizing the window
+    },
+    unmounted: el => {
+      window.removeEventListener('resize', el.resizeWindowEvent)
     }
-    window.addEventListener('resize', el.resizeWindowEvent) // registering an event listener on resizing the window
-  },
-  unmounted: el => {
-    window.removeEventListener('resize', el.resizeWindowEvent)
-  }
-})
+  })
 
-tabGroupsApp.component('tab-groups-wrapper', {
-  props: ['groups', 'selectedGroup', 'loadingChildren'],
-  emits: ['loadChildren', 'selectGroup'],
-  mounted () {
-  },
-  methods: {
-    loadChildren (group) {
-      this.$emit('loadChildren', group)
+  tabGroupsApp.component('tab-groups-wrapper', {
+    props: ['groups', 'selectedGroup', 'loadingChildren', 'openAriaMessage', 'goToTheConceptPageAriaMessage'],
+    emits: ['loadChildren', 'selectGroup'],
+    mounted () {
     },
-    selectGroup (group) {
-      this.$emit('selectGroup', group)
-    }
-  },
-  template: `
-    <template v-for="(g, i) in groups" >
-      <tab-groups
-        :group="g"
-        :selectedGroup="selectedGroup"
-        :isTopGroup="true"
-        :isLast="i == groups.length - 1"
-        :loadingChildren="loadingChildren"
-        @load-children="loadChildren($event)"
-        @select-group="selectGroup($event)"
-      ></tab-groups>
-    </template>
-  `
-})
+    methods: {
+      loadChildren (group) {
+        this.$emit('loadChildren', group)
+      },
+      selectGroup (group) {
+        this.$emit('selectGroup', group)
+      }
+    },
+    template: `
+      <template v-for="(g, i) in groups" >
+        <tab-groups
+          :group="g"
+          :selectedGroup="selectedGroup"
+          :isTopGroup="true"
+          :isLast="i == groups.length - 1"
+          :loadingChildren="loadingChildren"
+          :openAriaMessage="openAriaMessage"
+          :goToTheConceptPageAriaMessage="goToTheConceptPageAriaMessage"
+          @load-children="loadChildren($event)"
+          @select-group="selectGroup($event)"
+        ></tab-groups>
+      </template>
+    `
+  })
 
-tabGroupsApp.component('tab-groups', {
-  props: ['group', 'selectedGroup', 'isTopGroup', 'isLast', 'loadingChildren'],
-  emits: ['loadChildren', 'selectGroup'],
-  inject: ['partialPageLoad', 'getConceptURL', 'showNotation'],
-  methods: {
-    handleClickOpenEvent (group) {
-      group.isOpen = !group.isOpen
-      this.$emit('loadChildren', group)
+  tabGroupsApp.component('tab-groups', {
+    props: ['group', 'selectedGroup', 'isTopGroup', 'isLast', 'loadingChildren', 'openAriaMessage', 'goToTheConceptPageAriaMessage'],
+    emits: ['loadChildren', 'selectGroup'],
+    inject: ['partialPageLoad', 'getConceptURL', 'showNotation'],
+    methods: {
+      handleClickOpenEvent (group) {
+        group.isOpen = !group.isOpen
+        this.$emit('loadChildren', group)
+      },
+      handleClickGroupEvent (event, group) {
+        group.isOpen = true
+        this.$emit('loadChildren', group)
+        this.$emit('selectGroup', group.uri)
+        this.partialPageLoad(event, this.getConceptURL(group.uri))
+      },
+      loadChildrenRecursive (group) {
+        this.$emit('loadChildren', group)
+      },
+      selectGroupRecursive (group) {
+        this.$emit('selectGroup', group)
+      }
     },
-    handleClickGroupEvent (event, group) {
-      group.isOpen = true
-      this.$emit('loadChildren', group)
-      this.$emit('selectGroup', group.uri)
-      this.partialPageLoad(event, this.getConceptURL(group.uri))
-    },
-    loadChildrenRecursive (group) {
-      this.$emit('loadChildren', group)
-    },
-    selectGroupRecursive (group) {
-      this.$emit('selectGroup', group)
-    }
-  },
-  template: `
-    <li class="list-group-item p-0" :class="{ 'top-concept': isTopGroup }">
-      <button type="button" class="hierarchy-button btn btn-primary" aria-label="Open"
-        :class="{ 'open': group.isOpen }"
-        v-if="group.hasMembers"
-        @click="handleClickOpenEvent(group)"
-      >
-        <template v-if="loadingChildren.includes(group)">
-          <i class="fa-solid fa-spinner fa-spin-pulse"></i>
-        </template>
-        <template v-else>
-          <img v-if="group.isOpen" alt="" src="resource/pics/black-lower-right-triangle.png">
-          <img v-else alt="" src="resource/pics/lower-right-triangle.png">
-        </template>
-      </button>
-      <span class="concept-label" :class="{ 'last': isLast }">
-        <i v-if="group.isGroup" class="property-hover fa-solid fa-layer-group"></i>
-        <a :class="{ 'selected': selectedGroup === group.uri }"
-          :href="getConceptURL(group.uri)"
-          @click="handleClickGroupEvent($event, group)"
-          aria-label="Go to the concept page"
+    template: `
+      <li class="list-group-item p-0" :class="{ 'top-concept': isTopGroup }">
+        <button type="button" class="hierarchy-button btn btn-primary"
+          :aria-label="openAriaMessage"
+          :class="{ 'open': group.isOpen }"
+          v-if="group.hasMembers"
+          @click="handleClickOpenEvent(group)"
         >
-          <span v-if="showNotation && group.notation" class="concept-notation">{{ group.notation }} </span>
-          {{ group.prefLabel }}
-        </a>
-      </span>
-      <ul class="list-group ps-3" v-if="group.childGroups.length !== 0 && group.isOpen">
-        <template v-for="(g, i) in group.childGroups">
-          <tab-groups
-            :group="g"
-            :selectedGroup="selectedGroup"
-            :isTopGroup="false"
-            :isLast="i == group.childGroups.length - 1"
-            :loadingChildren="loadingChildren"
-            @load-children="loadChildrenRecursive($event)"
-            @select-group="selectGroupRecursive($event)"
-          ></tab-groups>
-        </template>
-      </ul>
-    </li>
-  `
-})
+          <template v-if="loadingChildren.includes(group)">
+            <i class="fa-solid fa-spinner fa-spin-pulse"></i>
+          </template>
+          <template v-else>
+            <img v-if="group.isOpen" alt="" src="resource/pics/black-lower-right-triangle.png">
+            <img v-else alt="" src="resource/pics/lower-right-triangle.png">
+          </template>
+        </button>
+        <span class="concept-label" :class="{ 'last': isLast }">
+          <i v-if="group.isGroup" class="property-hover fa-solid fa-layer-group"></i>
+          <a :class="{ 'selected': selectedGroup === group.uri }"
+            :href="getConceptURL(group.uri)"
+            @click="handleClickGroupEvent($event, group)"
+            :aria-label="goToTheConceptPageAriaMessage"
+          >
+            <span v-if="showNotation && group.notation" class="concept-notation">{{ group.notation }} </span>
+            {{ group.prefLabel }}
+          </a>
+        </span>
+        <ul class="list-group ps-3" v-if="group.childGroups.length !== 0 && group.isOpen">
+          <template v-for="(g, i) in group.childGroups">
+            <tab-groups
+              :group="g"
+              :selectedGroup="selectedGroup"
+              :isTopGroup="false"
+              :isLast="i == group.childGroups.length - 1"
+              :loadingChildren="loadingChildren"
+              :openAriaMessage="openAriaMessage"
+              :goToTheConceptPageAriaMessage="goToTheConceptPageAriaMessage"
+              @load-children="loadChildrenRecursive($event)"
+              @select-group="selectGroupRecursive($event)"
+            ></tab-groups>
+          </template>
+        </ul>
+      </li>
+    `
+  })
 
-tabGroupsApp.mount('#tab-groups')
+  tabGroupsApp.mount('#tab-groups')
+}
+
+onTranslationReady(startHierarchyApp)

--- a/tests/cypress/template/sidebar-groups.cy.js
+++ b/tests/cypress/template/sidebar-groups.cy.js
@@ -3,7 +3,7 @@ describe('Groups tab', () => {
     // Go to test vocab home page
     cy.visit('/groups/en/')
     // Check that groups tab is available and click it open
-    cy.get('#groups').should('not.have.class', 'disabled').click({force: true})
+    cy.get('#groups').should('not.have.class', 'disabled').click()
     // Check that groups includes correct top groups
     cy.get('#groups-list li').should('have.length', 3).invoke('text')
       .should('contain', 'Fish')
@@ -35,7 +35,7 @@ describe('Groups tab', () => {
     // Go to test vocab home page
     cy.visit('/groups/en/')
     // Click groups tab open
-    cy.get('#groups').should('not.have.class', 'disabled').click({force: true})
+    cy.get('#groups').should('not.have.class', 'disabled').click()
     // Click open button of second group
     cy.get('#groups-list li button').eq(1).click({force: true})
     // Check that child "Carp" is loaded in
@@ -49,12 +49,41 @@ describe('Groups tab', () => {
     // Go to test vocab home page
     cy.visit('/groups/en/')
     // Click groups tab open
-    cy.get('#groups').should('not.have.class', 'disabled').click({force: true})
+    cy.get('#groups').should('not.have.class', 'disabled').click()
     // Click second group
-    cy.get('#groups-list li a').eq(1).click({force: true})
+    cy.get('#groups-list li a').eq(1).click()
     // Check that children are loaded in
     cy.get('#groups-list li ul', {'timeout': 15000}).first().children().should('have.length', 1)
     // Check that child is correct
     cy.get('#groups-list li ul').invoke('text').should('include', 'Carp')
+  })
+  it('Has correct translations', () => {
+    // Go to test vocab home page in English
+    cy.visit('/yso/en/')
+    // Click on groups tab
+    cy.get('#groups').click()
+    // Check that hierarchy button has correct Aria label
+    cy.get('#groups-list').find('ul.list-group button').should('have.attr', 'aria-label', 'Open')
+    // Check that concepts have correct Aria labels
+    cy.get('.concept-label a').first().should('have.attr', 'aria-label', 'Go to the concept page')
+
+    // Go to test vocab home page in Finnish
+    cy.visit('/yso/fi/')
+    // Click on groups tab
+    cy.get('#groups').click()
+    // Check that hierarchy button has correct Aria label
+    cy.get('#groups-list').find('ul.list-group button').should('have.attr', 'aria-label', 'Avaa')
+    // Check that concepts have correct Aria labels
+    cy.get('.concept-label a').first().should('have.attr', 'aria-label', 'Mene käsitesivulle')
+
+    // Go to test vocab home page in Swedish
+    cy.visit('/yso/sv/')
+    // Click on groups tab
+    cy.get('#groups').click()
+    // Check that hierarchy button has correct Aria label
+    cy.get('#groups-list').find('ul.list-group button').should('have.attr', 'aria-label', 'Öppna')
+    // Check that concepts have correct Aria labels
+    cy.get('.concept-label a').first().should('have.attr', 'aria-label', 'Gå till begreppssidan')
+
   })
 })


### PR DESCRIPTION
## Reasons for creating this PR

Translation is not currently implemented in the tab-groups Vue component in Skosmos 3. This PR adds translations.

## Link to relevant issue(s), if any

- Closes #1769
- Part of #1712

## Description of the changes in this PR

- Add translation service for tab-groups Vue component
- Add translations to tab-groups
- Add cypress tests for translations
- Fix other tab-groups cypress tests

## Known problems or uncertainties in this PR

## Checklist

- [ ] phpUnit tests pass locally with my changes
- [ ] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [ ] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [ ] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
