### PR TITLE
Upgrade to Jena Fuseki 5.3.0, including a new Dockerfile

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       context: ./dockerfiles/jena-fuseki2-docker
       dockerfile: Dockerfile
       args:
-        JENA_VERSION: 4.8.0
+        JENA_VERSION: 5.3.0
     command: --config=/fuseki/skosmos.ttl
     environment:
       - JAVA_OPTIONS=-Xmx2g -Xms1g

--- a/dockerfiles/jena-fuseki2-docker/Dockerfile
+++ b/dockerfiles/jena-fuseki2-docker/Dockerfile
@@ -17,9 +17,9 @@
 
 ## This Dockefile builds a reduced footprint container.
 
-ARG JAVA_VERSION=17
+ARG JAVA_VERSION=21
 
-ARG ALPINE_VERSION=3.17.1
+ARG ALPINE_VERSION=3.21.2
 ARG JENA_VERSION=""
 
 # Internal, passed between stages.

--- a/dockerfiles/jena-fuseki2-docker/README.md
+++ b/dockerfiles/jena-fuseki2-docker/README.md
@@ -9,4 +9,4 @@ ask about that again.
 
 The files were copied from the following commit.
 
-26153afe9a229bb7a609d5406d899eb240ab385e
+70e761d88c9e475ccf991873276349b6f8716921

--- a/resource/js/tab-hierarchy.js
+++ b/resource/js/tab-hierarchy.js
@@ -199,7 +199,13 @@ function startHierarchyApp () {
           sensitivity: 'variant' // Strings that differ in base letters, diacritic marks, or case compare as unequal
         }
 
-        return strA.localeCompare(strB, lang, options)
+        const result = strA.localeCompare(strB, lang, options)
+        if (result !== 0) {
+          return result
+        } else {
+          // fall back to non-numeric sort to ensure a consistent order
+          return strA.localeCompare(strB, lang, { sensitivity: 'variant' })
+        }
       }
     },
     template: `

--- a/tests/cypress/template/sidebar-hierarchy.cy.js
+++ b/tests/cypress/template/sidebar-hierarchy.cy.js
@@ -100,16 +100,16 @@ describe('Hierarchy', () => {
   it('Sorts concepts based on notation codes in lexical order', () => {
     // Go to "Tuna" concept page in a vocab with lexical sorting
     cy.visit('/test-notation-sort/en/page/?uri=http%3A%2F%2Fwww.skosmos.skos%2Ftest%2Fta0111')
-    // First and second concepts in hierarchy should be sorted by notation codes in lexical order
-    cy.get('#hierarchy-list .list-group-item').eq(1).find('.concept-notation').invoke('text').should('equal', '33.01')
-    cy.get('#hierarchy-list .list-group-item').eq(2).find('.concept-notation').invoke('text').should('equal', '33.02')
+    // 4th and 5th concepts in hierarchy should be sorted by notation codes in lexical order (33.10 < 33.2)
+    cy.get('#hierarchy-list .list-group-item').eq(4).find('.concept-notation').invoke('text').should('equal', '33.10')
+    cy.get('#hierarchy-list .list-group-item').eq(5).find('.concept-notation').invoke('text').should('equal', '33.2')
   })
   it('Sorts concepts based on notation codes in natural order', () => {
     // Go to "Tuna" concept page in a vocab with natural sorting
     cy.visit('/testNotation/en/page/?uri=http%3A%2F%2Fwww.skosmos.skos%2Ftest%2Fta0111')
-    // First and second concepts in hierarchy should be sorted by notation codes in natural order
-    cy.get('#hierarchy-list .list-group-item').eq(1).find('.concept-notation').invoke('text').should('equal', '33.01')
-    cy.get('#hierarchy-list .list-group-item').eq(2).find('.concept-notation').invoke('text').should('equal', '33.1')
+    // 5th and 6th concepts in hierarchy should be sorted by notation codes in natural order (33.9 < 33.10)
+    cy.get('#hierarchy-list .list-group-item').eq(5).find('.concept-notation').invoke('text').should('equal', '33.9')
+    cy.get('#hierarchy-list .list-group-item').eq(6).find('.concept-notation').invoke('text').should('equal', '33.10')
   })
   // Check the correctness of Aria-labels (Sami language will be implemented later)
   it('Aria tags are correct for each language', () => {

--- a/tests/cypress/template/sidebar-hierarchy.cy.js
+++ b/tests/cypress/template/sidebar-hierarchy.cy.js
@@ -108,8 +108,8 @@ describe('Hierarchy', () => {
     // Go to "Tuna" concept page in a vocab with natural sorting
     cy.visit('/testNotation/en/page/?uri=http%3A%2F%2Fwww.skosmos.skos%2Ftest%2Fta0111')
     // First and second concepts in hierarchy should be sorted by notation codes in natural order
-    cy.get('#hierarchy-list .list-group-item').eq(1).find('.concept-notation').invoke('text').should('equal', '33.1')
-    cy.get('#hierarchy-list .list-group-item').eq(2).find('.concept-notation').invoke('text').should('equal', '33.01')
+    cy.get('#hierarchy-list .list-group-item').eq(1).find('.concept-notation').invoke('text').should('equal', '33.01')
+    cy.get('#hierarchy-list .list-group-item').eq(2).find('.concept-notation').invoke('text').should('equal', '33.1')
   })
   // Check the correctness of Aria-labels (Sami language will be implemented later)
   it('Aria tags are correct for each language', () => {


### PR DESCRIPTION
## Reasons for creating this PR

Our Fuseki version is obsolete, see #1775. This PR upgrades Fuseki to 5.3.0 and also inclusdes some changes to the Fuseki Dockerfile (upgrade from Java 17 to 21 and a newer Alpine Linux base image).

This PR also includes a fix to the natural sorting behavior of the hierarchy tab. The Fuseki upgrade surfaced a problem where the sort order was sometimes inconsistent when using natural sorting by notation code. This PR changes the code to include a fallback sorting order which ensures a consistent sorting result and adjusts the Cypress tests to better reflect important differences between different sorting orders.

## Link to relevant issue(s), if any

- Closes #1775 

## Description of the changes in this PR

- bump JENA_VERSION to 5.3.0 (was 4.7.0)
- upgrade the Dockerfile for Fuseki, copied from Apache Jena
- fall back to non-numeric sort to ensure a consistent natural sorting order in the hierarchy tab
- adjust the hierarchy Cypress tests to better reflect differences between sorting orders

## Known problems or uncertainties in this PR

-

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
