### PR TITLE
Visual layout improvements especially for landing page

### DIFF
--- a/resource/css/skosmos.css
+++ b/resource/css/skosmos.css
@@ -62,15 +62,15 @@ body {
 /* Font awesome
  *****************************************/
   #main-container.landing #info-box .fa-arrow-right {
-    color: var(--info-box-arrow);
+    color: var(--secondary-dark-color);
   }
 
   #main-container.landing-one-vocab #info-box .fa-arrow-right {
-    color: var(--info-box-one-arrow);
+    color: var(--secondary-dark-color);
   }
 
   #vocab-box .fa-arrow-right {
-    color: var(--vocab-box-one-arrow);
+    color: var(--secondary-dark-color);
   }
 
   #main-container.vocab-home .fa-arrow-right, #main-container.concept .fa-arrow-right {

--- a/resource/css/skosmos.css
+++ b/resource/css/skosmos.css
@@ -39,13 +39,12 @@
   --font-size: 1em; /* same as the browser default font size, often 16px */
   --font-family: 'Public Sans', sans-serif;
   --font-family-heading: 'EB Garamond', serif;
-
-  font-family: var(--font-family);
-  font-size: var(--font-size);
 }
 
 body {
   color: var(--dark-color);
+  font-family: var(--font-family);
+  font-size: var(--font-size);
 }
 
 .bg-dark {

--- a/resource/css/skosmos.css
+++ b/resource/css/skosmos.css
@@ -161,7 +161,7 @@ body {
   /* Headerbar
    *****************************************/
   #headerbar.landing, #headerbar.landing-one-vocab {
-    color: var(--headerbar-text-1);
+    color: var(--dark-color);
   }
 
   #headerbar.vocab-home, #headerbar.concept {
@@ -178,13 +178,13 @@ body {
   }
 
   #vocab-title a {
-    color: var(--headerbar-text-2);
+    color: var(--vocab-text);
     font-family: var(--font-family-heading);
     text-decoration: none;
   }
 
   #search-multi-vocab-title {
-    color: var(--headerbar-text-2);
+    color: var(--vocab-text);
     font-family: var(--font-family-heading);
   }
 
@@ -193,7 +193,7 @@ body {
   }
 
   #search-wrapper {
-    color: var(--headerbar-text-2);
+    color: var(--vocab-text);
     float: right;
     height: 3.5em;
 }
@@ -204,7 +204,7 @@ body {
 
   #search-wrapper button.dropdown-toggle {
     background-color: var(--search-bg);
-    color: var(--headerbar-text-2);
+    color: var(--vocab-text);
     border: 1px solid var(--search-border);
     border-radius: 0;
     padding-left: 1rem;
@@ -223,7 +223,7 @@ body {
   #search-wrapper #language-list {
     inset: -3px auto auto 0px !important;
     background-color: var(--search-bg);
-    color: var(--headerbar-text-2);
+    color: var(--vocab-text);
     border: 1px solid var(--search-border);
     border-radius: 0;
   }
@@ -239,7 +239,7 @@ body {
   }
 
   #search-wrapper .form-check-input:checked {
-    background-color: var(--headerbar-text-2);
+    background-color: var(--vocab-text);
   }
 
   #search-wrapper input {
@@ -261,7 +261,7 @@ body {
   #search-wrapper .dropdown-menu {
     transform: translateY(-1px);
     background-color: var(--search-dropdown-bg);
-    color: var(--headerbar-text-2);
+    color: var(--vocab-text);
     border: 1px solid var(--search-border);
     border-radius: 0;
   }
@@ -366,6 +366,7 @@ body {
   }
 
   #main-container h1 {
+    color: var(--dark-color);
     font-family: var(--font-family-heading);
     font-weight: bold;
   }
@@ -783,6 +784,7 @@ body {
   }
 
   .property {
+    color: var(--vocab-text);
     border-top: 1px solid var(--vocab-table-border);
     padding: .5rem 0;
   }
@@ -792,8 +794,9 @@ body {
   }
 
   .property-label h2 {
+    color: var(--dark-color);
     font-weight: bold;
-    font-size: 1.4rem;
+    font-size: 1.2rem;
     margin-bottom: 0;
     display: inline;
   }
@@ -842,11 +845,12 @@ body {
   }
 
   nav#concept-breadcrumbs .breadcrumb-current {
-    color: black;
+    color: var(--dark-color);
     font-weight: normal;
   }
 
   #concept-property-label {
+    color: var(--dark-color);
     align-self: start;
     padding-top: 1.25rem;
   }

--- a/resource/css/skosmos.css
+++ b/resource/css/skosmos.css
@@ -170,10 +170,10 @@ body {
   #skosmos-logo {
     background-image: url(../pics/skosmos-RGB.svg);
     background-repeat: no-repeat;
-    background-position: -20px -20px;
-    width: 400px;
-    height: 110px;
-    background-size: 400px;
+    background-position: -8px -15px;
+    width: 300px;
+    height: 80px;
+    background-size: 300px;
   }
 
   #vocab-title {
@@ -394,6 +394,7 @@ body {
     background-repeat: no-repeat;
     background-size: 650px;
     background-position: -41px calc(100% + 55px);
+    padding-top: 0;
   }
 
   #vocab-box, #welcome-box, #info-box {

--- a/resource/css/skosmos.css
+++ b/resource/css/skosmos.css
@@ -362,7 +362,7 @@ body {
   }
 
   #main-container {
-    padding-top: 2.75rem;
+    padding-top: 2.4rem;
   }
 
   #main-container h1 {
@@ -371,7 +371,11 @@ body {
   }
 
   #main-container-row {
-    --bs-gutter-x: 2.25rem;
+    --bs-gutter-x: 2rem;
+  }
+
+  .mb-custom {
+    margin-bottom: 2rem;
   }
 
   /***** Main container landing page & landing page one vocab *****/
@@ -448,9 +452,6 @@ body {
 
   #main-container.landing #info-box {
     background-color: var(--info-box-bg);
-    height: 100%;
-    display: flex;
-    flex-direction: column;
     justify-content: center;
   }
 

--- a/resource/css/skosmos.css
+++ b/resource/css/skosmos.css
@@ -177,10 +177,13 @@ body {
     background-size: 400px;
   }
 
+  #vocab-title {
+    font-size: 2.5rem;
+  }
+
   #vocab-title a {
     color: var(--vocab-text);
     font-family: var(--font-family-heading);
-    text-decoration: none;
   }
 
   #search-multi-vocab-title {

--- a/resource/css/skosmos.css
+++ b/resource/css/skosmos.css
@@ -376,8 +376,8 @@ body {
     --bs-gutter-x: 2rem;
   }
 
-  .mb-custom {
-    margin-bottom: 2rem;
+  .mb-gutterwidth {
+    margin-bottom: var(--bs-gutter-x);
   }
 
   /***** Main container landing page & landing page one vocab *****/

--- a/resource/css/skosmos.css
+++ b/resource/css/skosmos.css
@@ -369,7 +369,6 @@ body {
   }
 
   #main-container h1 {
-    color: var(--dark-color);
     font-family: var(--font-family-heading);
     font-weight: bold;
   }
@@ -411,9 +410,6 @@ body {
 
   #vocabulary-list h2, #welcome-box h2, #vocab-info h2 {
     font-family: var(--font-family-heading) !important;
-  }
-  #vocabulary-list h2 {
-    color: var(--dark-color);
   }
   header > h2 > a {
     font-family: var(--font-family-heading) !important;
@@ -787,7 +783,6 @@ body {
   }
 
   .property {
-    color: var(--vocab-text);
     border-top: 1px solid var(--vocab-table-border);
     padding: .5rem 0;
   }
@@ -797,7 +792,6 @@ body {
   }
 
   .property-label h2 {
-    color: var(--dark-color);
     font-weight: bold;
     font-size: 1.2rem;
     margin-bottom: 0;
@@ -853,7 +847,6 @@ body {
   }
 
   #concept-property-label {
-    color: var(--dark-color);
     align-self: start;
     padding-top: 1.25rem;
   }

--- a/resource/css/skosmos.css
+++ b/resource/css/skosmos.css
@@ -40,12 +40,12 @@
   --font-family: 'Public Sans', sans-serif;
   --font-family-heading: 'EB Garamond', serif;
 
-  color: var(--dark-color);
   font-family: var(--font-family);
   font-size: var(--font-size);
 }
 
 body {
+  color: var(--dark-color);
 }
 
 .bg-dark {

--- a/resource/css/skosmos.css
+++ b/resource/css/skosmos.css
@@ -374,7 +374,7 @@ body {
     --bs-gutter-x: 2.25rem;
   }
 
-  /***** Main container langing page & landing page one vocab *****/
+  /***** Main container landing page & landing page one vocab *****/
   #background.landing, #background.landing-one-vocab {
     background-color: var(--main-bg-1);
     background-image: var(--landing-stripes-1);
@@ -404,6 +404,9 @@ body {
   #vocabulary-list h2, #welcome-box h2, #vocab-info h2 {
     font-family: var(--font-family-heading) !important;
   }
+  #vocabulary-list h2 {
+    color: var(--dark-color);
+  }
   header > h2 > a {
     font-family: var(--font-family-heading) !important;
     color: var(--dark-color)
@@ -426,11 +429,12 @@ body {
   }
 
   .vocab-category a {
-    /** color: var(--secondary-medium-color) solid; **/
     color: var(--vocab-link);
     font-weight: bold;
-    text-decoration: underline ;
+    text-decoration: underline;
     text-decoration-thickness: 1px;
+    text-decoration-color: var(--secondary-medium-color);
+    text-underline-offset: 0.3rem;
   }
 
   #main-container.landing #vocab-box h2 {

--- a/resource/css/skosmos.css
+++ b/resource/css/skosmos.css
@@ -36,27 +36,16 @@
   --tooltip-border-color: var(--secondary-medium-color);
 
   /* Font definitions */
-  --font-size: 14px;
+  --font-size: 1em; /* same as the browser default font size, often 16px */
   --font-family: 'Public Sans', sans-serif;
   --font-family-heading: 'EB Garamond', serif;
-}
 
-body {
   color: var(--dark-color);
   font-family: var(--font-family);
   font-size: var(--font-size);
 }
 
-.fs-1 {
-  font-size: 4.25em !important;
-}
-
-.fs-2 {
-  font-size: 3.25em !important;
-}
-
-.fs-3 {
-  font-size: 2.75em !important;
+body {
 }
 
 .bg-dark {
@@ -87,25 +76,25 @@ body {
 
   #main-container.vocab-home .fa-arrow-right, #main-container.concept .fa-arrow-right {
     color: var(--vocab-text);
-    font-size: 12px;
+    font-size: .75rem;
     margin: 0 5px;
   }
 
   #main-container.vocab-search  .fa-arrow-right {
     color: var(--vocab-text);
-    font-size: 12px;
+    font-size: .85rem;
   }
 
   #main-container.vocab-search .list-group .fa-solid, #main-container.vocab-search  .list-group .fa-regular {
     color: var(--vocab-text);
-    font-size: 16px;
+    font-size: 1.15rem;
     width: 20px;
     text-align: center;
   }
 
   .fa-magnifying-glass {
     color: var(--search-button-text);
-    font-size: 22px;
+    font-size: 1.6rem;
     margin: calc((38px - 22px) / 2 ) 0; /* (button height - font height) / 2 */
   }
 
@@ -362,7 +351,7 @@ body {
     height: 40px;
     width: 40px;
     padding: 0;
-    font-size: 20px;
+    font-size: 1.4rem;
     z-index: 5;
   }
 
@@ -374,7 +363,6 @@ body {
 
   #main-container {
     padding-top: 2.75rem;
-    font-size: 1rem;
   }
 
   #main-container h1 {
@@ -614,7 +602,7 @@ body {
   /*** sidebar changes tab ***/
   #tab-changes .sidebar-list h2 {
     color: var(--vocab-text);
-    font-size: 20px;
+    font-size: 1.4rem;
     font-weight: bold;
     margin: 0;
   }
@@ -693,7 +681,7 @@ body {
 
   #tab-groups .sidebar-list .list-group-item .concept-label i {
     color: var(--dark-color);
-    font-size: 14px;
+    font-size: 1rem;
   }
 
   .hierarchy-button {
@@ -701,7 +689,7 @@ body {
     color: var(--vocab-text);
     border: none;
     padding: 0;
-    font-size: 10px;
+    font-size: 0.7rem;
   }
 
   .hierarchy-button:hover, .hierarchy-button:active {
@@ -714,7 +702,7 @@ body {
     left: 11px;
     top: 7px;
     z-index: 1;
-    font-size: 12px;
+    font-size: .85rem;
   }
 
   .hierarchy-button img {
@@ -761,7 +749,7 @@ body {
   .select-wrapper::after { /* Also used in feedback form */
     color: var(--vocab-text);
     content: '﹀';
-    font-size: 20px;
+    font-size: 1.4rem;
     position: absolute;
     top: 10px;
     right: 10px;
@@ -800,7 +788,7 @@ body {
 
   .property-label h2 {
     font-weight: bold;
-    font-size: 20px !important;
+    font-size: 1.4rem;
     margin-bottom: 0;
     display: inline;
   }
@@ -864,7 +852,7 @@ body {
 
   #copy-preflabel, #copy-notation {
     color: var(--vocab-text);
-    font-size: 30px;
+    font-size: 2.1rem;
     position: relative;
     bottom: 10px;
     left: 5px;
@@ -1062,7 +1050,7 @@ body {
  /* About page
    *****************************************/
   #about-content a {
-    font-size: 1.0em;
+    font-size: 1.0rem;
     color: var(--vocab-link);
     text-decoration: underline var(--secondary-medium-color) solid;
     font-weight: 700;
@@ -1073,7 +1061,7 @@ body {
   }
 
   .vocab-statistics > h3 {
-    font-size: 20px !important;
+    font-size: 1.4rem;
   }
 
 /* Tooltips */

--- a/src/view/base-template.twig
+++ b/src/view/base-template.twig
@@ -80,9 +80,9 @@
       <div class="row">
         <div class="col-7">
           {% if pageType == 'vocab-home' %}
-            <h1 class="fs-2 fw-bold text-decoration-none" id="vocab-title"><a class="text-decoration-none" href="{% if request.vocabid != '' %}{{ request.vocabid  }}/{% endif %}{{ request.lang }}/{% if request.contentLang != request.lang %}?clang={{ request.contentLang }}{% endif %}">{{ request.vocab.title(request.contentLang) }}</a></h1>
+            <h1 class="fw-bold" id="vocab-title"><a class="text-decoration-none" href="{% if request.vocabid != '' %}{{ request.vocabid  }}/{% endif %}{{ request.lang }}/{% if request.contentLang != request.lang %}?clang={{ request.contentLang }}{% endif %}">{{ request.vocab.title(request.contentLang) }}</a></h1>
           {% else%}
-            <h2 class="fs-2 fw-bold text-decoration-none" id="vocab-title"><a class="text-decoration-none" href="{% if request.vocabid != '' %}{{ request.vocabid  }}/{% endif %}{{ request.lang }}/{% if request.contentLang != request.lang %}?clang={{ request.contentLang }}{% endif %}">{{ request.vocab.title(request.contentLang) }}</a></h2>
+            <h2 class="fw-bold" id="vocab-title"><a class="text-decoration-none" href="{% if request.vocabid != '' %}{{ request.vocabid  }}/{% endif %}{{ request.lang }}/{% if request.contentLang != request.lang %}?clang={{ request.contentLang }}{% endif %}">{{ request.vocab.title(request.contentLang) }}</a></h2>
           {% endif %}
         </div>
         <div class="col-5">

--- a/src/view/base-template.twig
+++ b/src/view/base-template.twig
@@ -107,16 +107,17 @@
   <footer class="bg-white pb-5 mt-5">
     <div class="container py-5">
       <div class="row">
-        <div class="col-md-7 pe-5">
-          <p class="fs-5">
+        <div class="col-md-5 pe-5">
+          <p class="fs-6">
                     Skosmos is a web-based tool providing services for accessing controlled vocabularies,
                     which are used by indexers describing documents and searchers looking
                     for suitable keywords. Vocabularies are accessed via SPARQL endpoints containing SKOS vocabularies.
           </p>
         </div>
+        <div class="col-md-2"></div>
         <div class="col-md-5 px-3">
-          <span class="fs-5 fw-bold">{{ "Contact us!" | trans }}</span>
-          <p class="fs-5">Yhteystiedot?<p>
+          <span class="fs-6 fw-bold">{{ "Contact us!" | trans }}</span>
+          <p class="fs-6">Yhteystiedot?<p>
         </div>
       </div>
     </div>

--- a/src/view/landing.twig
+++ b/src/view/landing.twig
@@ -5,7 +5,7 @@
 {% block url %}{{ BaseHref }}{{ request.langurl }}{% endblock %}
 
 {% block content %}
-<div class="col-md-7">
+<div class="col-lg-7 mb-custom mb-lg-0">
   <div class="px-4 py-4 bg-medium" id="vocabulary-list">
     {% if request.vocabList|length == 0 %}
     <h2 class="fs-3 fw-bold">{{ "No vocabularies on the server!" | trans }}</h2>
@@ -28,29 +28,20 @@
     {% endif %}
   </div>
 </div>
-<div class="col-md-5">
-  <div class="gy-5 row h-100 flex-column">
-    <div class="col-md-12">
-      <div class="bg-dark px-5 py-5 text-light" id="welcome-box">
-
+<div class="col-lg-5 d-flex flex-column">
+      <div class="bg-dark px-5 py-5 mb-custom text-light" id="welcome-box">
         <h2 class="fw-bold fs-3">Welcome to the Skosmos browser demo</h2>
         <p class="fs-5">
         Skosmos is a web-based tool providing services for accessing controlled vocabularies, 
         which are used by indexers describing documents and searchers looking
         for suitable keywords. Vocabularies are accessed via SPARQL endpoints containing SKOS vocabularies.
         </p>
-        <p class="fs-5">Skosmos is being developed at the National library of Finland.</p>
-
+        <p class="fs-5">Skosmos is being developed at the National Library of Finland.</p>
       </div>
-    </div>
-    <div class="col-md-12 flex-grow-1">
-      <div class="bg-medium px-5 py-5" id="info-box">
 
+      <div class="bg-medium px-5 py-5 flex-grow-1 d-flex align-items-center" id="info-box">
         <a class="fs-5 text-dark text-decoration-none" href="#">Skosmos is open source and on GitHub -></a>
-
       </div>
-    </div>
-  </div>
 </div>
 {% endblock %}
 

--- a/src/view/landing.twig
+++ b/src/view/landing.twig
@@ -6,14 +6,14 @@
 
 {% block content %}
 <div class="col-lg-7 mb-custom mb-lg-0">
-  <div class="px-4 py-4 bg-medium" id="vocabulary-list">
+  <div class="px-3 py-4 bg-medium" id="vocabulary-list">
     {% if request.vocabList|length == 0 %}
     <h2 class="fs-3 fw-bold">{{ "No vocabularies on the server!" | trans }}</h2>
     {% else %}
       {% if category_label %}
-      <h2 class="fs-3 fw-bold py-3">{{ category_label }}</h2>
+      <h2 class="fs-3 fw-bold pb-3">{{ category_label }}</h2>
       {% else %}
-      <h2 class="fs-3 fw-bold py-3">{{ "Vocabularies" | trans }}</h2>
+      <h2 class="fs-3 fw-bold pb-3">{{ "Vocabularies" | trans }}</h2>
       {% endif %}
       {% for vocabClassName,vocabArray in request.vocabList %}
       <div class="vocab-category border-top pb-4">
@@ -29,8 +29,8 @@
   </div>
 </div>
 <div class="col-lg-5 d-flex flex-column">
-      <div class="bg-dark px-5 py-5 mb-custom text-light" id="welcome-box">
-        <h2 class="fw-bold fs-3">Welcome to the Skosmos browser demo</h2>
+      <div class="bg-dark px-4 py-4 mb-custom text-light" id="welcome-box">
+        <h2 class="fw-bold fs-3 my-3">Welcome to the Skosmos browser demo</h2>
         <p class="fs-5">
         Skosmos is a web-based tool providing services for accessing controlled vocabularies, 
         which are used by indexers describing documents and searchers looking

--- a/src/view/landing.twig
+++ b/src/view/landing.twig
@@ -8,19 +8,19 @@
 <div class="col-md-7">
   <div class="px-4 py-4 bg-medium" id="vocabulary-list">
     {% if request.vocabList|length == 0 %}
-    <h2 class="fs-2 fw-bold">{{ "No vocabularies on the server!" | trans }}</h2>
+    <h2 class="fs-3 fw-bold">{{ "No vocabularies on the server!" | trans }}</h2>
     {% else %}
       {% if category_label %}
-      <h2 class="fs-2 fw-bold py-3">{{ category_label }}</h2>
+      <h2 class="fs-3 fw-bold py-3">{{ category_label }}</h2>
       {% else %}
-      <h2 class="fs-2 fw-bold py-3">{{ "Available vocabularies and ontologies" | trans }}</h2>
+      <h2 class="fs-3 fw-bold py-3">{{ "Available vocabularies and ontologies" | trans }}</h2>
       {% endif %}
       {% for vocabClassName,vocabArray in request.vocabList %}
-      <div class="vocab-category border-top pb-5">
-        <h3 class="fs-3 pt-2">{{ vocabClassName }}</h3>
+      <div class="vocab-category border-top pb-4">
+        <h3 class="fs-4 pt-2">{{ vocabClassName }}</h3>
         <ul class="list-group">
         {% for vocab in vocabArray %}
-          <li class="list-group-item border-0 ps-0"><a class="fs-4 fw-bold" href="{{ vocab.id }}/{{ request.lang }}/{% if request.contentLang != request.lang and request.contentLang != '' and request.contentLang in vocab.config.languages %}?clang={{ request.contentLang }}{% endif %}">{{ vocab.title }}</a></li>
+          <li class="list-group-item ps-0 py-1"><a class="fs-5 fw-bold" href="{{ vocab.id }}/{{ request.lang }}/{% if request.contentLang != request.lang and request.contentLang != '' and request.contentLang in vocab.config.languages %}?clang={{ request.contentLang }}{% endif %}">{{ vocab.title }}</a></li>
         {% endfor %}
         </ul>
       </div>
@@ -33,20 +33,20 @@
     <div class="col-md-12">
       <div class="bg-dark px-5 py-5 text-light" id="welcome-box">
 
-        <h2 class="fw-bold fs-2">Welcome to the Skosmos browser demo</h2>
-        <p class="fs-4">
+        <h2 class="fw-bold fs-3">Welcome to the Skosmos browser demo</h2>
+        <p class="fs-5">
         Skosmos is a web-based tool providing services for accessing controlled vocabularies, 
         which are used by indexers describing documents and searchers looking
         for suitable keywords. Vocabularies are accessed via SPARQL endpoints containing SKOS vocabularies.
         </p>
-        <p class="fs-4">Skosmos is being developed at the National library of Finland.</p>
+        <p class="fs-5">Skosmos is being developed at the National library of Finland.</p>
 
       </div>
     </div>
     <div class="col-md-12 flex-grow-1">
       <div class="bg-medium px-5 py-5" id="info-box">
 
-        <a class="fs-4 text-dark text-decoration-none" href="#">Skosmos is open source and on GitHub -></a>
+        <a class="fs-5 text-dark text-decoration-none" href="#">Skosmos is open source and on GitHub -></a>
 
       </div>
     </div>

--- a/src/view/landing.twig
+++ b/src/view/landing.twig
@@ -13,7 +13,7 @@
       {% if category_label %}
       <h2 class="fs-3 fw-bold py-3">{{ category_label }}</h2>
       {% else %}
-      <h2 class="fs-3 fw-bold py-3">{{ "Available vocabularies and ontologies" | trans }}</h2>
+      <h2 class="fs-3 fw-bold py-3">{{ "Vocabularies" | trans }}</h2>
       {% endif %}
       {% for vocabClassName,vocabArray in request.vocabList %}
       <div class="vocab-category border-top pb-4">

--- a/src/view/landing.twig
+++ b/src/view/landing.twig
@@ -40,7 +40,7 @@
       </div>
 
       <div class="bg-medium px-5 py-5 flex-grow-1 d-flex align-items-center" id="info-box">
-        <a class="fs-5 text-dark text-decoration-none" href="#">Skosmos is open source and on GitHub -></a>
+        <a class="fs-5 text-dark text-decoration-none" href="https://github.com/NatLibFi/Skosmos">Skosmos is open source and on GitHub <i class="fa-solid fa-arrow-right ps-2"></i></a>
       </div>
 </div>
 {% endblock %}

--- a/src/view/landing.twig
+++ b/src/view/landing.twig
@@ -5,7 +5,7 @@
 {% block url %}{{ BaseHref }}{{ request.langurl }}{% endblock %}
 
 {% block content %}
-<div class="col-lg-7 mb-custom mb-lg-0">
+<div class="col-lg-7 mb-gutterwidth mb-lg-0">
   <div class="px-3 py-4 bg-medium" id="vocabulary-list">
     {% if request.vocabList|length == 0 %}
     <h2 class="fs-3 fw-bold">{{ "No vocabularies on the server!" | trans }}</h2>
@@ -29,7 +29,7 @@
   </div>
 </div>
 <div class="col-lg-5 d-flex flex-column">
-      <div class="bg-dark px-4 py-4 mb-custom text-light" id="welcome-box">
+      <div class="bg-dark px-4 py-4 mb-gutterwidth text-light" id="welcome-box">
         <h2 class="fw-bold fs-3 my-3">Welcome to the Skosmos browser demo</h2>
         <p class="fs-5">
         Skosmos is a web-based tool providing services for accessing controlled vocabularies, 


### PR DESCRIPTION
## Reasons for creating this PR

The landing page didn't follow the visual spec very well and there were issues with font sizes, with some users seeing absurdly large text. This PR attempts to fix the font size inconsistency issue by changing all font-size declarations to use `rem` units. There are many visual improvements to the landing page layout as well as some adjustments that also affect other page types.

## Link to relevant issue(s), if any

- part of #1480 (mostly)
- closes #1320 

## Description of the changes in this PR

- always specify font sizes in `rem` (except for the `:root` element, where `em` is better)
- adjust landing page layout to better follow visual spec
- make landing page layout responsive & columns equal height
- adjust footer layout to better follow visual spec, at least on landing page
- set landing page default headline to "Vocabularies" (can be overridden in config.ttl)
- many small adjustments to font sizes, colors etc., also affecting other page types

## Known problems or uncertainties in this PR

- I hope I didn't break anything too badly when changing CSS rules

## Checklist

- [ ] phpUnit tests pass locally with my changes
- [ ] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [ ] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [ ] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
