### PR TITLE
Fix GitHub Actions for Skosmos 2: Upgrade actions/cache to v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         fetch-depth: 0
 
     - name: Cache Fuseki installation
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: tests/apache-jena-fuseki-*
         key: fuseki-${{ hashFiles('tests/init_fuseki.sh') }}
@@ -34,7 +34,7 @@ jobs:
       run: cd tests; sh ./init_fuseki.sh
     
     - name: Cache Composer dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           /tmp/composer-cache


### PR DESCRIPTION
## Reasons for creating this PR

This PR fixes GitHub Actions CI for Skosmos 2. The `actions/cache@v2` action was discontinued. This PR upgrades to `v3` which still works.

See https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down

