### PR TITLE
WIP: optimize change list / New tab SPARQL query

### DIFF
--- a/controller/WebController.php
+++ b/controller/WebController.php
@@ -595,14 +595,15 @@ class WebController extends Controller
      * @param string $prop the name of the property eg. 'dc:modified'.
      * @param int $offset starting index offset
      * @param int $limit maximum number of concepts to return
+     * @param int $cutoffYears amount of years to consider past current date
      * @return Array list of concepts
      */
-    public function getChangeList($request, $prop, $offset=0, $limit=200)
+    public function getChangeList($request, $prop, $offset=0, $limit=200, $cutoffYears=1)
     {
         // set language parameters for gettext
         $this->setLanguageProperties($request->getLang());
 
-        return $request->getVocab()->getChangeList($prop, $request->getContentLang(), $offset, $limit);
+        return $request->getVocab()->getChangeList($prop, $request->getContentLang(), $offset, $limit, $cutoffYears);
     }
 
     /**

--- a/model/sparql/GenericSparql.php
+++ b/model/sparql/GenericSparql.php
@@ -2278,15 +2278,16 @@ EOQ;
      * @param int $offset offset of results to retrieve; 0 for beginning of list
      * @param int $limit maximum number of results to return
      * @param boolean $showDeprecated whether to include deprecated concepts in the change list
+     * @param int $cutoffYears amount of years to consider past current date
      * @return string sparql query
      */
-    private function generateChangeListQuery($prop, $lang, $offset, $limit=200, $showDeprecated=false) {
+    private function generateChangeListQuery($prop, $lang, $offset, $limit=200, $showDeprecated=false, $cutoffYears=1) {
         $fcl = $this->generateFromClause();
         $offset = ($offset) ? 'OFFSET ' . $offset : '';
 
         // only consider concepts changed within 1 year from today
         $date = new DateTime();
-        $date->modify('-1 year');
+        $date->modify("-$cutoffYears year");
         $cutoffDate = $date->format('Y-m-d');
 
         //Additional clauses when deprecated concepts need to be included in the results
@@ -2382,10 +2383,11 @@ EOQ;
      * @param int $offset offset of results to retrieve; 0 for beginning of list
      * @param int $limit maximum number of results to return
      * @param boolean $showDeprecated whether to include deprecated concepts in the change list
+     * @param int $cutoffYears amount of years to consider past current date
      * @return array Result array
      */
-    public function queryChangeList($prop, $lang, $offset, $limit, $showDeprecated=false) {
-        $query = $this->generateChangeListQuery($prop, $lang, $offset, $limit, $showDeprecated);
+    public function queryChangeList($prop, $lang, $offset, $limit, $showDeprecated=false, $cutoffYears=1) {
+        $query = $this->generateChangeListQuery($prop, $lang, $offset, $limit, $showDeprecated, $cutoffYears);
 
         $result = $this->query($query);
         return $this->transformChangeListResults($result);

--- a/tests/GenericSparqlTest.php
+++ b/tests/GenericSparqlTest.php
@@ -1219,7 +1219,7 @@ class GenericSparqlTest extends PHPUnit\Framework\TestCase
     $voc = $this->model->getVocabulary('changes');
     $graph = $voc->getGraph();
     $sparql = new GenericSparql($this->endpoint, $graph, $this->model);
-    $actual = $sparql->queryChangeList('dc:modified', 'en', 0, 10, false);
+    $actual = $sparql->queryChangeList('dc:modified', 'en', 0, 10, false, 100);
 
     $order = array();
     foreach($actual as $concept) {
@@ -1239,7 +1239,7 @@ class GenericSparqlTest extends PHPUnit\Framework\TestCase
     $voc = $this->model->getVocabulary('changes');
     $graph = $voc->getGraph();
     $sparql = new GenericSparql($this->endpoint, $graph, $this->model);
-    $actual = $sparql->queryChangeList('dc:created', 'en', 0, 10, true);
+    $actual = $sparql->queryChangeList('dc:created', 'en', 0, 10, true, 100);
     $order = array();
     foreach($actual as $concept) {
         array_push($order, $concept['prefLabel']);

--- a/tests/VocabularyTest.php
+++ b/tests/VocabularyTest.php
@@ -437,7 +437,7 @@ class VocabularyTest extends \PHPUnit\Framework\TestCase
    */
   public function testGetChangeList() {
     $vocab = $this->model->getVocabulary('changes');
-    $changeList = $vocab->getChangeList('dc:created','en', 0, 5);
+    $changeList = $vocab->getChangeList('dc:created','en', 0, 5, cutoffYears: 100);
     $expected = array ('uri' => 'http://www.skosmos.skos/changes/d3', 'prefLabel' => 'Hurr Durr', 'date' => DateTime::__set_state(array('date' => '2010-02-12 10:26:39.000000', 'timezone_type' => 3, 'timezone' => 'UTC')), 'deprecated' => false);
     $this->assertEquals($expected, $changeList[2]);
   }

--- a/tests/WebControllerTest.php
+++ b/tests/WebControllerTest.php
@@ -220,7 +220,7 @@ class WebControllerTest extends TestCase
         $request->setContentLang('en');
         $request->setQueryParam('offset', '0');
 
-        $changeList = $this->webController->getChangeList($request, 'dc:created');
+        $changeList = $this->webController->getChangeList($request, 'dc:created', cutoffYears: 100);
         $months =$this->webController->formatChangeList($changeList, 'en');
 
         $expected = array ('hurr durr' => array ('uri' => 'http://www.skosmos.skos/changes/d3', 'prefLabel' => 'Hurr Durr', 'date' => DateTime::__set_state(array('date' => '2010-02-12 10:26:39.000000', 'timezone_type' => 3, 'timezone' => 'UTC')), 'datestring' => 'Feb 12, 2010', 'deprecated' => false), 'second date' => array ('uri' => 'http://www.skosmos.skos/changes/d2', 'prefLabel' => 'Second date', 'date' => DateTime::__set_state(array('date' => '2010-02-12 15:26:39.000000', 'timezone_type' => 3, 'timezone' => 'UTC')), 'datestring' => 'Feb 12, 2010', 'deprecated' => false));


### PR DESCRIPTION
This is work in progress. It's not yet functional.

## Reasons for creating this PR

I'm trying to optimize the "New" / "New and Deprecated" tab that shows the recently added (or deprecated) concepts. It is very slow, especially in the case of a large vocabulary such as KANTO/finaf.

The optimized SPARQL query in this PR introduces a cutoff date, by default 1 year in the past. Only concepts whose timestamp (created or modified, depending on circumstances) is after this cutoff date are included in the query results. This drastically reduces the number of concepts to consider and so speeds up the query by a factor of approximately 10 (yso) to 15 (finaf).

## Link to relevant issue(s), if any

n/a

## Description of the changes in this PR

- optimize the SPARQL query that queries the new and deprecated concepts, introducing a cutoff date
- try to fix the unit tests that broke due to the above

## Known problems or uncertainties in this PR

Unfortunately, this change causes problems for the unit tests. The test data is much older than 1 year, so a lot of tests will fail because the time stamps are older than the default cutoff date. I tried to fix this by making the cutoff date into a parameter, but this makes the code more complicated, and I didn't yet get it working. I wonder if another mechanism - for example a configuration setting that sets the cutoff date - would work better for this.

This PR is against skosmos-2, because the functionality would be useful in current (Skosmos 2.x) based Finto. However, the same change should be made to Skosmos 3 (main) as well.

## Checklist

- [ ] phpUnit tests pass locally with my changes
- [ ] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
