### PR TITLE
Narrower container for landing & other global page types

### DIFF
--- a/resource/css/skosmos.css
+++ b/resource/css/skosmos.css
@@ -359,7 +359,7 @@ body {
 
   /* Main container
    *****************************************/
-  .container {
+  .vocab-home .container, .concept .container, .vocab-search .container {
     max-width: 1460px !important;
   }
 


### PR DESCRIPTION
## Reasons for creating this PR

The landing page is too wide, it doesn't match the layout spec.

This PR adjusts the landing page and other global page types so that the container is a bit narrower on typical desktop browser window sizes. In practice, it reverts the landing page to the default Bootstrap 5 widths for `.container` while retaining the expanded 1460px width for the vocabulary-specific page types (vocab-home, concept, vocab-search).

## Link to relevant issue(s), if any

- Part of #1480 

## Description of the changes in this PR

* set max-width: 1460px only for vocabulary-specific page types instead of all of them

## Known problems or uncertainties in this PR

Not sure if these widths are ideal, but at least it should be an improvement.

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
