### PR TITLE
Upgrade to Fuseki 5.4.0 in Skosmos tests and containers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       context: ./dockerfiles/jena-fuseki2-docker
       dockerfile: Dockerfile
       args:
-        JENA_VERSION: 5.3.0
+        JENA_VERSION: 5.4.0
     command: --config=/fuseki/skosmos.ttl
     environment:
       - JAVA_OPTIONS=-Xmx2g -Xms1g

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 services:
   fuseki:
     hostname: fuseki

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 services:
   fuseki:
     extends:


### PR DESCRIPTION
## Reasons for creating this PR

There was a new release 5.4.0 of Jena Fuseki that fixes a timeout enforcement bug. It makes sense to upgrade to that version for Skosmos, because long-running queries are quite common.

This PR also contains a minor fix to docker-compose.yml files: dropping the obsolete `version` option.

## Link to relevant issue(s), if any

- follow-up to #1775 and PR #1778 that upgraded to Fuseki 5.3.0

## Description of the changes in this PR

* upgrade Fuseki to 5.4.0
* drop obsolete version option from docker compose files

## Known problems or uncertainties in this PR

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
