### PR TITLE
Set max width for topbar and headerbar

### DIFF
--- a/resource/css/skosmos.css
+++ b/resource/css/skosmos.css
@@ -145,6 +145,7 @@ body {
     background-repeat: no-repeat;
     width: 168px;
     height: 60px;
+    display: inline-block;
   }
 
   #skosmos-logo-top h2 {
@@ -166,6 +167,11 @@ body {
 
   #headerbar.vocab-home, #headerbar.concept {
     background-color: var(--headerbar-vocab-bg);
+  }
+
+  header .container-fluid .row {
+    max-width: 1460px;
+    margin: 0 auto;
   }
 
   #skosmos-logo {

--- a/src/view/base-template.twig
+++ b/src/view/base-template.twig
@@ -35,61 +35,67 @@
 <body class="{% if pageType =='landing' %}bg-white frontpage-logo{% else %}{% if pageType == 'concept' or pageType == 'vocab-home' %}bg-medium vocab-{{ request.vocabid }}{% else %}bg-light{% endif %}{% endif %}">
   <header>
     <a class="visually-hidden" id="skiptocontent" href="{{ request.langurl }}#maincontent">Skip to main</a>
-    <div class="container-fluid bg-dark d-flex my-auto py-3 px-4 text-bg-dark">
-      {% if request.vocabid == '' and request.page != 'about' and request.page != 'feedback' %}
-        <span class="fs-6 py-3 text-light">Yhteishaku sanastoista v</span>
-      {% else %}
-        <a id="skosmos-logo-top" href="{{ request.lang }}/{% if request.contentLang and request.contentLang != request.lang %}?clang={{ request.contentLang }}{% endif %}{% if request.queryParam('anylang') == 'on' %}{% if request.contentLang == request.lang %}?{% else %}&{% endif %}anylang=on{% endif %}">
-          <h2 class="visually-hidden">Skosmos</h2>
-        </a>
-      {% endif %}
-      <ul class="nav nav-pills ms-auto my-auto text-light gx-3 py-3" id="topbar-nav">
-        <li class="nav-item">
-          <a href="{{ request.lang }}/{% if request.contentLang and request.contentLang != request.lang %}?clang={{ request.contentLang }}{% endif %}{% if request.queryParam('anylang') == 'on' %}{% if request.contentLang == request.lang %}?{% else %}&{% endif %}anylang=on{% endif %}" id="navi1" class="fs-6 text-light topbar-nav-link ms-3 text-decoration-none" >
-                   <i class="fa-solid fa-house"></i>&nbsp;{{ "Vocabularies" | trans }}
-          </a>
-        </li>
-        <li class="nav-item">
-          <a href="{{ request.lang }}/about{% if request.contentLang and request.contentLang != request.lang %}?clang={{ request.contentLang }}{% endif %}{% if request.queryParam('anylang') == 'on' %}{% if request.contentLang == request.lang %}?{% else %}&{% endif %}anylang=on{% endif %}" id="navi2" class="fs-6 text-light topbar-nav-link ms-3 text-decoration-none">
-                   <i class="fa-solid fa-circle-info"></i>&nbsp;{{ "About" | trans }}
-          </a>
-        </li>
-        <li class="nav-item">
-          <a href="{% if request.vocabid and vocab.title%}{{ request.vocabid }}/{% endif %}{{ request.lang }}/feedback{% if request.contentLang and request.contentLang != request.lang %}?clang={{ request.contentLang }}{% endif %}{% if request.queryParam('anylang') == 'on' %}{% if request.contentLang == request.lang %}?{% else %}&{% endif %}anylang=on{% endif %}" id="navi3" class="fs-6 text-light topbar-nav-link ms-3 text-decoration-none">
-                   <i class="fa-solid fa-comment"></i>&nbsp;{{ "Feedback" | trans }}
-          </a>
-        </li>
-        {% if languages|length > 1 %}
-        {% for langcode, langdata in languages %}
-        {% if request.lang != langcode %}
-        <li class="nav-item language">
-          <a class="fs-6 text-light ms-3 text-decoration-none" id="language-{{ langcode }}" href="{{ request.langurl(langcode) }}"> {{ langdata.name }}</a>
-        </li>
-        {% endif %}
-        {% endfor %}
-        {% endif %}
-      </ul>
+    <div class="container-fluid bg-dark text-bg-dark">
+      <div class="row">
+        <div class="col-md-5">
+          {% if request.vocabid == '' and request.page != 'about' and request.page != 'feedback' %}
+            <span class="fs-6 py-3 text-light">Yhteishaku sanastoista v</span>
+          {% else %}
+            <a id="skosmos-logo-top" href="{{ request.lang }}/{% if request.contentLang and request.contentLang != request.lang %}?clang={{ request.contentLang }}{% endif %}{% if request.queryParam('anylang') == 'on' %}{% if request.contentLang == request.lang %}?{% else %}&{% endif %}anylang=on{% endif %}">
+              <h2 class="visually-hidden">Skosmos</h2>
+            </a>
+          {% endif %}
+            </div>
+            <div class="col-md-7 text-end px-4">
+          <ul class="list-inline nav nav-pills d-flex justify-content-end ms-auto my-auto text-light gx-3 py-3" id="topbar-nav">
+            <li class="list-inline-item nav-item">
+              <a href="{{ request.lang }}/{% if request.contentLang and request.contentLang != request.lang %}?clang={{ request.contentLang }}{% endif %}{% if request.queryParam('anylang') == 'on' %}{% if request.contentLang == request.lang %}?{% else %}&{% endif %}anylang=on{% endif %}" id="navi1" class="fs-6 text-light topbar-nav-link ms-3 text-decoration-none" >
+                       <i class="fa-solid fa-house"></i>&nbsp;{{ "Vocabularies" | trans }}
+              </a>
+            </li>
+            <li class="list-inline-item nav-item">
+              <a href="{{ request.lang }}/about{% if request.contentLang and request.contentLang != request.lang %}?clang={{ request.contentLang }}{% endif %}{% if request.queryParam('anylang') == 'on' %}{% if request.contentLang == request.lang %}?{% else %}&{% endif %}anylang=on{% endif %}" id="navi2" class="fs-6 text-light topbar-nav-link ms-3 text-decoration-none">
+                       <i class="fa-solid fa-circle-info"></i>&nbsp;{{ "About" | trans }}
+              </a>
+            </li>
+            <li class="list-inline-item nav-item">
+              <a href="{% if request.vocabid and vocab.title%}{{ request.vocabid }}/{% endif %}{{ request.lang }}/feedback{% if request.contentLang and request.contentLang != request.lang %}?clang={{ request.contentLang }}{% endif %}{% if request.queryParam('anylang') == 'on' %}{% if request.contentLang == request.lang %}?{% else %}&{% endif %}anylang=on{% endif %}" id="navi3" class="fs-6 text-light topbar-nav-link ms-3 text-decoration-none">
+                       <i class="fa-solid fa-comment"></i>&nbsp;{{ "Feedback" | trans }}
+              </a>
+            </li>
+            {% if languages|length > 1 %}
+            {% for langcode, langdata in languages %}
+            {% if request.lang != langcode %}
+            <li class="list-inline-item nav-item language">
+              <a class="fs-6 text-light ms-3 text-decoration-none" id="language-{{ langcode }}" href="{{ request.langurl(langcode) }}"> {{ langdata.name }}</a>
+            </li>
+            {% endif %}
+            {% endfor %}
+            {% endif %}
+          </ul>
+        </div>
+      </div>
     </div>
     {% if pageType == 'landing' or pageType == 'vocab-home' or pageType == 'concept' %}
-    <div class="container-fluid bg-white py-4 px-4" id="headerbar">
-      {% if pageType == 'landing' %}
-        <div id="skosmos-logo">
+    <div class="container-fluid bg-white py-4" id="headerbar">
+      <div class="row">
+        {% if pageType == 'landing' %}
+        <div class="col px-4" id="skosmos-logo">
           <h1 class="visually-hidden">Skosmos</h1>
         </div>
-      {% else %}
-      <div class="row">
-        <div class="col-7">
+        {% else %}
+        <div class="col-7 px-3">
           {% if pageType == 'vocab-home' %}
             <h1 class="fw-bold" id="vocab-title"><a class="text-decoration-none" href="{% if request.vocabid != '' %}{{ request.vocabid  }}/{% endif %}{{ request.lang }}/{% if request.contentLang != request.lang %}?clang={{ request.contentLang }}{% endif %}">{{ request.vocab.title(request.contentLang) }}</a></h1>
-          {% else%}
+          {% else %}
             <h2 class="fw-bold" id="vocab-title"><a class="text-decoration-none" href="{% if request.vocabid != '' %}{{ request.vocabid  }}/{% endif %}{{ request.lang }}/{% if request.contentLang != request.lang %}?clang={{ request.contentLang }}{% endif %}">{{ request.vocab.title(request.contentLang) }}</a></h2>
           {% endif %}
         </div>
         <div class="col-5">
           <div id="search-vocab"></div>
         </div>
+        {% endif %}
       </div>
-      {% endif %}
     </div>
     {% endif %}
   </header>


### PR DESCRIPTION
## Reasons for creating this PR

The layout of the top header looks funny on very wide screens, because the contents (logo, navigation links etc.) are placed near the edges of the page.

This PR changes the header elements to use Bootstrap Grid classes (row, col) and then sets a max-width of 1460px for the contents. Also some margins and paddings are adjusted. The end result is that the navigation elements at the top are kept in the middle of the page, not near the edges.

## Link to relevant issue(s), if any

- part of #1480

## Description of the changes in this PR

* use Bootstrap Grid classes for header
* add max-width 1460px for the header elements
* adjust margins and paddings

## Known problems or uncertainties in this PR

I'm still not 100% happy with the alignment of the left and right edges. Especially on some zoom levels / page widths the edges don't always align nicely.

One problem here is that the Skosmos logo used within vocabularies (negative version, for use on a dark background) includes a lot of empty space around the logo itself within the svg file, making it hard to align. I tried two methods of cropping the svg to its content, but when I replaced the svg file with a cropped version, the logo just failed to display at all. I can't figure out why, but in any case, here are the two cropped logos (they look a bit funny here if you have a white background) in case they are useful:
 
![skosmos-NEGA-RGB-cropped](https://github.com/user-attachments/assets/a2ec3d3e-bbb5-41a9-a082-d7546a05429e)
![skosmos-NEGA-RGB-cropped-2](https://github.com/user-attachments/assets/6e1f9a1c-5068-478f-bf4b-440c09a77e4f)

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
