### PR TITLE
updated curl for loading voc to work with curl v8.5.0

### DIFF
--- a/dockerfiles/README.md
+++ b/dockerfiles/README.md
@@ -128,10 +128,10 @@ to use `localhost:9030` instead.
     # load STW vocabulary data
     curl -L -o stw.ttl.zip http://zbw.eu/stw/version/latest/download/stw.ttl.zip
     unzip stw.ttl.zip
-    curl -I -X POST -H Content-Type:text/turtle -T stw.ttl -G http://localhost:3030/skosmos/data --data-urlencode graph=http://zbw.eu/stw/
+    curl -X POST -H "Content-Type: text/turtle" -T stw.ttl "http://localhost:9030/skosmos/data?graph=http%3A%2F%2Fzbw.eu%2Fstw%2F"
     # load UNESCO vocabulary data
     curl -L -o unescothes.ttl http://skos.um.es/unescothes/unescothes.ttl
-    curl -I -X POST -H Content-Type:text/turtle -T unescothes.ttl -G http://localhost:3030/skosmos/data --data-urlencode graph=http://skos.um.es/unescothes/
+    curl -X POST -H "Content-Type: text/turtle" -T unescothes.ttl "http://localhost:9030/skosmos/data?graph=http%3A%2F%2Fskos.um.es%2Funescothes%2F"
 
 After you execute these commands successfully, you should be able to use all the
 features of Skosmos, such as browsing vocabularies and concepts.


### PR DESCRIPTION
## Reasons for creating this PR

Since my local machine is running curl v8.5.0 the vocabulary loading curl commands in dockerfiles/README.md  were failing.

`curl -I -X POST -H Content-Type:text/turtle -T unescothes.ttl -G http://localhost:9030/skosmos/data --data-urlencode graph=http://skos.um.es/unescothes/`

> Warning: You can only select one HTTP request method! You asked for both PUT 
> Warning: (-T, --upload-file) and HEAD (-I, --head).

I also saw that these changes to curl were tackled in https://github.com/NatLibFi/Skosmos/pull/1695 but this readme seems to need updating

## Description of the changes in this PR

Updates dockerfiles/README.md cURL commands to work with cURL v8.5.0

## Known problems or uncertainties in this PR

Haven't been able to check whether changes are compatible with previous versions of cURL 

## Checklist

- [ ] phpUnit tests pass locally with my changes
- [ ] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [ x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x ] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
