### PR TITLE
Heading structure fixes

### DIFF
--- a/resource/css/skosmos.css
+++ b/resource/css/skosmos.css
@@ -905,6 +905,12 @@ body {
   #search-results {
     background-color: var(--vocab-bg);
   }
+
+  #search-results h1 {
+    font-size: 1.3rem;
+    font-family: var(--font-family);
+  }
+
   .search-result {
     border-top: 1px solid var(--vocab-table-border);
     margin-top: 2.5rem;

--- a/resource/css/skosmos.css
+++ b/resource/css/skosmos.css
@@ -907,7 +907,7 @@ body {
   }
 
   #search-results h1 {
-    font-size: 1.3rem;
+    font-size: 1.1rem;
     font-family: var(--font-family);
   }
 

--- a/src/model/Vocabulary.php
+++ b/src/model/Vocabulary.php
@@ -449,7 +449,7 @@ class Vocabulary extends DataObject implements Modifiable
      * @param string $clang content language
      * @return Concept
      */
-    public function getConceptInfo(string $uri, string $clang): Concept
+    public function getConceptInfo(string $uri, string $clang): ?Concept
     {
         $sparql = $this->getSparql();
         $conceptInfo = null;
@@ -459,6 +459,9 @@ class Vocabulary extends DataObject implements Modifiable
             if ($this->model->getConfig()->getLogCaughtExceptions()) {
                 error_log('Caught exception: ' . $e->getMessage());
             }
+        }
+        if (!$conceptInfo) {
+            return null;
         }
         return $conceptInfo[0];
     }

--- a/src/view/about-info.inc.twig
+++ b/src/view/about-info.inc.twig
@@ -6,11 +6,11 @@
     <p>Skosmos on web-pohjainen sanasto ja ontologiaselain.</p>
     <a href="http://github.com/NatLibFi/Skosmos">Skosmos GitHub-repositorio</a>
   {% elseif request.lang == 'sv' %}
-    <h4>Information</h4>
+    <h2>Information</h2>
     <p>Skosmos är en ontologibrowser.</p>
     <a href="http://github.com/NatLibFi/Skosmos">Skosmos på GitHub</a>
   {% elseif request.lang == 'en' %}
-    <h4>About</h4>
+    <h2>About</h2>
     <p>Skosmos is a web based open source ontology browser.</p>
     <a href="http://github.com/NatLibFi/Skosmos">Skosmos GitHub repository</a>
   {% endif %}

--- a/src/view/base-template.twig
+++ b/src/view/base-template.twig
@@ -76,7 +76,7 @@
         </div>
       </div>
     </div>
-    {% if pageType == 'landing' or pageType == 'vocab-home' or pageType == 'concept' %}
+    {% if pageType in ['landing', 'vocab-home', 'concept', 'vocab-search'] %}
     <div class="container-fluid bg-white py-4" id="headerbar">
       <div id="headerbar-top-slot" class="row"></div>
       <div class="row">

--- a/src/view/base-template.twig
+++ b/src/view/base-template.twig
@@ -86,11 +86,7 @@
         </div>
         {% else %}
         <div class="col-7 px-3">
-          {% if pageType == 'vocab-home' %}
-            <h1 class="fw-bold" id="vocab-title"><a class="text-decoration-none" href="{% if request.vocabid != '' %}{{ request.vocabid  }}/{% endif %}{{ request.lang }}/{% if request.contentLang != request.lang %}?clang={{ request.contentLang }}{% endif %}">{{ request.vocab.title(request.contentLang) }}</a></h1>
-          {% else %}
-            <h2 class="fw-bold" id="vocab-title"><a class="text-decoration-none" href="{% if request.vocabid != '' %}{{ request.vocabid  }}/{% endif %}{{ request.lang }}/{% if request.contentLang != request.lang %}?clang={{ request.contentLang }}{% endif %}">{{ request.vocab.title(request.contentLang) }}</a></h2>
-          {% endif %}
+          <h2 class="fw-bold" id="vocab-title"><a class="text-decoration-none" href="{% if request.vocabid != '' %}{{ request.vocabid  }}/{% endif %}{{ request.lang }}/{% if request.contentLang != request.lang %}?clang={{ request.contentLang }}{% endif %}">{{ request.vocab.title(request.contentLang) }}</a></h2>
         </div>
         <div class="col-5">
           <div id="search-vocab"></div>

--- a/src/view/error.twig
+++ b/src/view/error.twig
@@ -9,6 +9,7 @@
 {% endif %}
 <div class="container{% if pageError %} col-md-8" id="main-content{% endif %}">
   <div class="alert py-5 px-5">
+    <h1>{{ "Error" | trans }}</h1>
     <span class="fw-bold fs-5">{% if not message%}{% trans %}404 Error: The page %requested_page% cannot be found.{% endtrans %}{% else %}{{ message }}{% endif %}</span>
   </div>
 </div>

--- a/src/view/global-search.twig
+++ b/src/view/global-search.twig
@@ -8,12 +8,8 @@
   <div class="row">
     <div id="main-content">
       <div class="p-4 pt-4" id="search-results">
-        <div class="search-count">
-          <p class="py-2">
-            <span class="fw-bold">{{ "%search_count% results for '%term%'" | trans({'%search_count%': search_count, '%term%' : term}) }}</span>
-          </p>
-        </div>
-	      {% include "search-results.inc.twig" %}
+        <h1>{{ "%search_count% results for '%term%'" | trans({'%search_count%': search_count, '%term%' : term}) }}</h1>
+        {% include "search-results.inc.twig" %}
       </div>
     </div>
   </div>

--- a/src/view/search-results-filter.inc.twig
+++ b/src/view/search-results-filter.inc.twig
@@ -1,7 +1,7 @@
 {% block content %}
   <div class="col-md-4 pe-3">
     <div class="p-4" id="sidebar">
-      <h4 class="fw-bold mb-5">{{ "Search options" | trans }}</h4>
+      <h3 class="fw-bold mb-5">{{ "Search options" | trans }}</h3>
   </div>
 </div>
 {% endblock %}

--- a/src/view/vocab-search.twig
+++ b/src/view/vocab-search.twig
@@ -9,12 +9,8 @@
     {% include "search-results-filter.inc.twig" %}
     <div class="col-md-7 ps-3" id="main-content">
       <div class="p-4 pt-4" id="search-results">
-        <div class="search-count">
-          <p class="py-2">
-            <span class="fw-bold">{{ "%search_count% results for '%term%'" | trans({'%search_count%': search_count, '%term%' : term}) }}</span>
-          </p>
-        </div>
-  	    {% include "search-results.inc.twig" %}
+        <h1>{{ "%search_count% results for '%term%'" | trans({'%search_count%': search_count, '%term%' : term}) }}</h1>
+        {% include "search-results.inc.twig" %}
       </div>
     </div>
   </div>

--- a/tests/cypress/template/global-search.cy.js
+++ b/tests/cypress/template/global-search.cy.js
@@ -31,11 +31,10 @@ describe('Global search page', () => {
       cy.visit(`/en/search?clang=en&q=${term}`)
 
       //Check that the search count is correct
-      cy.get('.search-count > p > span').invoke('text').should('contain', searchCountTitle);
+      cy.get('#search-results > h1').invoke('text').should('contain', searchCountTitle);
 
-      //Check that search count matces the number of results
+      //Check that search count matches the number of results
       cy.get('div.search-result').should('have.length', count)
-
   })
   it('Search results contains correct info', () => {
       cy.visit(`/en/search?clang=en&q=${term}`)

--- a/tests/cypress/template/vocab-search.cy.js
+++ b/tests/cypress/template/vocab-search.cy.js
@@ -32,11 +32,10 @@ describe('Vocabulary search page', () => {
       cy.visit(`/${vocab}/en/search?clang=en&q=${term}`)
 
       //Check that the search count is correct
-      cy.get('.search-count > p > span').invoke('text').should('contain', searchCountTitle);
+      cy.get('#search-results > h1').invoke('text').should('contain', searchCountTitle);
 
-      //Check that search count matces the number of results
+      //Check that search count matches the number of results
       cy.get('div.search-result').should('have.length', count)
-
   })
   it('Search results contains correct info', () => {
       cy.visit(`/${vocab}/en/search?clang=en&q=${term}`)


### PR DESCRIPTION
## Reasons for creating this PR

Fix many heading level issues in Skosmos 3, see #1801.

## Link to relevant issue(s), if any

- Closes #1801

## Description of the changes in this PR

* add vocab header (with the vocab name and search fields) to vocab search result page
* make sure vocab-search and global-search pages have a h1 header: the "XX results for 'YYY'" message is now a h1 element
* adjust heading levels on vocab-search page to avoid skipping levels: the "Search options" element is now h3 instead of h4
* always use h2 element for the vocab header; previously it was h1 for the vocab-home page and h2 on other pages, but that causes problems with partial page loads, so keeping it always h2 is simpler (the "Vocabulary information" heading is now the only h1 element on vocab-home pages)
* add h1 heading "Error" on the error page
* unrelated: the error page was crashing on URLs like yso/en/page/xxxxx where xxxx is not a valid localname; this PR fixes the crash, although the resulting error page looks a bit funny (see below)
* change h4 headings to h2 on about page in Swedish and English to avoid skipping levels (in Finnish it was already h2)

## Known problems or uncertainties in this PR

I'm not 100% sure that it's a great idea to make the "XX results for 'YYY'" message on search results pages into a h1 level heading. But there is no other obvious heading on the page, unless we want to add a prominent heading like "Search results" to the page.

I fixed a PHP crash on the error page within a vocabulary (e.g. http://localhost/Skosmos/yso/en/page/xxx ), but now the sidebar looks a bit strange, probably due to some CSS issues. Also, there should probably be a vocab header on this page:

<img width="1863" height="443" alt="kuva" src="https://github.com/user-attachments/assets/dded989f-85a3-4de4-8822-d6f336f260f5" />


## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
