### PR TITLE
Skosmos 3 configuration overhaul

### DIFF
--- a/config.ttl.dist
+++ b/config.ttl.dist
@@ -62,9 +62,9 @@
     # whether to display the ui language selection as a dropdown (useful for cases where there are more than 3 languages) 
     skosmos:uiLanguageDropdown false ;
     # whether to enable the spam honey pot or not, enabled by default
-    skosmos:uiHoneypotEnabled true ;
+    skosmos:feedbackHoneypotEnabled true ;
     # default time a user must wait before submitting a form
-    skosmos:uiHoneypotTime 5 ;
+    skosmos:feedbackHoneypotTime 5 ;
     # plugins to activate for the whole installation (including all vocabularies)
     skosmos:globalPlugins () .
 
@@ -81,7 +81,6 @@
     skosmos:language "fi";
     skosmos:shortName "YSA";
     skosmos:feedbackRecipient "vesa-posti@helsinki.fi" ;
-    skosmos:showChangeList "true" ;
     void:dataDump <http://api.finto.fi/download/ysa/ysa-skos.ttl> ;
     void:sparqlEndpoint <http://api.dev.finto.fi/sparql> ;
     skosmos:sparqlGraph <http://www.yso.fi/onto/ysa/>

--- a/config.ttl.dist
+++ b/config.ttl.dist
@@ -20,7 +20,7 @@
     # a local Fuseki server is usually on localhost:3030
     #skosmos:sparqlEndpoint <http://localhost:3030/ds/sparql> ;
     # use the dev.finto.fi endpoint where the example vocabularies reside
-    skosmos:sparqlEndpoint <http://api.dev.finto.fi/sparql> ;
+    skosmos:sparqlEndpoint <https://api.dev.finto.fi/sparql> ;
     # sparql-query extension, or "Generic" for plain SPARQL 1.1
     # set to "JenaText" instead if you use Fuseki with jena-text index
     skosmos:sparqlDialect "Generic" ;
@@ -81,8 +81,8 @@
     skosmos:language "fi";
     skosmos:shortName "YSA";
     skosmos:feedbackRecipient "vesa-posti@helsinki.fi" ;
-    void:dataDump <http://api.finto.fi/download/ysa/ysa-skos.ttl> ;
-    void:sparqlEndpoint <http://api.dev.finto.fi/sparql> ;
+    void:dataDump <https://api.finto.fi/download/ysa/ysa-skos.ttl> ;
+    void:sparqlEndpoint <https://api.dev.finto.fi/sparql> ;
     skosmos:sparqlGraph <http://www.yso.fi/onto/ysa/>
 .
 
@@ -102,8 +102,8 @@
                     "ALLFO"@sv;
     skosmos:groupClass isothes:ConceptGroup ;
     skosmos:arrayClass isothes:ThesaurusArray ;
-    void:dataDump <http://api.finto.fi/download/yso/yso-skos.ttl> ;
-    void:sparqlEndpoint <http://api.dev.finto.fi/sparql> ;
+    void:dataDump <https://api.finto.fi/download/yso/yso-skos.ttl> ;
+    void:sparqlEndpoint <https://api.dev.finto.fi/sparql> ;
     skosmos:sparqlGraph <http://www.yso.fi/onto/yso/> ;
     skosmos:mainConceptScheme <http://www.yso.fi/onto/yso/>
 .

--- a/src/model/GlobalConfig.php
+++ b/src/model/GlobalConfig.php
@@ -376,7 +376,7 @@ class GlobalConfig extends BaseConfig
      */
     public function getHoneypotEnabled()
     {
-        return $this->getBoolean('skosmos:uiHoneypotEnabled', true);
+        return $this->getBoolean('skosmos:feedbackHoneypotEnabled', true);
     }
 
     /**
@@ -384,7 +384,7 @@ class GlobalConfig extends BaseConfig
      */
     public function getHoneypotTime()
     {
-        return $this->getLiteral('skosmos:uiHoneypotTime', 5);
+        return $this->getLiteral('skosmos:feedbackHoneypotTime', 5);
     }
 
     /**

--- a/tests/VocabularyConfigTest.php
+++ b/tests/VocabularyConfigTest.php
@@ -642,22 +642,22 @@ class VocabularyConfigTest extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * @covers VocabularyConfig::getPluginArray
+     * @covers VocabularyConfig::getPluginNames
      */
     public function testGetOrderedPlugins()
     {
         $vocab = $this->model->getVocabulary('paramPluginOrderTest');
-        $plugins = $vocab->getConfig()->getPluginArray();
-        $this->assertEquals(["plugin2", "Bravo", "plugin1", "alpha", "charlie", "imaginaryPlugin", "plugin3"], $plugins);
+        $plugins = $vocab->getConfig()->getPluginNames();
+        $this->assertEquals(["plugin2", "Bravo", "plugin1", "imaginaryPlugin", "alpha", "charlie"], $plugins);
     }
 
     /**
-     * @covers VocabularyConfig::getPluginArray
+     * @covers VocabularyConfig::getPluginNames
      */
     public function testGetUnorderedVocabularyPlugins()
     {
         $vocab = $this->model->getVocabulary('paramPluginTest');
-        $plugins = $vocab->getConfig()->getPluginArray();
+        $plugins = $vocab->getConfig()->getPluginNames();
         $arrayElements = ["plugin2", "Bravo", "imaginaryPlugin", "plugin1", "alpha", "charlie", "plugin3"];
         $this->assertEquals(sort($arrayElements), sort($plugins));
     }

--- a/tests/jenatestconfig.ttl
+++ b/tests/jenatestconfig.ttl
@@ -58,9 +58,9 @@
     # whether to display the ui language selection as a dropdown (useful for cases where there are more than 3 languages) 
     skosmos:uiLanguageDropdown false ;
     # whether to enable the spam honey pot or not, enabled by default
-    skosmos:uiHoneypotEnabled true ;
+    skosmos:feedbackHoneypotEnabled true ;
     # default time a user must wait before submitting a form
-    skosmos:uiHoneypotTime 5 .
+    skosmos:feedbackHoneypotTime 5 .
 
 # Skosmos vocabularies
 

--- a/tests/jenatestconfig.ttl
+++ b/tests/jenatestconfig.ttl
@@ -120,7 +120,6 @@
 	void:uriSpace "http://www.skosmos.skos/onto/testdiff#";
 	skosmos:language "fi", "en";
 	skosmos:sparqlDialect "JenaText";
-	skosmos:fullAlphabeticalIndex "true";
 	skosmos:explicitLanguageTags "true";
 	skosmos:defaultSidebarView "groups";
 	skosmos:showTopConcepts "false";

--- a/tests/testconfig.ttl
+++ b/tests/testconfig.ttl
@@ -134,7 +134,6 @@
     skosmos:marcSourceCode "yso/fin"@fi, "yso/swe"@sv, "yso/eng"@en;
     skosmos:language "fi", "sv", "se", "en";
     skosmos:showTopConcepts "true";
-    skosmos:showChangeList "true" ;
     skosmos:showDeprecatedChanges "true" ;
     skosmos:showPropertyInSearch skos:note ;
     skosmos:useModifiedDate "true";
@@ -192,7 +191,6 @@
     void:uriSpace "http://www.skosmos.skos/test-551-A/";
     skosmos:language "fi" ;
     skosmos:defaultLanguage "fi";
-    skosmos:showChangeList "true" ;
     skosmos:showDeprecatedChanges "true" ;
     skosmos:useModifiedDate "true" ;
     skosmos:sparqlGraph <http://www.skosmos.skos/test-551-A/> ;

--- a/tests/testconfig.ttl
+++ b/tests/testconfig.ttl
@@ -213,7 +213,6 @@
 	void:uriSpace "http://www.skosmos.skos/onto/testdiff#";
 	skosmos:language "fi", "en";
 	skosmos:sparqlDialect "JenaText";
-	skosmos:fullAlphabeticalIndex "true";
 	skosmos:explicitLanguageTags "true";
 	skosmos:defaultSidebarView "groups";
 	skosmos:defaultConceptSidebarView "groups";

--- a/tests/testconfig.ttl
+++ b/tests/testconfig.ttl
@@ -67,9 +67,9 @@
     # whether to display the ui language selection as a dropdown (useful for cases where there are more than 3 languages) 
     skosmos:uiLanguageDropdown true ;
     # whether to enable the spam honey pot or not, enabled by default
-    skosmos:uiHoneypotEnabled false ;
+    skosmos:feedbackHoneypotEnabled false ;
     # default time a user must wait before submitting a form
-    skosmos:uiHoneypotTime 2 ;
+    skosmos:feedbackHoneypotTime 2 ;
     # plugins to activate for the whole installation (including all vocabularies)
     skosmos:globalPlugins ("alpha" "Bravo" "charlie") .
 

--- a/tests/testconfig.ttl
+++ b/tests/testconfig.ttl
@@ -442,18 +442,13 @@
     dc:title "Test plugin"@en ;
     void:dataDump <http://skosmos.skos/dump/test/> ;
     void:uriSpace "http://www.skosmos.skos/test/" ;
-    skosmos:vocabularyPlugins ( "test-plugin-vue" "test-plugin-vanilla-js" ) ;
-    skosmos:usePlugin "test-plugin-vue" ;
-    skosmos:usePlugin "test-plugin-vanilla-js" .
+    skosmos:vocabularyPlugins ( "test-plugin-vue" "test-plugin-vanilla-js" ) .
 
 :paramPluginTest a skosmos:Vocabulary, void:Dataset ;
 	dc:title "Test plugin order"@en ;
 	void:dataDump <http://skosmos.skos/dump/test/> ;
 	void:uriSpace "http://www.skosmos.skos/test/";
-	skosmos:vocabularyPlugins "plugin2", "Bravo", :parameterizedPlugin, "plugin1";
-	skosmos:usePlugin "plugin1" ;
-	skosmos:usePlugin "plugin3" ;
-	skosmos:useParamPlugin :parameterizedPlugin .
+	skosmos:vocabularyPlugins "plugin2", "Bravo", :parameterizedPlugin, "plugin1" .
 
 :paramPluginOrderTest a skosmos:Vocabulary, void:Dataset ;
 	dc:title "Test plugin parameters"@en ;
@@ -467,10 +462,7 @@
     skosmos:feedbackRecipient "developer@vocabulary.org";
 	skosmos:groupClass skos:Collection;
 	skosmos:language "en";
-	skosmos:vocabularyPlugins ("plugin2" "Bravo" "plugin1");
-	skosmos:usePlugin "plugin1" ;
-	skosmos:usePlugin "plugin3" ;
-	skosmos:useParamPlugin :parameterizedPlugin ;
+	skosmos:vocabularyPlugins ("plugin2" "Bravo" "plugin1" :parameterizedPlugin);
 	skosmos:showTopConcepts "true";
 	skosmos:shortName "Test params",
                     "Testi parametri"@fi;


### PR DESCRIPTION
## Reasons for creating this PR

Some Skosmos configuration parameters are redundant or badly named. With the upcoming release of Skosmos 3, we can clean up some of this legacy. See #1793 

## Link to relevant issue(s), if any

- Closes #1793

## Description of the changes in this PR

- renamed `skosmos:uiHoneypotEnabled` to `skosmos:feedbackHoneypotEnabled` (the ui is misleading)
- renamed `skosmos:uiHoneypotTime` to `skosmos:feedbackHoneypotTime` (the ui is misleading)
- simplified plugin configuration/activation: dropped support for `skosmos:useParamPlugin` and standalone `skosmos:usePlugin`; all configuration is now done using `skosmos:globalPlugins` and `skosmos:vocabularyPlugins`
- dropped obsolete (already removed in #1493) configuration options `skosmos:showChangeList` and `skosmos:fullAlphabeticalIndex` from the config files used in unit tests
- make matching changes to `config.ttl.dist`; also change HTTP URLs to HTTPS for public SPARQL endpoints and vocabulary downloads in the file

Note: I've created a new wiki page [Configuration for Skosmos 3](https://github.com/NatLibFi/Skosmos/wiki/Configuration-for-Skosmos-3) (+ added it to the wiki sidebar) and rewritten the section on [Enabling Plugins](https://github.com/NatLibFi/Skosmos/wiki/Plugins-for-Skosmos-3#enabling-plugins) in the wiki page Plugins for Skosmos 3 to match this PR.

## Known problems or uncertainties in this PR

Not sure about `skosmos:logCaughtExceptions`. Is it still useful? Should it be dropped?

I have a feeling that there could be other configuration options that are no longer relevant for Skosmos 3, but it's hard to tell...

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
