### PR TITLE
Sidebar tab styling on narrow screens

### DIFF
--- a/resource/css/skosmos.css
+++ b/resource/css/skosmos.css
@@ -520,7 +520,6 @@ body {
     align-items: center;
     justify-content: center;
     transition: none;
-    padding: 0.5rem;
   }
 
   #main-container.vocab-home #sidebar .nav .active, #main-container.concept #sidebar .nav .active {
@@ -614,7 +613,7 @@ body {
 
   /* In smaller screen sizes, the last sidebar tab overflows to the right */
   @media only screen and (min-width: 768px) and (max-width: 1070px) {
-    #sidebar-tabs.wide .nav {
+    #sidebar-tabs.wide {
       flex-wrap: nowrap;
     }
 
@@ -654,13 +653,6 @@ body {
   @media only screen and (max-width: 900px) {
     #sidebar .nav-link {
       padding: 0.5rem 0.1rem !important;
-    }
-  }
-
-
-  @media only screen and (max-width: 820px) {
-    #sidebar .nav-link {
-      padding: 0.5rem 1px !important;
     }
   }
 

--- a/src/view/sidebar.inc.twig
+++ b/src/view/sidebar.inc.twig
@@ -3,9 +3,9 @@
   {% block sidebar %}
     <div class="sidebar-buttons">
       <h2 class="visually-hidden">{{'Sidebar listing: list and traverse vocabulary contents by a criterion' | trans}}</h2>
-      <ul class="nav nav-tabs-no-style nav-justified{% if vocab.config.sidebarViews | length == 4 and vocab.config.showDeprecatedChanges %} wide{% endif %}" id="sidebar-tabs" role="tablist">
+      <ul class="nav nav-tabs-no-style nav-justified{% if vocab.config.sidebarViews | length >= 4 and vocab.config.showDeprecatedChanges %} wide{% endif %}" id="sidebar-tabs" role="tablist">
         {% for view in vocab.config.sidebarViews %}
-          {% if view == 'alphabetical' %} {% set view_trans_text = (vocab.config.sidebarViews | length == 4) ? 'A-Z' : 'Alpha-nav' %}
+          {% if view == 'alphabetical' %} {% set view_trans_text = (vocab.config.sidebarViews | length >= 4) ? 'A-Z' : 'Alpha-nav' %}
           {% elseif view == 'hierarchy' %} {% set view_trans_text = 'Hier-nav' %}
           {% elseif view == 'groups' %} {% set view_trans_text = 'Group-nav' %}
           {% else %} {% set view_trans_text = vocab.config.showDeprecatedChanges ? 'Changes-and-deprecations-nav' : 'Changes-nav' %}{% endif %}
@@ -15,7 +15,7 @@
           {# Hierarchy tab is disabled on vocab page if showTopConcepts is set to false #}
           {% set disabled_class = request.page == 'vocab' and view == 'hierarchy' and not (vocab.config.showTopConcepts) %}
           <li id="{{ view }}" class="nav-item">
-            <a class="nav-link{% if active_class %} active{% elseif disabled_class %} disabled{% endif %}"
+            <a class="nav-link p-2{% if active_class %} active{% elseif disabled_class %} disabled{% endif %}"
               {% if disabled_class %}data-title="{{ 'hierarchy-disabled-help' | trans }}"{% endif %} 
               role="tab" data-bs-toggle="tab" href="#tab-{{ view }}" aria-controls="tab-{{ view }}">
               {{ view_trans_text | trans }}


### PR DESCRIPTION
## Reasons for creating this PR

Sidebar tabs end up on two separate lines on narrow screen sizes. This PR adds an initial fix for this.

## Link to relevant issue(s), if any

- Part of #1747

## Description of the changes in this PR

- Make sidebar tab padding more narrow
- Add stylings for sidebars with 4 tabs:
  - Reduce padding more on narrow screens
  - Make last tab overflow with a fade out on narrow screens
  - Use A-Z on alphabetical tab

Addresses requirement 7.2 in #1747

## Known problems or uncertainties in this PR

## Checklist

- [ ] phpUnit tests pass locally with my changes
- [ ] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [ ] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [ ] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
