### PR TITLE
Fix sidebar gradient height

### DIFF
--- a/resource/css/skosmos.css
+++ b/resource/css/skosmos.css
@@ -632,15 +632,16 @@ body {
     #sidebar-tabs.wide .nav-item:last-of-type .nav-link {
       justify-content: start !important;
       white-space: nowrap;
+      position: relative;
     }
 
     #sidebar-tabs.wide .nav-item:last-of-type .nav-link::after {
       content: "";
       position: absolute;
       top: 0;
-      right: 1rem;
+      right: 0;
       width: 1rem;
-      height: 40px;
+      height: 100%;
       pointer-events: none;
       background: linear-gradient(to right, transparent, var(--sidebar-tab-inactive-bg));
     }


### PR DESCRIPTION
## Reasons for creating this PR

The height of the gradient applied to the last tab in the sidebar on narrow screens is not set correctly. This PR fixes it.

## Link to relevant issue(s), if any

- Part of #1747

## Description of the changes in this PR

Make the gradient height 100% of the parent nav-link element.

## Known problems or uncertainties in this PR

## Checklist

- [ ] phpUnit tests pass locally with my changes
- [ ] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [ ] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [ ] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
