### PR TITLE
Deprecated concept display fixes (Skosmos 2)

### DIFF
--- a/view/concept-shared.twig
+++ b/view/concept-shared.twig
@@ -6,8 +6,7 @@
     <div class="alert alert-danger">
       <p class="deprecated-alert">{% trans %}deprecated{% endtrans %}</p>
     </div>
-    {% endif %}
-    {% if concept.label.lang != request.contentLang %}
+    {% elseif concept.label.lang != request.contentLang %}
     <div class="alert alert-lang">
       <p class="language-alert">{% trans %}There is no term for this concept in this language{% endtrans %}</p>
     </div>

--- a/view/concept-shared.twig
+++ b/view/concept-shared.twig
@@ -38,6 +38,7 @@
         {% endfor %}
         </div>
       {% endif %}
+      {% if concept.label %}
       {% spaceless %}
       <div class="row{% if concept.type == 'skosext:DeprecatedConcept' %} deprecated{% endif %} property prop-preflabel">
         <div class="property-label property-label-pref">
@@ -90,6 +91,7 @@
         <div class="col-md-12"><div class="preflabel-spacer"></div></div>
       </div>
       {% endspaceless %}
+      {% endif %}
 
       {% for property in concept.properties %} {# loop through ConceptProperty objects #}
         {% if property.getSubPropertyOf != 'skos:hiddenLabel' %}


### PR DESCRIPTION
## Reasons for creating this PR

Deprecated concepts/records in Kanto/finaf look a bit silly. Due to the restrictions of the source data, we don't have much information about the records removed from Asteri/finaf/Kanto ; there is only (if we're lucky) a `dct:isReplacedBy` link to the new record. Skosmos currently renders them like this:

<img width="1061" height="491" alt="kuva" src="https://github.com/user-attachments/assets/c2ad1d64-1266-47fd-9e8f-de018f591c44" />

This PR changes the concept display in two ways:

1. Remove the message "There is no term for this concept in this language." for deprecated concepts. One warning box should be enough!
2. Remove the prefLabel section entirely if the concept has no prefLabel at all.

The end result looks like this:

<img width="1061" height="305" alt="kuva" src="https://github.com/user-attachments/assets/75229d6b-17f5-40e1-9285-28e95783cd34" />


## Link to relevant issue(s), if any

n/a

## Description of the changes in this PR

Two commits, corresponding to the two changes mentioned above.

## Known problems or uncertainties in this PR

none

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
