### PR TITLE
Fix flaky vocab-home Cypress test under GitHub Actions CI

### DIFF
--- a/tests/cypress/template/vocab-home.cy.js
+++ b/tests/cypress/template/vocab-home.cy.js
@@ -65,7 +65,7 @@ describe('Vocabulary home page', () => {
     // check the second mapping property name
     cy.get('.prop-mapping h2', {'timeout': 15000}).eq(0).contains('Exactly matching concepts')
     // check the second mapping property values
-    cy.get('.prop-mapping').eq(0).find('.prop-mapping-label').eq(0).find('a').invoke('text').should('equal', 'fish')
+    cy.get('.prop-mapping').eq(0).find('.prop-mapping-label').eq(0).find('a').invoke('text').should('match', /^(fish|wd:Q152)$/)
     cy.get('.prop-mapping').eq(0).find('.prop-mapping-label').eq(0).find('a').should('have.attr', 'href', 'http://www.wikidata.org/entity/Q152')
     cy.get('.prop-mapping').eq(0).find('.prop-mapping-vocab').eq(0).contains('www.wikidata.org')
 


### PR DESCRIPTION
## Reasons for creating this PR

One of the vocab-home Cypress tests started failing very often (more than 50%) under GitHub Actions CI. It is a test that verifies that a partial page load is performed after clicking on the hierarchy. Part of the test checks that a mapping to Wikidata is shown properly. This fails, because the expected Wikidata label "fish" is not being shown.

I couldn't replicate the problem locally so I assume this has something to do with traffic between GitHub Actions and Wikidata. Maybe Wikidata blocks some queries?

This PR adjusts the test slightly so that either a label or Wikidata URI is an acceptable value. Now it should work under GitHub Actions as well.

## Link to relevant issue(s), if any

n/a

## Description of the changes in this PR

* robustness fix: accept either wikidata label or URI in vocab-home cypress test

## Known problems or uncertainties in this PR

It was a bit mysterious so not 100% sure this fixes the problem for good.

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
