### PR TITLE
Fix width of changes tab on window resize

### DIFF
--- a/resource/js/tab-changes.js
+++ b/resource/js/tab-changes.js
@@ -131,7 +131,7 @@ function startChangesApp () {
       }
     },
     template: `
-      <div v-click-tab-changes="handleClickChangesEvent">
+      <div v-click-tab-changes="handleClickChangesEvent" v-resize-window="setListStyle">
         <tab-changes
           :changed-concepts="changedConcepts"
           :selected-concept="selectedConcept"
@@ -157,6 +157,19 @@ function startChangesApp () {
     },
     unmounted: el => {
       document.querySelector('#changes').removeEventListener('click', el.clickTabEvent)
+    }
+  })
+
+  /* Custom directive used to add an event listener on resizing the window */
+  tabChangesApp.directive('resize-window', {
+    beforeMount: (el, binding) => {
+      el.resizeWindowEvent = event => {
+        binding.value() // calling the method given as the attribute value (setListStyle)
+      }
+      window.addEventListener('resize', el.resizeWindowEvent) // registering an event listener on resizing the window
+    },
+    unmounted: el => {
+      window.removeEventListener('resize', el.resizeWindowEvent)
     }
   })
 


### PR DESCRIPTION
## Reasons for creating this PR

Width of changes tab Vue component does not react to window resizing , this PR fixes that.

## Link to relevant issue(s), if any

- Part of #1735 

## Description of the changes in this PR

- Add event listener to changes tab component for window resizing

Addresses requirement 22 in #1735

## Known problems or uncertainties in this PR

## Checklist

- [ ] phpUnit tests pass locally with my changes
- [ ] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [ ] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [ ] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
