### PR TITLE
Fix hierarchy button visibility on concept pages

### DIFF
--- a/resource/js/tab-hierarchy.js
+++ b/resource/js/tab-hierarchy.js
@@ -198,7 +198,7 @@ function startHierarchyApp () {
             .map(c => this.createConceptNode(c))
 
           // new concept node to be added to hierarchy tree
-          const conceptNode = this.createConceptNode({ ...concept , hasChildren: true}, true, children)
+          const conceptNode = this.createConceptNode({ ...concept, hasChildren: true }, true, children)
 
           if (window.SKOSMOS.showConceptSchemesInHierarchy) {
             // if concept schemes are shown in hierarchy, push new concept to the children of the correct concept scheme


### PR DESCRIPTION
## Reasons for creating this PR

When visiting a concept page (e.g. https://test.dev.finto.fi/yso/en/page/p23406), opening the hierarchy in the sidebar creates a bug where the hierarchy button is not visible for the open top concept (e.g. objects).

## Link to relevant issue(s), if any

- Part of #1521

## Description of the changes in this PR

- Set `hasChildren` property of the open top concept object correctly
- Fix typos

## Known problems or uncertainties in this PR

## Checklist

- [ ] phpUnit tests pass locally with my changes
- [ ] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [ ] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [ ] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
