### PR TITLE
Vocabulary list on landing page: fallback to any language

### DIFF
--- a/src/model/VocabularyConfig.php
+++ b/src/model/VocabularyConfig.php
@@ -230,7 +230,16 @@ class VocabularyConfig extends BaseConfig
      */
     public function getTitle($lang = null)
     {
-        return $this->getLiteral('dc:title', false, $lang);
+        $title = $this->getLiteral('dc:title', null, $lang);
+        if ($title === null) {
+            // not found using given language or without language tag
+            // try any language
+            $literal = $this->resource->getLiteral('dc:title');
+            if ($literal) {
+                $title = $literal->getValue();
+            }
+        }
+        return $title;
     }
 
     /**

--- a/tests/VocabularyConfigTest.php
+++ b/tests/VocabularyConfigTest.php
@@ -388,6 +388,15 @@ class VocabularyConfigTest extends PHPUnit\Framework\TestCase
     }
 
     /**
+     * @covers VocabularyConfig::getTitle
+     */
+    public function testGetTitleLanguageFallback()
+    {
+        $vocab = $this->model->getVocabulary('test');
+        $this->assertEquals('Test ontology', $vocab->getConfig()->getTitle('fi'));
+    }
+
+    /**
      * @covers VocabularyConfig::getDescription
      */
     public function testGetDesctiption()

--- a/tests/cypress/template/global-search-bar.cy.js
+++ b/tests/cypress/template/global-search-bar.cy.js
@@ -4,23 +4,21 @@ describe('Global search bar', () => {
     cy.get('#search-wrapper').should('exist')
   })
 
-  it('vocab-list has two vocabularies', () => {
-    cy.get('#vocab-list li').should('have.length', 2)
+  it('vocab-list has 13 vocabularies', () => {
+    cy.get('#vocab-list li').should('have.length', 13)
   })
 
   it('dropdown menu header text is updated according to the selected vocabularies', () => {
-
     cy.get('#vocab-selector .vocab-dropdown-btn').should('contain.text', '1. Choose vocabulary')
-
-
-    cy.get('#vocab-list li').eq(0).find('input[type="checkbox"]').check({ force: true })
+    // select "altlabel"
+    cy.get('#vocab-list').contains('label', 'altlabel').find('input[type="checkbox"]').check({ force: true })
     cy.get('#vocab-selector .vocab-dropdown-btn').should('contain.text', 'altlabel')
-
-    cy.get('#vocab-list li').eq(1).find('input[type="checkbox"]').check({ force: true })
+    // select "YSO"
+    cy.get('#vocab-list').contains('label', 'YSO').find('input[type="checkbox"]').check({ force: true })
     cy.get('#vocab-selector .vocab-dropdown-btn').should('contain.text', 'altlabel')
     cy.get('#vocab-selector .vocab-dropdown-btn').should('contain.text', 'YSO')
-
-    cy.get('#vocab-list li').eq(0).find('input[type="checkbox"]').uncheck({ force: true })
+    // unselect "altlabel"
+    cy.get('#vocab-list').contains('label', 'altlabel').find('input[type="checkbox"]').uncheck({ force: true })
     cy.get('#vocab-selector .vocab-dropdown-btn').should('not.contain.text', 'altlabel')
     cy.get('#vocab-selector .vocab-dropdown-btn').should('contain.text', 'YSO')
   })
@@ -56,7 +54,8 @@ describe('Global search bar', () => {
     it('Dropdown search results are displayed for the selected vocabulary and search language', () => {
 
     cy.get('#global-search-toggle').click()
-    cy.get('#vocab-list li').eq(1).find('input[type="checkbox"]').check({ force: true })
+    // select "YSO"
+    cy.get('#vocab-list').contains('label', 'YSO').find('input[type="checkbox"]').check({ force: true })
     cy.get('#language-list li').contains('suomi').find('input[type="radio"]').check({ force: true })
 
     cy.get('#search-field').type('arkeolog'); // even if the search yields no results, there shoulde a single line in the result list


### PR DESCRIPTION
## Reasons for creating this PR

Vocabularies that didn't have a label in the current UI label were not visible on the landing page. See #1824

This PR fixes the problem by adding a fallback: if a vocabulary doesn't have a `dcterms:title` in the current UI language in the config.ttl file (and also doesn't have a title without a language tag), then Skosmos will just pick any title regardless of the language tag. This ensures that the vocabulary is visible, even though its name may not be in the expected language.

The change also affects the vocabulary dropdown list in the global search bar: now vocabularies without a title in the current language are also shown in that list. (This caused some breakage for Cypress tests that didn't expect this.)

## Link to relevant issue(s), if any

- Closes #1824

## Description of the changes in this PR

* implement fallback for VocabularyConfig::getTitle
* add a PHPUnit test that verifies that the fallback works
* adjust some Cypress tests related to the global search bar that broke due to this change

## Known problems or uncertainties in this PR

none

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
