### PR TITLE
Fix sizing of sidebar Vue components

### DIFF
--- a/resource/css/skosmos.css
+++ b/resource/css/skosmos.css
@@ -715,10 +715,6 @@ header .container-fluid .row {
   box-shadow: none;
 }
 
-#sidebar .loading-message {
-  padding: 2rem 1rem;
-}
-
 /* --- Sidebar hierarchy and groups tabs --- */
 
 #tab-hierarchy .list-group-item,

--- a/resource/js/tab-alpha.js
+++ b/resource/js/tab-alpha.js
@@ -133,12 +133,11 @@ function startAlphaApp () {
         const pagination = this.$refs.tabAlpha.$refs.pagination
         const sidebarTabs = document.getElementById('sidebar-tabs')
 
-        // get height and width of pagination and sidebar tabs elements if they exist
-        const height = pagination && pagination.clientHeight + sidebarTabs.clientHeight
-        const width = pagination && pagination.clientWidth - 1
+        const height = pagination ? pagination.clientHeight + sidebarTabs.clientHeight : sidebarTabs.clientHeight
+        const width = sidebarTabs.getBoundingClientRect().width
 
         this.listStyle = {
-          height: 'calc(100% - ' + height + 'px )',
+          height: 'calc( 100% - ' + height + 'px )',
           width: width + 'px'
         }
       }
@@ -204,12 +203,7 @@ function startAlphaApp () {
       }
     },
     template: `
-      <template v-if="loadingLetters">
-        <div class="loading-message">
-          {{ this.loadingMessage }} <i class="fa-solid fa-spinner fa-spin-pulse"></i>
-        </div>
-      </template>
-      <template v-else>
+      <template v-if="!loadingLetters">
         <ul class="pagination" v-if="indexLetters.length !== 0" ref="pagination">
           <li v-for="letter in indexLetters" class="page-item">
             <a class="page-link" href="#" @click="loadConcepts($event, letter)">{{ letter }}</a>
@@ -218,7 +212,7 @@ function startAlphaApp () {
       </template>
       
       <div class="sidebar-list" :style="listStyle" ref="list">
-        <template v-if="loadingConcepts">
+        <template v-if="loadingConcepts || loadingLetters">
           <div>
             {{ this.loadingMessage }} <i class="fa-solid fa-spinner fa-spin-pulse"></i>
           </div>

--- a/resource/js/tab-changes.js
+++ b/resource/js/tab-changes.js
@@ -126,7 +126,7 @@ function startChangesApp () {
       },
       setListStyle () {
         const height = document.getElementById('sidebar-tabs').clientHeight
-        const width = document.getElementById('sidebar-tabs').clientWidth - 1
+        const width = document.getElementById('sidebar-tabs').getBoundingClientRect().width
         this.listStyle = {
           height: 'calc( 100% - ' + height + 'px )',
           width: width + 'px'

--- a/resource/js/tab-groups.js
+++ b/resource/js/tab-groups.js
@@ -32,6 +32,8 @@ function startGroupsApp () {
       if (document.querySelector('#groups > a').classList.contains('active')) {
         this.loadGroups()
       }
+
+      this.setListStyle()
     },
     beforeUpdate () {
       this.setListStyle()
@@ -153,7 +155,7 @@ function startGroupsApp () {
       },
       setListStyle () {
         const height = document.getElementById('sidebar-tabs').clientHeight
-        const width = document.getElementById('sidebar-tabs').clientWidth - 1
+        const width = document.getElementById('sidebar-tabs').getBoundingClientRect().width
         this.listStyle = {
           height: 'calc( 100% - ' + height + 'px )',
           width: width + 'px'

--- a/resource/js/tab-hierarchy.js
+++ b/resource/js/tab-hierarchy.js
@@ -32,6 +32,8 @@ function startHierarchyApp () {
       if (document.querySelector('#hierarchy > a').classList.contains('active')) {
         this.loadHierarchy()
       }
+
+      this.setListStyle()
     },
     beforeUpdate () {
       this.setListStyle()
@@ -298,7 +300,7 @@ function startHierarchyApp () {
       },
       setListStyle () {
         const height = document.getElementById('sidebar-tabs').clientHeight
-        const width = document.getElementById('sidebar-tabs').clientWidth - 1
+        const width = document.getElementById('sidebar-tabs').getBoundingClientRect().width
         this.listStyle = {
           height: 'calc( 100% - ' + height + 'px )',
           width: width + 'px'


### PR DESCRIPTION
## Reasons for creating this PR

Sidebar Vue components have incorrect initial height and width before load and often incorrect width after load. This PR fixes the component sizing.

## Link to relevant issue(s), if any

- Part of #1521 and #1563

## Description of the changes in this PR

- Fix setting sidebar width in alphabetical, hierarchical, groups and changes tabs
- Fix setting initial sizing for sidebar in alphabetical and changes tabs

Addresses requirement 3k in #1521 and 1c in #1563

## Known problems or uncertainties in this PR

## Checklist

- [ ] phpUnit tests pass locally with my changes
- [ ] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [ ] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [ ] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
