### PR TITLE
Update topbar navigation (inc. language links) during partial page load

### DIFF
--- a/resource/js/partial-page-load.js
+++ b/resource/js/partial-page-load.js
@@ -23,6 +23,13 @@ const fetchWithAbort = (function () {
   }
 })()
 
+const updateTopbarNav = (conceptHTML) => {
+  // update topbar navigation with language links
+  const conceptTopbarNav = conceptHTML.querySelector('#topbar-nav')
+  const topbarNav = document.querySelector('#topbar-nav')
+  topbarNav.innerHTML = conceptTopbarNav.innerHTML
+}
+
 const updateMainContent = (conceptHTML) => {
   // concept card
   const conceptMainContent = conceptHTML.querySelectorAll('#main-content > :not(#concept-mappings)') // all elements from concept card except concept mappings
@@ -96,6 +103,7 @@ const partialPageLoad = (event, pageUri) => {
       const conceptHTML = document.createElement('div')
       conceptHTML.innerHTML = data.trim()
 
+      updateTopbarNav(conceptHTML)
       updateMainContent(conceptHTML)
       updateTitle(conceptHTML)
       updateJsonLD(conceptHTML)

--- a/tests/cypress/e2e/vocab-home-concept-lang.cy.js
+++ b/tests/cypress/e2e/vocab-home-concept-lang.cy.js
@@ -1,0 +1,19 @@
+describe('Vocab home page -> concept page -> change lang', () => {
+  before(() => {
+    cy.visit('/yso/en');
+  });
+
+  it('vocabulary home, concept page, change clang', () => {
+    // click on the link "acids" (should trigger partial page load)
+    cy.get('#tab-alphabetical').contains('a', 'acids').click()
+
+    // Confirm that we are on the correct page (acids, English)
+    cy.url().should('include', '/yso/en/page/p6514');
+
+    // Change the UI language to Finnish by clicking on the language link
+    cy.get('#topbar-nav').contains('a', 'suomeksi').click()
+
+    // Confirm that we are on the correct page (hapot, Finnish)
+    cy.url().should('include', '/yso/fi/page/p6514');
+  });
+});


### PR DESCRIPTION
## Reasons for creating this PR

Fix a bug where changing the UI language after a partial page load could load the wrong page, see #1848.

This PR adds one more step to the partial page load: updating the topbar navigation links by copying them from the loaded concept page into the current page DOM. I also added a Cypress E2E test to verify that it works.

## Link to relevant issue(s), if any

- Closes #1848

## Description of the changes in this PR

- add `updateTopbarNav` function to partial-page-load.js
- add Cypress test to verify

## Known problems or uncertainties in this PR

None

## Checklist

- [ ] phpUnit tests pass locally with my changes
- [ ] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [ ] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [ ] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
