### PR TITLE
fix #1857. Remove sparql query aggregates from GROUP BY to avoid malf…

### DIFF
--- a/model/sparql/GenericSparql.php
+++ b/model/sparql/GenericSparql.php
@@ -1141,7 +1141,7 @@ WHERE {
  }
  $filterGraph
 }
-GROUP BY ?s ?match ?label ?plabel ?alabel ?hlabel ?notation ?distLabels ?graph
+GROUP BY ?s ?match ?label ?plabel ?alabel ?hlabel ?notation ?graph
 ORDER BY LCASE(STR(?match)) LANG(?match) LCASE(STR(?distLabels)) $orderextra
 EOQ;
         return $query;


### PR DESCRIPTION
## Reasons for creating this PR

PR https://github.com/NatLibFi/Skosmos/pull/1380 introduced malformed SPARQL Query while using search engine. `MALFORMED QUERY: projection alias 'distLabels' was previously used`.

## Link to relevant issue(s), if any

- Closes #1857

## Description of the changes in this PR

`(GROUP_CONCAT(DISTINCT STR(?distcoal);separator='|||') as ?distLabels)` as not yet been evaluated at the moment of the GROUP BY evaluation