### PR TITLE
Translate concept/collection types on concept page

### DIFF
--- a/src/view/concept-card.inc.twig
+++ b/src/view/concept-card.inc.twig
@@ -94,6 +94,7 @@
                 </ul>
                 {% endif %}
               </li>
+              {% elseif property.type == 'rdf:type' %}<li>{{ propval.label|trans }}</li>
               {% else %} {# literals, e.g. altLabels #}
               <li>
                 {%- apply spaceless %}

--- a/tests/cypress/template/concept.cy.js
+++ b/tests/cypress/template/concept.cy.js
@@ -153,7 +153,17 @@ describe('Concept page', () => {
     // the tooltip should now be visible
     cy.get('#concept-label .tooltip-html-content').should('be.visible')
   })
-  it('contains concept type', () => {
+  it('contains concept type (skos:Collection and iso-thes)', () => {
+    cy.visit('/groups/en/page/fish') // go to "Fish" ConceptGroup page
+
+    // check the property name
+    cy.get('.prop-rdf_type .property-label').invoke('text').should('equal', 'Type')
+
+    // check the concept type
+    cy.get('.prop-rdf_type .property-value li').invoke('text').should('contain', 'Collection')
+    cy.get('.prop-rdf_type .property-value li').invoke('text').should('contain', 'Array of sibling concepts')
+  })
+  it('contains concept type (vocabulary-specific type)', () => {
     cy.visit('/yso/en/page/p21685') // go to "music research" concept page
 
     // check the property name

--- a/tests/testconfig.ttl
+++ b/tests/testconfig.ttl
@@ -230,7 +230,7 @@
 	dc:subject :cat_general ;
 	void:dataDump <http://skosmos.skos/dump/test/groups.ttl>,
 		<http://skosmos.skos/dump/test/groups> ;
-	void:uriSpace "http://www.skosmos.skos/onto/groups/";
+	void:uriSpace "http://www.skosmos.skos/groups/";
 	skosmos:arrayClass isothes:ThesaurusArray ;
     skosmos:groupClass skos:Collection ;
     skosmos:defaultConceptSidebarView "groups" ;


### PR DESCRIPTION
## Reasons for creating this PR

Concept types were not localized (translated) on the concept page in all cases. This PR makes sure that also types that are localized via the translation files (e.g. skos:Collection, iso-thes:ConceptGroup) are properly translated. A Cypress test verifies this.

For example the display of the YSO group [00 General terms](https://test.dev.finto.fi/yso/en/page/p26556) was affected by this.

Before this PR:

<img width="1119" height="225" alt="image" src="https://github.com/user-attachments/assets/47512b34-b9bf-454a-a3f2-bec80291efaa" />

After:

<img width="1119" height="216" alt="image" src="https://github.com/user-attachments/assets/ed64e9c5-92d8-40f1-a84e-73e26153ad5d" />



## Link to relevant issue(s), if any

- Closes #1902

## Description of the changes in this PR

* add special handling for concept type, with translation, in concept page Twig template
* add Cypress test to verify translation of e.g. skos:Collection type label
* fix configuration of `groups` test vocabulary URI space (needed by cypress test)

## Known problems or uncertainties in this PR

Some mapping-related Cypress tests are failing, but they are not related to this change and PR #1912 should fix them.

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
