### PR TITLE
Resolve Wikidata URIs using QLever SPARQL endpoint instead of WDQS

### DIFF
--- a/src/model/resolver/Resolver.php
+++ b/src/model/resolver/Resolver.php
@@ -28,7 +28,7 @@ class Resolver
         if (preg_match('|http://id.loc.gov/[^/]+/[^/]+/.+|', $uri)) {
             $res = new LOCResource($this->model, $uri);
         } elseif ($this->startsWith('http://www.wikidata.org/entity/', $uri)) {
-            $res = new WDQSResource($this->model, $uri);
+            $res = new WikidataResource($this->model, $uri);
         } else {
             $res = new LinkedDataResource($this->model, $uri);
         }

--- a/src/model/resolver/WikidataResource.php
+++ b/src/model/resolver/WikidataResource.php
@@ -1,8 +1,9 @@
 <?php
 
-class WDQSResource extends RemoteResource
+class WikidataResource extends RemoteResource
 {
-    public const WDQS_ENDPOINT = "https://query.wikidata.org/sparql";
+    // use the QLever Wikidata endpoint as it is much faster than WDQS
+    public const WIKIDATA_ENDPOINT = "https://qlever.dev/api/wikidata";
 
     public function resolve(int $timeout): ?EasyRdf\Resource
     {
@@ -10,7 +11,6 @@ class WDQSResource extends RemoteResource
             // change the timeout setting for external requests
             $httpclient = EasyRdf\Http::getDefaultHttpClient();
             $httpclient->setConfig(array('timeout' => $timeout, 'useragent' => 'Skosmos'));
-            $httpclient->setHeaders('Accept', 'text/turtle');
             EasyRdf\Http::setDefaultHttpClient($httpclient);
 
             $uri = $this->uri;
@@ -39,7 +39,7 @@ WHERE
 }
 EOQ;
 
-            $client = new EasyRdf\Sparql\Client(self::WDQS_ENDPOINT);
+            $client = new EasyRdf\Sparql\Client(self::WIKIDATA_ENDPOINT);
             $graph = $client->query($query);
             return $graph->resource($this->uri);
         } catch (Exception $e) {

--- a/tests/ResolverTest.php
+++ b/tests/ResolverTest.php
@@ -27,10 +27,10 @@ class ResolverTest extends PHPUnit\Framework\TestCase
     /**
      * @covers Resolver::resolve
      * @covers RemoteResource::__construct
-     * @covers WDQSResource::resolve
+     * @covers WikidataResource::resolve
      * @uses Resolver
      */
-    public function testResolveWDQSZeroTimeout()
+    public function testResolveWikidataZeroTimeout()
     {
         $uri = "http://www.wikidata.org/entity/Q42"; // Wikidata: Douglas Adams
         // use @ to suppress the timeout warning


### PR DESCRIPTION
## Reasons for creating this PR

Wikidata URIs were not being resolved properly, see #1911. This PR works around the issue by switching to the alternative QLever Wikidata SPARQL endpoint which is much faster and (hopefully) more reliable than the Blazegraph-based official WDQS.

## Link to relevant issue(s), if any

- Closes #1911

## Description of the changes in this PR

* switch to QLever SPARQL endpoint for resolving Wikidata entities
* rename some classes (WDQS -> Wikidata) to avoid confusion, as we are no longer using WDQS

## Known problems or uncertainties in this PR

I hope it really helped solve the problem?

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
