### PR TITLE
Fix autocomplete hiding cross-language matches in "Any language" mode

### DIFF
--- a/resource/js/vocab-search.js
+++ b/resource/js/vocab-search.js
@@ -60,7 +60,8 @@ function startVocabSearchApp () {
         const mySearchCounter = this.searchCounter + 1 // make sure we can identify this search later in case of several ongoing searches
         this.searchCounter = mySearchCounter
         let skosmosSearchUrl = 'rest/v1/' + window.SKOSMOS.vocab + '/search?'
-        const skosmosSearchUrlParams = new URLSearchParams({ query: this.formatSearchTerm(), unique: true })
+        const unique = this.selectedLanguage !== 'all'
+        const skosmosSearchUrlParams = new URLSearchParams({ query: this.formatSearchTerm(), unique: unique })
         if (this.selectedLanguage !== 'all') skosmosSearchUrlParams.set('lang', this.selectedLanguage)
         skosmosSearchUrl += skosmosSearchUrlParams.toString()
 


### PR DESCRIPTION
## Summary
- Autocomplete search always passes `unique=true` to the REST API, which deduplicates results by URI
- When "Any language" is selected, this silently drops matches from other languages (e.g. French results hidden by Spanish ones for the same concept)
- Fix: set `unique=false` when "Any language" is selected, `unique=true` otherwise

## Steps to reproduce
1. Set up a multilingual vocabulary (e.g. EN/FR/ES)
2. Select "Any language" in the search dropdown
3. Type a term that exists in multiple languages (e.g. `restaur` matching both Spanish "Restaurar..." and French "Restaurer...")
4. Only results from one language appear; the other language matches are silently dropped

## Fix
One-line change in `resource/js/vocab-search.js`: make `unique` conditional on whether a specific language is selected.

```javascript
// Before:
const skosmosSearchUrlParams = new URLSearchParams({ query: this.formatSearchTerm(), unique: true })

// After:
const unique = this.selectedLanguage !== 'all'
const skosmosSearchUrlParams = new URLSearchParams({ query: this.formatSearchTerm(), unique: unique })
```

## Before / After

**Before (v3.1):** Only Spanish (es) matches — French results silently dropped.

<img src="https://github.com/user-attachments/assets/6a9e8736-d628-401c-9a9a-9c584888b694" alt="before" width="400" />

---

**After (this fix):** Both Spanish and French matches shown, as expected for "Any language" search.

<img src="https://github.com/user-attachments/assets/fbba84dc-4b68-4c60-ae92-8e31bf0ba66a" alt="after" width="400" />



Fixes #1934