### PR TITLE
French language name should be "en français" (lowercase f)

### DIFF
--- a/resource/translations/messages.fr.json
+++ b/resource/translations/messages.fr.json
@@ -102,7 +102,7 @@
     "from all": "Partout",
     "helper_help": "Passer le curseur sur un texte soulign\u00e9 en pointill\u00e9 pour voir plus d'informations sur la propri\u00e9t\u00e9.",
     "hierarchy-disabled-help": "Impossible d'afficher les concepts racines de la hi\u00e9rarchie pour ce vocabulaire.",
-    "in_this_language": "en Fran\u00e7ais",
+    "in_this_language": "en fran\u00e7ais",
     "isothes:ConceptGroup": "Groupe de concepts",
     "isothes:ThesaurusArray": "Tableau de concepts fr\u00e8res",
     "isothes:broaderGeneric": "Concepts g\u00e9n\u00e9riques",


### PR DESCRIPTION
Description of the changes in this PR
-------------------------------------

The language switcher in the top-right navigation bar displays **"en Français"** with a capital F. In French, language names are common nouns and should not be capitalized: **"en français"**.

**File:** `resource/translations/messages.fr.json`, key `"in_this_language"`

This was likely introduced during the Lokalise migration in #1648.

Reasons for creating this PR
----------------------------

French orthographic rules require lowercase for language names. This is a minor localization fix.

Link to relevant issue(s), if any
---------------------------------

None.

Known problems or uncertainties in this PR
------------------------------------------

If translations are synced from Lokalise, the fix may need to be applied there as well to avoid being overwritten on the next sync.

Checklist
---------

-   [x]  phpUnit tests pass locally with my changes
-   [x]  I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
-   [x]  The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
-   [x]  The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)