### PR TITLE
Fix SKOSMOS object prefLabels property

### DIFF
--- a/src/view/scripts.inc.twig
+++ b/src/view/scripts.inc.twig
@@ -15,7 +15,7 @@ window.SKOSMOS = {
   "waypoint_results": {{ parameters ? parameters.searchLimit : "null" }},
   "search_count": {{ search_count ? search_count : "null" }},
   "search_results_size": {{ GlobalConfig.searchResultsSize }},
-  {%- if request.page == "page" and concept %}
+  {% if request.page == "page" and concept -%}
   "prefLabels": [{"lang": "{{ concept.label.lang }}", "label": "{{ concept.label }}"}{% for data in concept.foreignLabels %}{% for literal in data.prefLabel %}, {"lang": "{{ literal.lang }}", "label": "{{ literal.label }}"}{% endfor %}{% endfor %}],
   "uri": "{{ concept.uri }}",
   {% endif %}


### PR DESCRIPTION
## Reasons for creating this PR

`prefLabels` property in the SKOSMOS JavaScript object only shows a prefLabel in selected content language. This PR fixes forming the array of prefLabels.

## Description of the changes in this PR

- Fix creating array of prefLabels and language codes in `prefLabels` property of SKOSMOS JS object

## Known problems or uncertainties in this PR

## Checklist

- [ ] phpUnit tests pass locally with my changes
- [ ] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [ ] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [ ] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
