### PR TITLE
Draft: Keyboard navigation for vocabulary dropdown in global search

### DIFF
--- a/resource/css/skosmos.css
+++ b/resource/css/skosmos.css
@@ -426,8 +426,21 @@ header .container-fluid .row {
   position: absolute;
   opacity: 0;
   cursor: pointer;
-  height: 0;
-  width: 0;
+  height: 1.5rem;
+  width: 1.5rem;
+  top: 0;
+  left: 0;
+}
+
+/* Show a visible focus ring when the (visually hidden) checkbox is focused */
+#search-wrapper #vocab-list .vocab-select:focus-within {
+  outline: 2px solid var(--dark-color);
+  outline-offset: 2px;
+}
+
+/* Optional: highlight the custom checkbox square when focused */
+#search-wrapper #vocab-list .vocab-select input:focus-visible ~ .checkmark {
+  box-shadow: 0 0 0 3px rgba(13, 40, 78, 0.35);
 }
 
 #search-wrapper .checkmark {

--- a/resource/css/skosmos.css
+++ b/resource/css/skosmos.css
@@ -493,11 +493,11 @@ header .container-fluid .row {
 /* --- Browser specific rules --- */
 
 /* Setting scrollbar style separately in Firefox */
-@-moz-document url-prefix() {
+@supports (-moz-appearance: none) {
   #search-wrapper ul {
     scrollbar-color: var(--scrollbar-thumb) var(--search-dropdown-bg);
   }
-} 
+}
 
 /* Setting scrollbar style for Webkit based browsers (Chrome, Safari, Edge, etc) */
 #search-wrapper ul::-webkit-scrollbar {
@@ -928,11 +928,11 @@ header .container-fluid .row {
 /* --- Browser specific rules --- */
 
 /* Setting scrollbar style separately in Firefox */
-@-moz-document url-prefix() {
+@supports (-moz-appearance: none) {
   #sidebar .sidebar-list {
     scrollbar-color: var(--sidebar-scrollbar-thumb) var(--sidebar-scrollbar-track);
   }
-} 
+}
 
 /* Setting scrollbar style for Webkit based browsers (Chrome, Safari, Edge, etc) */
 #sidebar .sidebar-list::-webkit-scrollbar {

--- a/resource/js/global-search.js
+++ b/resource/js/global-search.js
@@ -53,6 +53,19 @@ function startGlobalSearchApp () {
       this.selectedLanguage = this.getSearchLang()
       this.languageStrings = this.formatLanguages()
       this.vocabStrings = window.SKOSMOS.vocab_list
+
+      this.$nextTick(() => {
+        const btn = this.$refs.vocabToggle
+        if (!btn) return
+        btn.addEventListener('shown.bs.dropdown', this.onVocabDropdownShown)
+        btn.addEventListener('hidden.bs.dropdown', this.onVocabDropdownHidden)
+      })
+    },
+    beforeUnmount () {
+      const btn = this.$refs.vocabToggle
+      if (!btn) return
+      btn.removeEventListener('shown.bs.dropdown', this.onVocabDropdownShown)
+      btn.removeEventListener('hidden.bs.dropdown', this.onVocabDropdownHidden)
     },
     watch: {
       selectedLanguage (newLang) {
@@ -255,12 +268,58 @@ function startGlobalSearchApp () {
       showAutoComplete () {
         this.showDropdown = true
         this.$forceUpdate()
+      },
+      onVocabDropdownShown () {
+        this.$nextTick(() => {
+          const first = document.querySelector('#vocab-list .vocab-checkbox')
+          first?.focus()
+        })
+      },
+      onVocabDropdownHidden () {
+        this.$nextTick(() => {
+          this.$refs.vocabToggle?.focus()
+        })
+      },
+      onVocabMenuKeydown (e) {
+        const items = Array.from(document.querySelectorAll('#vocab-list .vocab-checkbox'))
+        if (!items.length) return
+
+        const currentIndex = items.indexOf(document.activeElement)
+
+        const focusAt = (newIndex) => {
+          const i = (newIndex + items.length) % items.length
+          items[i].focus()
+        }
+
+        switch (e.key) {
+          case 'ArrowDown':
+            e.preventDefault()
+            focusAt(currentIndex < 0 ? 0 : currentIndex + 1)
+            break
+          case 'ArrowUp':
+            e.preventDefault()
+            focusAt(currentIndex < 0 ? items.length - 1 : currentIndex - 1)
+            break
+          case 'Home':
+            e.preventDefault()
+            focusAt(0)
+            break
+          case 'End':
+            e.preventDefault()
+            focusAt(items.length - 1)
+            break
+          case 'Escape':
+            e.preventDefault()
+            // close dropdown and restore focus
+            this.$refs.vocabToggle?.click()
+            break
+        }
       }
     },
     template: `
       <div id="search-wrapper" class="input-group ps-xl-2 flex-nowrap">
         <div class="dropdown" id="vocab-selector">
-          <button class="btn btn-outline-secondary dropdown-toggle vocab-dropdown-btn"
+          <button ref="vocabToggle" class="btn btn-outline-secondary dropdown-toggle vocab-dropdown-btn"
             role="button"
             data-bs-toggle="dropdown"
             data-bs-auto-close="outside"
@@ -271,10 +330,11 @@ function startGlobalSearchApp () {
             <span v-else>{{ vocabSelectorPlaceholder }}</span>
             <i class="chevron fa-solid fa-chevron-down"></i>
           </button>
-          <ul class="dropdown-menu" id="vocab-list" role="menu">
-            <li v-for="(value, key) in vocabStrings" :key="key">
-              <label class="vocab-select">
+          <ul class="dropdown-menu" id="vocab-list" role="menu" @keydown="onVocabMenuKeydown">
+            <li v-for="(value, key) in vocabStrings" :key="key" role="none">
+              <label class="dropdown-item vocab-select">
                 <input
+                  class="vocab-checkbox"
                   type="checkbox"
                   :value="key"
                   v-model="selectedVocabs"


### PR DESCRIPTION
## Reasons for creating this PR

Attempting to implement keyboard navigation in the global search bar.

This is an alternative to #1915 which hit a wall.

I made this with the help of Aider and GPT-5.2. The implementation is probably not ideal but we could perhaps take inspiration from it. Leaving it as draft PR for now.

## Link to relevant issue(s), if any

- partially addresses #1891

## Description of the changes in this PR

* add keyboard navigation functionality to vocabulary selection dropdown in global search
* add CSS rules that make the focus visible
* (fix some unrelated CSS issues)

## Known problems or uncertainties in this PR

The CSS changes are probably too heavy-handed. Aider/GPT-5.2 went on to fix some unrelated things and we probably don't want to show the focus in exactly this way, so it needs to be adjusted.

## Checklist

- [ ] phpUnit tests pass locally with my changes
- [ ] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [ ] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [ ] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
