### PR TITLE
Convert CURIEs to URIs when rendering types in search autocomplete lists

### DIFF
--- a/resource/js/global-search.js
+++ b/resource/js/global-search.js
@@ -11,6 +11,7 @@ function startGlobalSearchApp () {
         searchCounter: null,
         renderedResultsList: [],
         languageStrings: null,
+        uriPrefixes: {},
         vocabStrings: null,
         showDropdown: false,
         showNotation: null
@@ -52,6 +53,7 @@ function startGlobalSearchApp () {
       this.languages = window.SKOSMOS.languageOrder
       this.selectedLanguage = this.getSearchLang()
       this.languageStrings = this.formatLanguages()
+      this.uriPrefixes = {}
       this.vocabStrings = window.SKOSMOS.vocab_list
     },
     watch: {
@@ -94,6 +96,7 @@ function startGlobalSearchApp () {
           .then(data => {
             if (mySearchCounter === this.searchCounter) {
               this.renderedResultsList = data.results // update results (update cache if it is implemented)
+              this.uriPrefixes = data['@context']
               this.renderResults() // render after the fetch has finished
             }
           })
@@ -173,7 +176,17 @@ function startGlobalSearchApp () {
       },
       renderType (typeUri) {
         const label = window.SKOSMOS.types[typeUri]
-        return (label) || typeUri
+        if (label) return label
+
+        const [prefix, local] = typeUri.split(':')
+        const iriBase = this.uriPrefixes[prefix]
+
+        if (iriBase) {
+          const iri = iriBase + local
+          return window.SKOSMOS.types[iri] || typeUri
+        }
+
+        return typeUri
       },
       /*
       * renderResults is used when the search string has been indexed in the cache

--- a/resource/js/vocab-search.js
+++ b/resource/js/vocab-search.js
@@ -9,6 +9,7 @@ function startVocabSearchApp () {
         searchCounter: null,
         renderedResultsList: [],
         languageStrings: null,
+        uriPrefixes: {},
         showDropdown: false,
         showNotation: null
       }
@@ -38,6 +39,7 @@ function startVocabSearchApp () {
       this.searchCounter = 0 // used for matching the query and the response in case there are many responses
       this.languageStrings = this.formatLanguages()
       this.renderedResultsList = []
+      this.uriPrefixes = {}
       this.showNotation = window.SKOSMOS.showNotation
     },
     methods: {
@@ -69,6 +71,7 @@ function startVocabSearchApp () {
           .then(data => {
             if (mySearchCounter === this.searchCounter) {
               this.renderedResultsList = data.results // update results (update cache if it is implemented)
+              this.uriPrefixes = data['@context']
               this.renderResults() // render after the fetch has finished
             }
           })
@@ -130,7 +133,17 @@ function startVocabSearchApp () {
       },
       renderType (typeUri) {
         const label = window.SKOSMOS.types[typeUri]
-        return (label) || typeUri
+        if (label) return label
+
+        const [prefix, local] = typeUri.split(':')
+        const iriBase = this.uriPrefixes[prefix]
+
+        if (iriBase) {
+          const iri = iriBase + local
+          return window.SKOSMOS.types[iri] || typeUri
+        }
+
+        return typeUri
       },
       /*
       * renderResults is used when the search string has been indexed in the cache

--- a/tests/cypress/template/global-search-bar.cy.js
+++ b/tests/cypress/template/global-search-bar.cy.js
@@ -132,6 +132,31 @@ describe('Global search bar', () => {
         cy.get('li').first().should('contain', 'Test class')
       })
     })
+    it('Autocomplete search result list concept types are translated', () => {
+      // go to landing page
+      cy.visit('/en/')
+
+      // open search bar
+      cy.get('#global-search-toggle').click()
+
+      // select a vocabulary
+      cy.contains('#vocab-list li label.vocab-select', 'conceptPropertyLabels').parents('li').find('input[type="checkbox"]').check({ force: true });
+
+      // Choose English from the language dropdown
+      cy.get('#language-selector .dropdown-toggle').click();
+      cy.get('#language-list .dropdown-item').contains('English').click();
+
+      // Enter a search term
+      cy.get('#search-field').type('Fish');
+
+      // Autocomplete should appear
+      cy.get('#search-autocomplete-results', { timeout: 20000 }).should('be.visible');
+
+      // Verify the dropdown should have the concept type literal
+      cy.get('#search-autocomplete-results').within(() => {
+	cy.get('li').first().find('div.col-auto.align-self-end.pr-1').should('have.text', 'Concept')
+      })
+    })
     it ('Autocomplete search result links point to concept pages', () => {
       // go to test vocab
       cy.visit('/en/')

--- a/tests/cypress/template/vocab-search-bar.cy.js
+++ b/tests/cypress/template/vocab-search-bar.cy.js
@@ -203,6 +203,25 @@ describe('Vocab search bar', () => {
         cy.get('li').first().should('contain', 'Test class')
       })
     })
+    it('Autocomplete search result list concept types are translated', () => {
+      // go to test vocab
+      cy.visit('/groups/en/')
+
+      // Choose English from the language dropdown
+      cy.get('#language-selector .dropdown-toggle').click();
+      cy.get('#language-list .dropdown-item').contains('English').click();
+
+      // Enter a search term
+      cy.get('#search-wrapper input').type('Fish');
+
+      // Autocomplete should appear
+      cy.get('#search-autocomplete-results', { timeout: 20000 }).should('be.visible');
+
+      // Verify the dropdown should have the concept type literal
+      cy.get('#search-autocomplete-results').within(() => {
+	cy.get('li').first().find('div.col-auto.align-self-end.pr-1').should('have.text', 'Collection')
+      })
+    })
   });
 
   describe('Search Result Rendering', () => {


### PR DESCRIPTION
## Reasons for creating this PR

Some types were not being properly displayed in the autocomplete lists of the global and vocab search components. Especially generic types like `skos:Concept` and `skos:Collection` were not translated but shown as is:

<img width="360" height="486" alt="kuva" src="https://github.com/user-attachments/assets/b9baf63e-467a-481a-9929-e8a16d81c819" />

The problem was that in the JSON-LD data returned by the REST API `search` method, shortened CURIEs were used for these types. This was not expected by the VueJS components that render the result; they expect full URIs for the types, which matches how they are represented in the `window.SKOSMOS.types` object.

The solution is to keep the URI prefix mapping from the JSON-LD response `@context` and use that to convert CURIEs to full URIs. This PR makes the same change in both global and vocab search and adds Cypress tests to verify.

Result:

<img width="360" height="487" alt="kuva" src="https://github.com/user-attachments/assets/8eed7a76-65b8-446d-b3d4-3117cf43e11e" />

## Link to relevant issue(s), if any

- Closes #1945

## Description of the changes in this PR

* convert CURIEs to URIs when rendering types in global-search and vocab-search components
* add Cypress tests

## Known problems or uncertainties in this PR

Some types are still not rendered in a human friendly way, e.g. HKLJ contains `owl:Class` types that have no known human readable labels either in the vocabulary data or in Skosmos code/translations. But I think that is a data problem, not something that Skosmos alone can fix.

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
