### PR TITLE
Create a mock-up to make collations follow the selected languages ins…

### DIFF
--- a/src/model/ConceptProperty.php
+++ b/src/model/ConceptProperty.php
@@ -143,6 +143,16 @@ class ConceptProperty
             } else {
                 uasort($this->values, function ($a, $b) {
                     // assume that sort keys are unique
+                    if ($this->prop === 'skos:narrower') {
+                        $context = $a->getCollationContext();
+                        return $this->model->compareStringsByLanguage(
+                            $a->getSortKey(),
+                            $b->getSortKey(),
+                            $context['contentLang'],
+                            $context['uiLang'],
+                            $context['defaultLang']
+                        );
+                    }
                     return strcoll($a->getSortKey(), $b->getSortKey());
                 });
             }

--- a/src/model/ConceptPropertyValue.php
+++ b/src/model/ConceptPropertyValue.php
@@ -54,6 +54,18 @@ class ConceptPropertyValue extends VocabularyDataObject
         return strtolower($this->getLabel());
     }
 
+    /**
+     * Collation context for backend sorting.
+     */
+    public function getCollationContext()
+    {
+        return array(
+            'contentLang' => $this->clang ?: null,
+            'uiLang' => $this->getLang() ?: null,
+            'defaultLang' => $this->vocab->getConfig()->getDefaultLanguage()
+        );
+    }
+
     public function getLabel($lang = '', $fallbackToUri = 'uri', $allowExternal = true)
     {
         if ($this->clang) {
@@ -147,7 +159,16 @@ class ConceptPropertyValue extends VocabularyDataObject
     private function sortSubMembers()
     {
         if (!empty($this->submembers)) {
-            ksort($this->submembers);
+            $context = $this->getCollationContext();
+            uasort($this->submembers, function ($a, $b) use ($context) {
+                return $this->model->compareStringsByLanguage(
+                    $a->getSortKey(),
+                    $b->getSortKey(),
+                    $context['contentLang'],
+                    $context['uiLang'],
+                    $context['defaultLang']
+                );
+            });
         }
 
     }

--- a/src/model/Model.php
+++ b/src/model/Model.php
@@ -25,6 +25,8 @@ class Model
     private $logger;
     private $resolver;
     private $translator;
+    /** cache for Collator instances by locale */
+    private $collatorCache = array();
 
     /**
      * Initializes the Model object
@@ -229,6 +231,64 @@ class Model
     public function getText($text)
     {
         return $this->translator->trans($text);
+    }
+
+    /**
+     * Compare two strings using a request-aware collation locale.
+     * Priority: content language (clang), UI language (lang), default language.
+     */
+    public function compareStringsByLanguage($a, $b, $contentLang = null, $uiLang = null, $defaultLang = null)
+    {
+        foreach ($this->resolveCollationLocales($contentLang, $uiLang, $defaultLang) as $locale) {
+            $collator = $this->getCollator($locale);
+            if ($collator !== null) {
+                $result = $collator->compare((string)$a, (string)$b);
+                if (is_int($result) && $result !== 0) {
+                    return $result;
+                }
+            }
+        }
+
+        // Deterministic fallback that does not depend on process locale.
+        return strcmp((string)$a, (string)$b);
+    }
+
+    private function resolveCollationLocales($contentLang, $uiLang, $defaultLang)
+    {
+        $languages = $this->getConfig()->getLanguages(); // lang code => locale
+        $candidates = array($contentLang, $uiLang, $defaultLang);
+        $locales = array();
+
+        foreach ($candidates as $code) {
+            if (!is_string($code) || $code === '') {
+                continue;
+            }
+
+            if (isset($languages[$code]) && is_string($languages[$code]) && $languages[$code] !== '') {
+                $locales[] = $languages[$code];
+            }
+
+            // Fallback candidate: try language code as locale too.
+            $locales[] = str_replace('-', '_', $code);
+        }
+
+        return array_values(array_unique($locales));
+    }
+
+    private function getCollator($locale)
+    {
+        if (!class_exists('Collator')) {
+            return null;
+        }
+
+        $key = ($locale && $locale !== '') ? $locale : 'root';
+        if (array_key_exists($key, $this->collatorCache)) {
+            return $this->collatorCache[$key];
+        }
+
+        $collator = collator_create($key);
+        $this->collatorCache[$key] = ($collator instanceof Collator) ? $collator : null;
+        return $this->collatorCache[$key];
     }
 
     /**


### PR DESCRIPTION
## Reasons for creating this PR
This is a mock-up intended to provide one example of how collation could be handled on the backend side (it will not work on the frontend due to the lack of Northern Sámi support in Chrome).

Previously the user interface and content could be displayed in multiple languages, but the actual sorting was in most cases determined by the runtime settings rather than by those languages.

Further investigation is required to determine how well the proposed model works in all cases and whether it can be generalized to all functionality that requires collation.

It is also worth considering whether there might be a more straightforward and reliable approach.

Attached screenshots show the situation before the mock-up. So far no errors have been dtected in Finnish, Swedish, Northern Sámi, or English when switching the content language and the user interface language across all possible permutations.

<img width="260" height="630" alt="Screenshot from 2026-03-18 12-53-24" src="https://github.com/user-attachments/assets/084255cb-d988-43aa-a505-5f8c6f8359c8" />
<img width="290" height="976" alt="Screenshot from 2026-03-18 12-53-08" src="https://github.com/user-attachments/assets/15715ed9-c145-4c9c-8620-3770f328486f" />

## Link to relevant issue(s), if any
#1420

- Closes #

## Description of the changes in this PR

**Model.php**
The comparison used for narrower sorting was moved into a single backend method (_compareStringsByLanguage_) so collation no longer depends on runtime locale. It uses the following language priority (in line with already existing practise) clang -> lang -> default plus the language mapping from config.ttl.

**ConceptProperty.php**
In the _skos:narrower_ case, the previous strcoll comparison was replaced with the centralized "language-aware" comparison so concept page narrower ordering follows the selected content language correctly.

**ConceptPropertyValue.php**
Submembers sorting was changed from ksort logic to the same backend collation path (uasort + collation context), so the sublist follows the same language-based ordering as the main narrower list. Uasort() sorts an array by its values using a user-defined comparison function.

_getCollationContext()_ was added (contentLang/uiLang/defaultLang) so sorting receives explicit request language context instead of deriving/calculating it implicitly from the environment.


## Known problems or uncertainties in this PR
It is a mock-up, we cannot wait it meets all the requirements

## Checklist

- [ ] phpUnit tests pass locally with my changes
- [ ] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [ ] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [ ] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
