### PR TITLE
Fix display of prefLabels in other languages (esp. KANTO cases)

### DIFF
--- a/resource/css/skosmos.css
+++ b/resource/css/skosmos.css
@@ -1174,6 +1174,10 @@ h1#vocab-heading {
   margin-bottom: 0;
 }
 
+.prop-foreignlabels .preflabel {
+  font-weight: bold;
+}
+
 #download-links li {
   display: inline-block;
 }

--- a/src/view/concept-card.inc.twig
+++ b/src/view/concept-card.inc.twig
@@ -188,9 +188,9 @@
                   {% if value.type == "skos:prefLabel" and value.lang in request.vocab.config.languages %}
                   <a {% if descriptionId %}aria-describedby="{{ descriptionId }}"{% endif %}
                     href="{{ concept.uri|link_url(request.vocabid,request.lang, 'page', value.lang) }}"
-                    hreflang="{{ value.lang }}">{{ value.label }}</a>
+                    hreflang="{{ value.lang }}" class="preflabel">{{ value.label }}</a>
                   {% else %}
-                  <span class="altlabel"{% if descriptionId %} aria-describedby="{{ descriptionId }}"{% endif %}>{{ value.label }}</span>
+                  <span class="{{ value.type == 'skos:prefLabel' ? 'preflabel' : 'altlabel' }}"{% if descriptionId %} aria-describedby="{{ descriptionId }}"{% endif %}>{{ value.label }}</span>
                   {% endif %}
                   </li>
                   {% endfor %}


### PR DESCRIPTION
## Reasons for creating this PR

Some prefLabels in the "terms in other languages" section were rendered like altLabels (in italic). This happened when the label was in a language that was not configured as a supported language for that vocabulary; a common scenario in KANTO/finaf where Finnish is the only supported content language but prefLabels in other languages are still sometimes included. This PR fixes the display of such prefLabels.

Before:
<img width="1065" height="44" alt="kuva" src="https://github.com/user-attachments/assets/109394e7-f3e0-4621-b831-3435923f4f28" />

After:
<img width="1065" height="44" alt="kuva" src="https://github.com/user-attachments/assets/eafba80f-d0f2-4126-8696-d28127529353" />

(please ignore the minor styling differences - the yellow emphasis - in the property name)

## Link to relevant issue(s), if any

n/a

## Description of the changes in this PR

* for other language labels, set a CSS class of either "preflabel" or "altlabel" depending on the label type
* adjust CSS to display preflabels in bold

## Known problems or uncertainties in this PR

I did not write a Cypress test for this case, as it's a pretty minor adjustment.

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
