### PR TITLE
WIP: optimize change list SPARQL query

### DIFF
--- a/src/model/sparql/GenericSparql.php
+++ b/src/model/sparql/GenericSparql.php
@@ -2356,6 +2356,11 @@ EOQ;
         $fcl = $this->generateFromClause();
         $offset = ($offset) ? 'OFFSET ' . $offset : '';
 
+        // only consider concepts changed within 1 year from today
+        $date = new DateTime();
+        $date->modify('-1 year');
+        $cutoffDate = $date->format('Y-m-d');
+
         //Additional clauses when deprecated concepts need to be included in the results
         $deprecatedOptions = '';
         $deprecatedVars = '';
@@ -2363,16 +2368,17 @@ EOQ;
             $deprecatedVars = '?replacedBy ?deprecated ?replacingLabel';
             $deprecatedOptions = <<<EOQ
 UNION {
-    ?concept owl:deprecated True; dc:modified ?date2 .
-    BIND(True as ?deprecated)
-    BIND(COALESCE(?date2, ?date) AS ?date)
+  ?concept owl:deprecated True;
+           dc:modified ?date .
+  FILTER (?date >= "$cutoffDate"^^xsd:date)
+  BIND(True as ?deprecated)
+  OPTIONAL {
+    ?concept dc:isReplacedBy ?replacedBy .
     OPTIONAL {
-        ?concept dc:isReplacedBy ?replacedBy .
-        OPTIONAL {
-            ?replacedBy skos:prefLabel ?replacingLabel .
-            FILTER (langMatches(lang(?replacingLabel), '$lang'))
-        }
+      ?replacedBy skos:prefLabel ?replacingLabel .
+      FILTER (langMatches(lang(?replacingLabel), 'fi'))
     }
+  }
 }
 EOQ;
         }
@@ -2380,14 +2386,20 @@ EOQ;
         $query = <<<EOQ
 SELECT ?concept ?date ?label $deprecatedVars $fcl
 WHERE {
-    ?concept a skos:Concept ;
-    skos:prefLabel ?label .
-    FILTER (langMatches(lang(?label), '$lang'))
-    {
-        ?concept $prop ?date .
-        MINUS { ?concept owl:deprecated True . }
+  {
+    SELECT * WHERE {
+      {
+        ?concept dc:created ?date .
+        FILTER (?date >= "$cutoffDate"^^xsd:date)
+        FILTER NOT EXISTS {
+          ?concept owl:deprecated True .
+        }
+      } $deprecatedOptions
     }
-    $deprecatedOptions
+  }
+  ?concept a skos:Concept .
+  ?concept skos:prefLabel ?label .
+  FILTER (langMatches(lang(?label), 'fi'))
 }
 ORDER BY DESC(YEAR(?date)) DESC(MONTH(?date)) LCASE(?label) DESC(?concept)
 LIMIT $limit $offset


### PR DESCRIPTION
This is work in progress. It's not yet functional.

It supersedes PR #1785 which was made for Skosmos 2. This is for Skosmos 3.

## Reasons for creating this PR

I'm trying to optimize the "New" / "New and Deprecated" tab that shows the recently added (or deprecated) concepts. It is very slow, especially in the case of a large vocabulary such as KANTO/finaf.

The optimized SPARQL query in this PR introduces a cutoff date, by default 1 year in the past. Only concepts whose timestamp (created or modified, depending on circumstances) is after this cutoff date are included in the query results. This drastically reduces the number of concepts to consider and so speeds up the query by a factor of approximately 10 (yso) to 15 (finaf).

## Link to relevant issue(s), if any

n/a

## Description of the changes in this PR

* optimize the SPARQL query that queries the new and deprecated concepts, introducing a cutoff date
* try to fix the unit tests that broke due to the above

## Known problems or uncertainties in this PR

Unfortunately, this change causes problems for the unit tests. The test data is much older than 1 year, so a lot of tests will fail because the time stamps are older than the default cutoff date. I tried to fix this by making the cutoff date into a parameter, but this makes the code more complicated, and I didn't yet get it working. I wonder if another mechanism - for example a configuration setting that sets the cutoff date - would work better for this.

## Checklist

- [ ] phpUnit tests pass locally with my changes
- [ ] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [ ] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [ ] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
