### PR TITLE
add custom content slots for headerbar and main-content

### DIFF
--- a/custom-templates/headerbar-bottom/README.txt
+++ b/custom-templates/headerbar-bottom/README.txt
@@ -1,0 +1,2 @@
+Any *.twig files placed here will be included into headerbar-bottom-slot in
+alphabetical order.

--- a/custom-templates/headerbar-top/README.txt
+++ b/custom-templates/headerbar-top/README.txt
@@ -1,0 +1,2 @@
+Any *.twig files placed here will be included into the headerbar-top-slot in
+alphabetical order.

--- a/custom-templates/main-content-bottom/README.txt
+++ b/custom-templates/main-content-bottom/README.txt
@@ -1,0 +1,2 @@
+Any *.twig files placed here will be included into main-content-bottom-slot
+in alphabetical order.

--- a/custom-templates/main-content-top/README.txt
+++ b/custom-templates/main-content-top/README.txt
@@ -1,0 +1,2 @@
+Any *.twig files placed here will be included into main-content-top-slot in
+alphabetical order.

--- a/src/view/base-template.twig
+++ b/src/view/base-template.twig
@@ -90,7 +90,9 @@
     {% endif %}
     {% if pageType in ['landing', 'vocab-home', 'concept', 'vocab-search'] %}
     <div class="container-fluid py-4" id="headerbar">
-      <div id="headerbar-top-slot" class="row"></div>
+      <div id="headerbar-top-slot" class="row">
+        {{ include('custom-templates.inc.twig', {slotName: 'headerbar-top'}) }}
+      </div>
       <div class="row">
         <div class="d-flex flex-column flex-xl-row align-items-start align-items-xl-center my-auto{% if pageType == 'landing' %} p-0{% endif %}">
           {% if pageType == 'landing' %}
@@ -109,7 +111,9 @@
           {% endif %}
         </div>
       </div>
-      <div id="headerbar-bottom-slot" class="row"></div>
+      <div id="headerbar-bottom-slot" class="row">
+        {{ include('custom-templates.inc.twig', {slotName: 'headerbar-bottom'}) }}
+      </div>
     </div>
     
     {% endif %}

--- a/src/view/concept-card.inc.twig
+++ b/src/view/concept-card.inc.twig
@@ -1,5 +1,7 @@
 <div class="col-md-8">
-  <div id="main-content-top-slot"></div>
+  <div id="main-content-top-slot">
+    {{ include('custom-templates.inc.twig', {slotName: 'main-content-top'}) }}
+  </div>
   <div id="main-content">
       {% if concept.deprecated %}
       <div class="main-content-section py-5 alert" id="concept-deprecated-alert">
@@ -239,5 +241,7 @@
       </div>
 
   </div>
-  <div id="main-content-bottom-slot"></div>
+  <div id="main-content-bottom-slot">
+    {{ include('custom-templates.inc.twig', {slotName: 'main-content-bottom'}) }}
+  </div>
 </div>

--- a/src/view/vocab-info.inc.twig
+++ b/src/view/vocab-info.inc.twig
@@ -1,5 +1,7 @@
 <div class="col-md-8">
-  <div id="main-content-top-slot"></div>
+  <div id="main-content-top-slot">
+    {{ include('custom-templates.inc.twig', {slotName: 'main-content-top'}) }}
+  </div>
   <div id="main-content">
     <div class="main-content-section py-4">
       <h1 id="vocab-heading">{{ "Vocabulary information" | trans }}</h1>
@@ -86,5 +88,7 @@
     <div id="concept-mappings">
     </div>
   </div>
-  <div id="main-content-bottom-slot"></div>
+  <div id="main-content-bottom-slot">
+    {{ include('custom-templates.inc.twig', {slotName: 'main-content-bottom'}) }}
+  </div>
 </div>


### PR DESCRIPTION
## Reasons for creating this PR

The Skosmos HTML DOM already included these empty DIVs for customization via plugins:
* `headerbar-top-slot`
* `headerbar-bottom-slot`
* `main-content-top-slot`
* `main-content-bottom-slot`

However, there were no corresponding custom content directories defined for these in the previous PRs that added customizable content (#1817, #1948). This PR adds four new custom content types corresponding to the above slots. These are needed for replacing old Finto / Skosmos 2 message plugins with custom content.

## Link to relevant issue(s), if any

- Part of #1946

## Description of the changes in this PR

Add four new custom content directories that populate the four slots mentioned above.

## Known problems or uncertainties in this PR

We need to update the [wiki documentation on custom templates](https://github.com/NatLibFi/Skosmos/wiki/Custom-templates) as well.

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
