### PR TITLE
Add translations for sidebar show/hide button on mobile

### DIFF
--- a/resource/js/mobile.js
+++ b/resource/js/mobile.js
@@ -1,20 +1,27 @@
+/* global $t, onTranslationReady */
+
 // Register event listener for clicking on sidebar collapse button that toggles visibility of sidebar
-const sidebarCollapseBtn = document.getElementById('sidebar-collapse-btn')
 
-if (sidebarCollapseBtn) {
-  sidebarCollapseBtn.addEventListener('click', () => {
-    // Toggle sidebar visibility
-    const sidebar = document.getElementById('sidebar-col')
-    sidebar.classList.toggle('d-none')
+function initializeSidebarCollapse() {
+  const sidebarCollapseBtn = document.getElementById('sidebar-collapse-btn')
 
-    // Toggle fontawesome icon
-    const i = document.querySelector('#sidebar-collapse-btn i')
-    i.classList.toggle('fa-chevron-right')
-    i.classList.toggle('fa-chevron-down')
+  if (sidebarCollapseBtn) {
+    sidebarCollapseBtn.addEventListener('click', () => {
+      // Toggle sidebar visibility
+      const sidebar = document.getElementById('sidebar-col')
+      sidebar.classList.toggle('d-none')
 
-    // Toggle button text
-    sidebarCollapseBtn.getElementsByTagName('span')[0].textContent = sidebar.classList.contains('d-none') ? 'Browse concepts' : 'Hide concepts'
+      // Toggle fontawesome icon
+      const i = document.querySelector('#sidebar-collapse-btn i')
+      i.classList.toggle('fa-chevron-right')
+      i.classList.toggle('fa-chevron-down')
 
-    sidebarCollapseBtn.setAttribute('aria-expanded', sidebarCollapseBtn.getAttribute('aria-expanded') === 'true' ? 'false' : 'true')
-  })
+      // Toggle button text
+      sidebarCollapseBtn.getElementsByTagName('span')[0].textContent = sidebar.classList.contains('d-none') ? $t('Browse concepts') : $t('Hide concepts')
+
+      sidebarCollapseBtn.setAttribute('aria-expanded', sidebarCollapseBtn.getAttribute('aria-expanded') === 'true' ? 'false' : 'true')
+    })
+  }
 }
+
+onTranslationReady(initializeSidebarCollapse)

--- a/resource/js/mobile.js
+++ b/resource/js/mobile.js
@@ -2,7 +2,7 @@
 
 // Register event listener for clicking on sidebar collapse button that toggles visibility of sidebar
 
-function initializeSidebarCollapse() {
+function initializeSidebarCollapse () {
   const sidebarCollapseBtn = document.getElementById('sidebar-collapse-btn')
 
   if (sidebarCollapseBtn) {

--- a/resource/translations/messages.en.json
+++ b/resource/translations/messages.en.json
@@ -179,5 +179,7 @@
     "Message": "Message",
     "Value is required and can not be empty": "Value is required and can not be empty",
     "Send feedback": "Send feedback",
-    "Warning!": "Warning!"
+    "Warning!": "Warning!",
+    "Browse concepts": "Browse concepts",
+    "Hide concepts": "Hide concepts"
 }

--- a/resource/translations/messages.fi.json
+++ b/resource/translations/messages.fi.json
@@ -1,4 +1,6 @@
 {
+    "Browse concepts": "Selaa k\u00e4sitteit\u00e4",
+    "Hide concepts": "Piilota k\u00e4sitteet",
     "Warning!": "Varoitus!",
     "See": "Katso",
     "%search_count% results for '%term%'": "%search_count% tulosta haulle '%term%'",

--- a/resource/translations/messages.sv.json
+++ b/resource/translations/messages.sv.json
@@ -1,4 +1,6 @@
 {
+    "Browse concepts": "Bl\u00e4ddra i begrepp",
+    "Hide concepts": "G\u00f6m begrepp",
     "Warning!": "Varning!",
     "See": "Se",
     "%search_count% results for '%term%'": "%search_count% s\u00f6kresultat f\u00f6r '%term%'",

--- a/src/view/sidebar.inc.twig
+++ b/src/view/sidebar.inc.twig
@@ -1,6 +1,6 @@
 <div class="d-md-none">
   <button id="sidebar-collapse-btn" class="btn btn-primary" type="button" aria-expanded="false" aria-controls="sidebar-col">
-    <i class="fa-solid fa-chevron-right"></i><span>Browse concepts</span>
+    <i class="fa-solid fa-chevron-right"></i><span>{{ "Browse concepts" | trans }}</span>
   </button>
 </div>
 

--- a/tests/cypress/template/sidebar.cy.js
+++ b/tests/cypress/template/sidebar.cy.js
@@ -23,19 +23,17 @@ describe('Sidebar', () => {
     cy.viewport(402, 874)
     // Check that button is visible and contains correct text
     cy.get('#sidebar-collapse-btn').should('be.visible')
-    cy.get('#sidebar-collapse-btn').invoke('text').should('contain', 'Browse concepts')
+    cy.get('#sidebar-collapse-btn').invoke('text').should('contain', 'Selaa käsitteitä')
     // Check that sidebar is not visible
     cy.get('#sidebar-col').should('not.be.visible')
     // Click button and check that it has correct text
     cy.get('#sidebar-collapse-btn').click()
-    cy.get('#sidebar-collapse-btn').invoke('text').should('contain', 'Hide concepts')
+    cy.get('#sidebar-collapse-btn').invoke('text').should('contain', 'Piilota käsitteet')
     // Check that sidebar is visible
     cy.get('#sidebar-col').should('be.visible')
     // Click button again and check that everything is toggled correctly
     cy.get('#sidebar-collapse-btn').click()
-    cy.get('#sidebar-collapse-btn').invoke('text').should('contain', 'Browse concepts')
+    cy.get('#sidebar-collapse-btn').invoke('text').should('contain', 'Selaa käsitteitä')
     cy.get('#sidebar-col').should('not.be.visible')
-
-
   })
 })


### PR DESCRIPTION
## Reasons for creating this PR

Sidebar show/hide buttons for mobile devices / narrow screens were implemented in #1956, but the PR did not include UI translation support for the Browse concepts / Hide concepts button. This PR fixes that, making the button text translatable and adding translations in Finnish, Swedish and English.

While doing this, I noticed that the Translation wiki page was outdated so I updated the [instructions for adding translation support in Vue and plain JS code](https://github.com/NatLibFi/Skosmos/wiki/Translation#how-to-mark-messages-to-be-translated-in-the-skosmos-codebase).

## Link to relevant issue(s), if any

- Closes #1901
- follow-up fix to #1956

## Description of the changes in this PR

- make sure to translate the UI button text in mobile.js and sidebar.inc.twig
- add translations for fi, sv, en (already synced against Lokalise)

## Known problems or uncertainties in this PR

## Checklist

- [ ] phpUnit tests pass locally with my changes
- [ ] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [ ] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [ ] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
