### PR TITLE
feat: add custom label overrides and tooltips for vocabulary properties

### DIFF
--- a/src/controller/WebController.php
+++ b/src/controller/WebController.php
@@ -552,6 +552,8 @@ class WebController extends Controller
 
         $vocabTypes = $this->model->getTypes($request->getVocabid(), $request->getLang());
 
+        $customLabels = $vocab->getConfig()->getPropertyLabelOverrides();
+
         echo $template->render(
             array(
                 'languages' => $this->languages,
@@ -561,7 +563,8 @@ class WebController extends Controller
                 'active_tab' => $defaultView,
                 'request' => $request,
                 'types' => $vocabTypes,
-                'plugin_params' => $pluginParameters
+                'plugin_params' => $pluginParameters,
+                'custom_labels' => $customLabels
             )
         );
     }

--- a/src/view/vocab-info.inc.twig
+++ b/src/view/vocab-info.inc.twig
@@ -14,7 +14,13 @@
 
       {% for key, values in vocabInfo %}
       <div class="row property">
-        <div class="col-lg-4 ps-0 property-label"><h2>{{ key | trans }}</h2></div>
+        {%- set label = custom_labels[key]['label'][request.lang] | default(key | trans) -%}
+        {%- set tooltip = custom_labels[key]['description'][request.lang] | default('') -%}
+        <div class="col-lg-4 ps-0 property-label"><h2{% if tooltip is not empty %} class="tooltip-inline t-top" data-title="{{ tooltip }}"{% endif %}>{{ label }}</h2>
+          {%- if tooltip is not empty %}
+          <span class="visually-hidden">{{ tooltip }}</span>
+          {%- endif %}
+        </div>
         <div class="col-lg-8 gx-0 gx-lg-4 align-self-center property-value">
           <ul class="align-bottom">
             {% for val in values %}

--- a/src/view/vocab-info.inc.twig
+++ b/src/view/vocab-info.inc.twig
@@ -16,9 +16,10 @@
       <div class="row property">
         {%- set label = custom_labels[key]['label'][request.lang] | default(key | trans) -%}
         {%- set tooltip = custom_labels[key]['description'][request.lang] | default('') -%}
-        <div class="col-lg-4 ps-0 property-label"><h2{% if tooltip is not empty %} class="tooltip-inline t-top" data-title="{{ tooltip }}"{% endif %}>{{ label }}</h2>
+        {%- set desc_id = 'vocab-prop-desc-' ~ loop.index -%}
+        <div class="col-lg-4 ps-0 property-label"><h2{% if tooltip is not empty %} class="tooltip-inline t-top" data-title="{{ tooltip }}" aria-describedby="{{ desc_id }}"{% endif %}>{{ label }}</h2>
           {%- if tooltip is not empty %}
-          <span class="visually-hidden">{{ tooltip }}</span>
+          <span id="{{ desc_id }}" class="visually-hidden">{{ tooltip }}</span>
           {%- endif %}
         </div>
         <div class="col-lg-8 gx-0 gx-lg-4 align-self-center property-value">

--- a/tests/VocabularyConfigTest.php
+++ b/tests/VocabularyConfigTest.php
@@ -752,6 +752,8 @@ class VocabularyConfigTest extends PHPUnit\Framework\TestCase
                                     'description' => array( 'en' => 'Class Number') ),
           'skos:exactMatch' => array( 'label' => array( 'fi' => 'vastaava luokka', 'sv' => 'motsvarande klasser', 'en' => 'exactly matching classes' ),
                                       'description' => array( 'en' => 'exactly matching classes in another vocabulary.' ) ),
+          'unknown:vocabularyProperty' => array( 'label' => array( 'en' => 'Vocabulary Property' ),
+                                                 'description' => array( 'en' => 'Vocabulary Property description' ) )
         );
         $this->assertEquals($expected, $overrides);
     }

--- a/tests/cypress/template/concept.cy.js
+++ b/tests/cypress/template/concept.cy.js
@@ -158,10 +158,15 @@ describe('Concept page', () => {
   it('overrides vocabulary property labels', () => {
     // Go to "Carp" concept page in vocab with property label overrides
     cy.visit('/conceptPropertyLabels/en/')
-    // Check that there is a .row .property-label with the overridden property label
-    cy.get('.row .property-label').eq(0).invoke('text').should('include', 'Vocabulary Property')
-    // Check that there is a .row .property-label with the overridden property label description as title
-    cy.get('.row .property-label').eq(0).should('have.attr', 'title').and('contain', 'Vocabulary Property description')
+    // Loop through all .row.property and if the element has a .property-value ul li with text "Overridden property value", check the label and title of the .property-label for this row
+    cy.get('.row.property').each($row => {
+      cy.wrap($row).find('.property-value ul li').each($li => {
+        if ($li.text().includes('Overridden property value')) {
+          cy.wrap($row).find('.property-label h2').eq(0).invoke('text').should('include', 'Vocabulary Property')
+          cy.wrap($row).find('.property-label h2').eq(0).should('have.attr', 'data-title').and('contain', 'Vocabulary Property description')
+        }
+      })
+    })
   })
   it('contains SKOS XL information for concept prefLabel', () => {
     cy.visit('/yso/en/page/p4625?clang=se') // go to "bronsaáigi" concept page ('Bronze Age' in Northern Sami)

--- a/tests/cypress/template/concept.cy.js
+++ b/tests/cypress/template/concept.cy.js
@@ -142,7 +142,7 @@ describe('Concept page', () => {
     // Check that "my property" property label is capitalized correctly
     cy.get('.prop-my_property .property-label h2').invoke('text').should('include', 'My property')
   })
-  it('overrides property labels', () => {
+  it('overrides concept property labels', () => {
     // Go to "Carp" concept page in vocab with property label overrides
     cy.visit('/conceptPropertyLabels/en/page/ta112')
     // Check that prefLabel property label is overridden correctly
@@ -154,6 +154,14 @@ describe('Concept page', () => {
     cy.get('.prop-mapping h2', {'timeout': 20000}).eq(0).invoke('text').should('contain', 'Exactly matching classes')
     // Check that mapping property title is overridden correctly
     cy.get('.prop-mapping .property-label').eq(0).should('have.attr', 'title').and('contain', 'Exactly matching classes in another vocabulary.')
+  })
+  it('overrides vocabulary property labels', () => {
+    // Go to "Carp" concept page in vocab with property label overrides
+    cy.visit('/conceptPropertyLabels/en/')
+    // Check that there is a .row .property-label with the overridden property label
+    cy.get('.row .property-label').eq(0).invoke('text').should('include', 'Vocabulary Property')
+    // Check that there is a .row .property-label with the overridden property label description as title
+    cy.get('.row .property-label').eq(0).should('have.attr', 'title').and('contain', 'Vocabulary Property description')
   })
   it('contains SKOS XL information for concept prefLabel', () => {
     cy.visit('/yso/en/page/p4625?clang=se') // go to "bronsaáigi" concept page ('Bronze Age' in Northern Sami)

--- a/tests/cypress/template/concept.cy.js
+++ b/tests/cypress/template/concept.cy.js
@@ -155,19 +155,6 @@ describe('Concept page', () => {
     // Check that mapping property title is overridden correctly
     cy.get('.prop-mapping .property-label').eq(0).should('have.attr', 'title').and('contain', 'Exactly matching classes in another vocabulary.')
   })
-  it('overrides vocabulary property labels', () => {
-    // Go to "Carp" concept page in vocab with property label overrides
-    cy.visit('/conceptPropertyLabels/en/')
-    // Loop through all .row.property and if the element has a .property-value ul li with text "Overridden property value", check the label and title of the .property-label for this row
-    cy.get('.row.property').each($row => {
-      cy.wrap($row).find('.property-value ul li').each($li => {
-        if ($li.text().includes('Overridden property value')) {
-          cy.wrap($row).find('.property-label h2').eq(0).invoke('text').should('include', 'Vocabulary Property')
-          cy.wrap($row).find('.property-label h2').eq(0).should('have.attr', 'data-title').and('contain', 'Vocabulary Property description')
-        }
-      })
-    })
-  })
   it('contains SKOS XL information for concept prefLabel', () => {
     cy.visit('/yso/en/page/p4625?clang=se') // go to "bronsaáigi" concept page ('Bronze Age' in Northern Sami)
 

--- a/tests/cypress/template/vocab-home.cy.js
+++ b/tests/cypress/template/vocab-home.cy.js
@@ -39,6 +39,18 @@ describe('Vocabulary home page', () => {
     // check that the vocabulary title is correct
     cy.get('#vocab-title > a').invoke('text').should('contain', 'Test ontology')
   })
+  it('Vocabulary property label is overridden', () => {
+    cy.visit('/conceptPropertyLabels/en/')
+    // Loop through all .row.property and if the element has a .property-value ul li with text "Overridden property value", check the label and title of the .property-label for this row
+    cy.get('.row.property').each($row => {
+      cy.wrap($row).find('.property-value ul li').each($li => {
+        if ($li.text().includes('Overridden property value')) {
+          cy.wrap($row).find('.property-label h2').eq(0).invoke('text').should('include', 'Vocabulary Property')
+          cy.wrap($row).find('.property-label h2').eq(0).should('have.attr', 'data-title').and('contain', 'Vocabulary Property description')
+        }
+      })
+    })
+  })
   it('Clicking on hierarchy entries performs partial page load', () => {
     cy.visit('/test/en') // go to the "Test ontology" home page
 

--- a/tests/test-vocab-data/conceptPropertyLabels.ttl
+++ b/tests/test-vocab-data/conceptPropertyLabels.ttl
@@ -10,6 +10,7 @@
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix mads: <http://www.loc.gov/mads/rdf/v1#> .
+@prefix unknown: <http://www.skosmos.skos/unknown/> .
 
 test:ta112 a skos:Concept ;
     skos:notation "665" ;
@@ -44,4 +45,5 @@ test:conceptscheme a skos:ConceptScheme ;
     rdfs:label "Test conceptscheme"@en ;
     dct:modified "2014-10-01T16:29:03+00:00"^^xsd:dateTime ;
     owl:versionInfo "The latest and greatest version"^^xsd:string ;
+    unknown:vocabularyProperty "Overridden property value"^^xsd:string ;
     skos:hasTopConcept test:ta1 .

--- a/tests/testconfig.ttl
+++ b/tests/testconfig.ttl
@@ -16,6 +16,7 @@
 @prefix my: <http://example.com/myns#> .
 @prefix mdrtype: <http://publications.europa.eu/resource/authority/dataset-type/> .
 @prefix test: <http://www.skosmos.skos/test/> .
+@prefix unknown: <http://www.skosmos.skos/unknown/> .
 @prefix : <http://base/#> .
 
 # Skosmos main configuration
@@ -415,7 +416,10 @@
           rdfs:comment "Class Number"@en ],
         [ skosmos:property skos:exactMatch ;
           rdfs:label "vastaava luokka"@fi, "motsvarande klasser"@sv, "exactly matching classes"@en ;
-          rdfs:comment "exactly matching classes in another vocabulary."@en ] ;
+          rdfs:comment "exactly matching classes in another vocabulary."@en ],
+				[ skosmos:property unknown:vocabularyProperty ;
+					rdfs:label "Vocabulary Property"@en ;
+					rdfs:comment "Vocabulary Property description"@en ] ;
         skosmos:sparqlGraph <http://www.skosmos.skos/conceptPropertyLabels/> .
 
 :cbd a skosmos:Vocabulary, void:Dataset ;

--- a/tests/testconfig.ttl
+++ b/tests/testconfig.ttl
@@ -417,9 +417,9 @@
         [ skosmos:property skos:exactMatch ;
           rdfs:label "vastaava luokka"@fi, "motsvarande klasser"@sv, "exactly matching classes"@en ;
           rdfs:comment "exactly matching classes in another vocabulary."@en ],
-				[ skosmos:property unknown:vocabularyProperty ;
-					rdfs:label "Vocabulary Property"@en ;
-					rdfs:comment "Vocabulary Property description"@en ] ;
+        [ skosmos:property unknown:vocabularyProperty ;
+          rdfs:label "Vocabulary Property"@en ;
+          rdfs:comment "Vocabulary Property description"@en ] ;
         skosmos:sparqlGraph <http://www.skosmos.skos/conceptPropertyLabels/> .
 
 :cbd a skosmos:Vocabulary, void:Dataset ;


### PR DESCRIPTION
## Reasons for creating this PR

Adding properties to a vocabulary other than those translated in the source code results in a raw property key in the vocabulary page. If I need idot:prefix term in my vocabulary it is not translated.

## Link to relevant issue(s), if any

*None*

## Description of the changes in this PR

I changed the vocabulary template so property label overrides defined in the skosmos.ttl vocabulary definition is applied to its properties.

## Known problems or uncertainties in this PR

*None*

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
