### PR TITLE
Replaced h1 element with service name

### DIFF
--- a/src/view/base-template.twig
+++ b/src/view/base-template.twig
@@ -98,7 +98,7 @@
         <div class="d-flex flex-column flex-xl-row align-items-start align-items-xl-center my-auto{% if pageType == 'landing' %} p-0{% endif %}">
           {% if pageType == 'landing' %}
           <div id="skosmos-logo">
-            <h1 class="visually-hidden">{{ GlobalConfig.serviceNameLong(request.lang) }}</h1
+            <h1 class="visually-hidden">{{ GlobalConfig.serviceNameLong(request.lang) }}</h1>
           </div>
           {% else %}
           <h2 class="fw-bold" id="vocab-title">

--- a/src/view/base-template.twig
+++ b/src/view/base-template.twig
@@ -98,7 +98,7 @@
         <div class="d-flex flex-column flex-xl-row align-items-start align-items-xl-center my-auto{% if pageType == 'landing' %} p-0{% endif %}">
           {% if pageType == 'landing' %}
           <div id="skosmos-logo">
-            <h1 class="visually-hidden">Skosmos</h1>
+            <h1 class="visually-hidden">{{ GlobalConfig.serviceNameLong(request.lang) }}</h1
           </div>
           {% else %}
           <h2 class="fw-bold" id="vocab-title">


### PR DESCRIPTION
## Reasons for creating this PR
Screen reader reads hidden h1 element which has "Skosmos" in it. Also welcome text should not be visible with mobile view.

## Link to relevant issue(s), if any

- Partially addresses #1976

## Description of the changes in this PR
h1 element has now long service name defined in config file. If the language version of name is missing it falls back to shorter name in config file, which does not have language version. If shorter name is missing, it falls back to "Skosmos".

[Custom template](https://github.com/NatLibFi/Finto-data/blob/master/conf/test.dev.finto.fi/custom-templates/landing-end/0-welcome.twig) for landing-end has been modified with Bootstrap calls to hide the welcome text from mobile view.

## Known problems or uncertainties in this PR
According to Hahmo layout, Finto front page should have mobile navigation bar which opens a page with welcome text in it. This navigation bar is not implement yet.

## Checklist

- [x] phpUnit tests pass locally with my changes
- [ ] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
