### PR TITLE
Changed to asynchronous test case for loading more results

### DIFF
--- a/tests/cypress/template/vocab-search-page.cy.js
+++ b/tests/cypress/template/vocab-search-page.cy.js
@@ -70,19 +70,19 @@ describe('Vocabulary search page', () => {
     cy.visit(`/yso/en/search?clang=en&q=an`)
     // Check that there are 5 search results
     cy.get('#search-results').find('.search-result').should('have.length', 5)
-    // Scroll to bottom of page
+
+    // Listen to the API call
+    cy.intercept('GET', '/yso/en/search?clang=en&q=an*').as('search')
+
     cy.scrollTo('bottom')
 
-    cy.get('#search-results').then(($results) => {
-      const spinner = $results.find('#search-results #search-loading-spinner')
-      if (spinner.length > 0) {
-        // If there's a spinner, wait for it to disappear
-        cy.get('#search-results #search-loading-spinner', { timeout: 20000 }).should('not.exist')
-      }
-    })
+    // Wait for the API call to finish
+    cy.wait('@search', { timeout: 20000 })
+
     // Check that there are 6 search results
     cy.get('#search-results').find('.search-result').should('have.length', 6)
     // Check that all results message is displayed
     cy.get('#search-count').invoke('text').should('contain', 'All 6 results displayed')
+
   })
 })

--- a/tests/cypress/template/vocab-search-page.cy.js
+++ b/tests/cypress/template/vocab-search-page.cy.js
@@ -72,8 +72,11 @@ describe('Vocabulary search page', () => {
     cy.get('#search-results').find('.search-result').should('have.length', 5)
     // Scroll to bottom of page
     cy.scrollTo('bottom')
+
+    cy.get('#search-results #search-loading-spinner', { timeout: 10000 }).should('be.visible')
+    cy.get('#search-results #search-loading-spinner', { timeout: 10000 }).should('not.exist')
     // Check that there are 6 search results
-    cy.get('#search-results').find('.search-result').should('have.length', 6, {'timeout': 20000})
+    cy.get('#search-results').find('.search-result').should('have.length', 6)
     // Check that all results message is displayed
     cy.get('#search-count').invoke('text').should('contain', 'All 6 results displayed')
   })

--- a/tests/cypress/template/vocab-search-page.cy.js
+++ b/tests/cypress/template/vocab-search-page.cy.js
@@ -73,8 +73,13 @@ describe('Vocabulary search page', () => {
     // Scroll to bottom of page
     cy.scrollTo('bottom')
 
-    cy.get('#search-results #search-loading-spinner', { timeout: 10000 }).should('be.visible')
-    cy.get('#search-results #search-loading-spinner', { timeout: 10000 }).should('not.exist')
+    cy.get('#search-results').then(($results) => {
+      const spinner = $results.find('#search-results #search-loading-spinner')
+      if (spinner.length > 0) {
+        // If there's a spinner, wait for it to disappear
+        cy.get('#search-results #search-loading-spinner', { timeout: 20000 }).should('not.exist')
+      }
+    })
     // Check that there are 6 search results
     cy.get('#search-results').find('.search-result').should('have.length', 6)
     // Check that all results message is displayed

--- a/tests/cypress/template/vocab-search-page.cy.js
+++ b/tests/cypress/template/vocab-search-page.cy.js
@@ -67,14 +67,14 @@ describe('Vocabulary search page', () => {
       more.should('not.exist')
   })
   it('More results are loaded on scroll', () => {
-    cy.visit(`/yso/en/search?clang=en&q=g`)
+    cy.visit(`/yso/en/search?clang=en&q=an`)
     // Check that there are 5 search results
     cy.get('#search-results').find('.search-result').should('have.length', 5)
     // Scroll to bottom of page
     cy.scrollTo('bottom')
-    // Check that there are 9 search results
-    cy.get('#search-results').find('.search-result').should('have.length', 9, {'timeout': 20000})
+    // Check that there are 6 search results
+    cy.get('#search-results').find('.search-result').should('have.length', 6, {'timeout': 20000})
     // Check that all results message is displayed
-    cy.get('#search-count').invoke('text').should('contain', 'All 9 results displayed')
+    cy.get('#search-count').invoke('text').should('contain', 'All 6 results displayed')
   })
 })


### PR DESCRIPTION
## Reasons for creating this PR

The cypress tests are failing for a unit test reoading more search results. This fixes it by changing to a more robust test case for testing the functionality of the same thing.

## Link to relevant issue(s), if any

- Closes #2019

## Description of the changes in this PR

Changed to a test case that returns only slightly more than 5 results

## Known problems or uncertainties in this PR

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
