### PR TITLE
upgrade Twig to 3.26 (or above) to fix security issues

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "version": "3.3-dev",
   "require": {
     "sweetrdf/easyrdf": "~1.18.2",
-    "twig/twig": "3.22.*",
+    "twig/twig": "^3.26.0",
     "willdurand/negotiation": "3.1.*",
     "punic/punic": "3.8.*",
     "ml/json-ld": "1.*",


### PR DESCRIPTION
## Reasons for creating this PR

It was not possible to install Composer dependencies (or build Docker images) because of recent security issues in Twig. This PR upgrades Twig to 3.26 (or above, but not 4.x) which fixes the problem.

Here is output from a CI run trying to build the docker image:

```
target skosmos: failed to solve: process "/bin/sh -c composer install       --ignore-platform-req=ext-intl       --ignore-platform-req=ext-xsl       --ignore-platform-req=php       $( [ \"$BUILD_ENV\" = \"production\" ] && echo \"--no-dev\" )" did not complete successfully: exit code: 2
1.750 Your requirements could not be resolved to an installable set of packages.
1.750 
1.750   Problem 1
1.750     - Root composer.json requires twig/twig 3.22.*, found twig/twig[v3.22.0, v3.22.1, v3.22.2] but these were not loaded, because they are affected by security advisories ("PKSA-5k7f-wvjj-jrgw", "PKSA-sjvz-tbbr-vwth", "PKSA-h8hf-ytnd-5t9q", "PKSA-wwb1-81rc-pd65", "PKSA-kvv6-36cr-fkzb", "PKSA-n14z-jjjg-g8vd", "PKSA-3mcc-k66d-pydb", "PKSA-gw7n-z4yx-7xjt", "PKSA-dpx1-78wg-1kqs", "PKSA-21g2-dzjv-sky5"). Go to https://packagist.org/security-advisories/ to find advisory details. To ignore the advisories, add them to the audit "ignore" config. To turn the feature off entirely, you can set "block-insecure" to false in your "audit" config.
1.750   Problem 2
1.750     - Root composer.json requires symfony/twig-bundle 6.4.* -> satisfiable by symfony/twig-bundle[v6.4.0, ..., v6.4.32].
1.750     - symfony/twig-bundle[v6.4.0, ..., v6.4.32] require twig/twig ^2.13|^3.0.4 -> found twig/twig[v2.13.0, ..., v2.16.1, v3.0.4, ..., v3.26.0] but these were not loaded, because they are affected by security advisories ("PKSA-5k7f-wvjj-jrgw", "PKSA-sjvz-tbbr-vwth", "PKSA-h8hf-ytnd-5t9q", "PKSA-wwb1-81rc-pd65", "PKSA-hgmw-wn4d-hpcy", "PKSA-kvv6-36cr-fkzb", "PKSA-n14z-jjjg-g8vd", "PKSA-3mcc-k66d-pydb", "PKSA-gw7n-z4yx-7xjt", "PKSA-dpx1-78wg-1kqs", "PKSA-21g2-dzjv-sky5", "PKSA-v3kg-5xkr-pykw", "PKSA-yhcn-xrg3-68b1", "PKSA-2wrf-1xmk-1pky", "PKSA-6319-ffpf-gx66", "PKSA-n7sg-8f52-pqtf", "PKSA-8kk8-h2xr-h5nx"). Go to https://packagist.org/security-advisories/ to find advisory details. To ignore the advisories, add them to the audit "ignore" config. To turn the feature off entirely, you can set "block-insecure" to false in your "audit" config.
```

## Link to relevant issue(s), if any

n/a

## Description of the changes in this PR

Upgrade Twig to `^3.26.0`

## Known problems or uncertainties in this PR

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
