### PR TITLE
Add keyboard navigation to alphabetical and changes lists

### DIFF
--- a/resource/js/tab-alpha.js
+++ b/resource/js/tab-alpha.js
@@ -230,16 +230,44 @@ function startAlphaApp () {
       'chooseLetterMessage',
       'ariaLiveMessage'
     ],
+    data () {
+      return {
+        conceptInFocus: 0
+      }
+    },
     emits: ['loadConcepts', 'selectConcept'],
     inject: ['partialPageLoad', 'getConceptURL', 'showNotation'],
     methods: {
       loadConcepts (event, letter) {
         event.preventDefault()
+        this.conceptInFocus = 0
         this.$emit('loadConcepts', letter)
       },
-      loadConcept (event, uri) {
+      loadConcept (event, uri, i) {
+        this.conceptInFocus = i
         partialPageLoad(event, getConceptURL(uri))
         this.$emit('selectConcept', uri)
+      },
+      handleKeydownEvent(e) {
+        if (e.key === ' ') {
+          // Click on link currently in focus
+          e.preventDefault()
+          this.$refs['concept' + this.conceptInFocus][0].click()
+        } else if (e.key === 'ArrowDown') {
+          // On last element move focus to first list item, otherwise next list item
+          e.preventDefault()
+          this.conceptInFocus = (this.conceptInFocus + 1) % this.indexConcepts.length
+          this.$refs['concept' + this.conceptInFocus][0].focus()
+        } else if (e.key === 'ArrowUp') {
+          // On first element move focus to last list item, otherwise to previous list item
+          e.preventDefault()
+          if (this.conceptInFocus === 0) {
+            this.conceptInFocus = this.indexConcepts.length - 1
+          } else {
+            this.conceptInFocus -= 1
+          }
+          this.$refs['concept' + this.conceptInFocus][0].focus()
+        }
       }
     },
     template: `
@@ -269,7 +297,7 @@ function startAlphaApp () {
         </fieldset>
       </template>
       
-      <div class="sidebar-list" :style="listStyle" ref="list">
+      <div class="sidebar-list" tabindex="-1" :style="listStyle" ref="list">
         <template v-if="loadingConcepts || loadingLetters">
           <div>
             {{ this.loadingMessage }} <i class="fa-solid fa-spinner fa-spin-pulse"></i>
@@ -277,13 +305,17 @@ function startAlphaApp () {
         </template>
         <template v-else>
           <ul class="list-group" v-if="indexConcepts.length !== 0">
-            <li v-for="concept in indexConcepts" class="list-group-item py-1 px-2">
+            <li v-for="(concept, i) in indexConcepts" class="list-group-item py-1 px-2">
               <template v-if="concept.altLabel">
                 <span class="fst-italic">{{ concept.altLabel }}</span>
                 <i class="fa-solid fa-arrow-right"></i>
               </template>
               <a :class="{ 'selected': selectedConcept === concept.uri }"
-                :href="getConceptURL(concept.uri)" @click="loadConcept($event, concept.uri)"
+                :href="getConceptURL(concept.uri)"
+                :tabindex="i === conceptInFocus ? 0 : -1"
+                :ref="'concept' + i"
+                @click="loadConcept($event, concept.uri, i)"
+                @keydown="handleKeydownEvent($event)"
               >
                 {{ concept.prefLabel }}{{ showNotation && concept.qualifier ? ' (' + concept.qualifier + ')' : '' }}
                 <span class="visually-hidden">{{ toConceptPageAriaMessage }}</span>

--- a/resource/js/tab-alpha.js
+++ b/resource/js/tab-alpha.js
@@ -248,7 +248,7 @@ function startAlphaApp () {
         partialPageLoad(event, getConceptURL(uri))
         this.$emit('selectConcept', uri)
       },
-      handleKeydownEvent(e) {
+      handleKeydownEvent (e) {
         if (e.key === ' ') {
           // Click on link currently in focus
           e.preventDefault()

--- a/resource/js/tab-alpha.js
+++ b/resource/js/tab-alpha.js
@@ -267,6 +267,16 @@ function startAlphaApp () {
             this.conceptInFocus -= 1
           }
           this.$refs['concept' + this.conceptInFocus][0].focus()
+        } else if (e.key === 'End') {
+          // Move focus to last list item
+          e.preventDefault()
+          this.conceptInFocus = this.indexConcepts.length - 1
+          this.$refs['concept' + this.conceptInFocus][0].focus()
+        } else if (e.key === 'Home') {
+          // Move focus to first list item
+          e.preventDefault()
+          this.conceptInFocus = 0
+          this.$refs['concept' + this.conceptInFocus][0].focus()
         }
       }
     },

--- a/resource/js/tab-changes.js
+++ b/resource/js/tab-changes.js
@@ -246,6 +246,16 @@ function startChangesApp () {
             this.conceptInFocus -= 1
           }
           this.$refs['concept' + this.conceptInFocus][0].focus()
+        } else if (e.key === 'End') {
+          // Move focus to last list item
+          e.preventDefault()
+          this.conceptInFocus = this.changedConceptsLength - 1
+          this.$refs['concept' + this.conceptInFocus][0].focus()
+        } else if (e.key === 'Home') {
+          // Move focus to first list item
+          e.preventDefault()
+          this.conceptInFocus = 0
+          this.$refs['concept' + this.conceptInFocus][0].focus()
         }
       }
     },

--- a/resource/js/tab-changes.js
+++ b/resource/js/tab-changes.js
@@ -227,7 +227,7 @@ function startChangesApp () {
         partialPageLoad(event, getConceptURL(uri))
         this.$emit('selectConcept', uri)
       },
-      handleKeydownEvent(e) {
+      handleKeydownEvent (e) {
         if (e.key === ' ') {
           // Click on link currently in focus
           e.preventDefault()

--- a/resource/js/tab-changes.js
+++ b/resource/js/tab-changes.js
@@ -191,16 +191,66 @@ function startChangesApp () {
 
   tabChangesApp.component('tab-changes', {
     props: ['changedConcepts', 'selectedConcept', 'loadingConcepts', 'loadingMoreConcepts', 'loadingMessage', 'toConceptPageAriaMessage', 'listStyle'],
+    data () {
+      return {
+        conceptInFocus: 0
+      }
+    },
+    computed: {
+      indexedConcepts () {
+        // Give each uri and replacedBy in changedConcepts a unique index for keyboard navigation
+        let counter = 0
+
+        const indexed = new Map(
+          [...this.changedConcepts].map(([month, entries]) => [
+            month,
+            entries.map(entry => {
+              const result = { ...entry, index: counter++ }
+              if (entry.replacedBy) result.replacedByIndex = counter++
+              return result
+            })
+          ])
+        )
+        return indexed
+      },
+      changedConceptsLength () {
+        return [...this.changedConcepts.values()]
+          .flat()
+          .reduce((acc, entry) => acc + 1 + (entry.replacedBy ? 1 : 0), 0)
+      }
+    },
     inject: ['partialPageLoad', 'getConceptURL'],
     emits: ['selectConcept'],
     methods: {
-      loadConcept (event, uri) {
+      loadConcept (event, uri, i) {
+        this.conceptInFocus = i
         partialPageLoad(event, getConceptURL(uri))
         this.$emit('selectConcept', uri)
+      },
+      handleKeydownEvent(e) {
+        if (e.key === ' ') {
+          // Click on link currently in focus
+          e.preventDefault()
+          this.$refs['concept' + this.conceptInFocus][0].click()
+        } else if (e.key === 'ArrowDown') {
+          // On last element move focus to first list item, otherwise next list item
+          e.preventDefault()
+          this.conceptInFocus = (this.conceptInFocus + 1) % this.changedConceptsLength
+          this.$refs['concept' + this.conceptInFocus][0].focus()
+        } else if (e.key === 'ArrowUp') {
+          // On first element move focus to last list item, otherwise to previous list item
+          e.preventDefault()
+          if (this.conceptInFocus === 0) {
+            this.conceptInFocus = this.changedConceptsLength - 1
+          } else {
+            this.conceptInFocus -= 1
+          }
+          this.$refs['concept' + this.conceptInFocus][0].focus()
+        }
       }
     },
     template: `
-      <div class="sidebar-list pt-3" :style="listStyle" ref="list">
+      <div class="sidebar-list pt-3" tabindex="-1" :style="listStyle" ref="list">
         <template v-if="loadingConcepts">
           <div>
             {{ loadingMessage }} <i class="fa-solid fa-spinner fa-spin-pulse"></i>
@@ -208,7 +258,7 @@ function startChangesApp () {
         </template>
         <template v-else>
           <ul class="list-group" v-if="changedConcepts.length !== 0">
-            <template v-for="[month, concepts] in changedConcepts">
+            <template v-for="[month, concepts] in indexedConcepts">
               <li class="list-group-item py-1 px-2">
                 <h2 class="pb-1">{{ month }}</h2>
               </li>
@@ -216,7 +266,10 @@ function startChangesApp () {
                 <template v-if="concept.replacedBy">
                   <a :class="{ 'selected': selectedConcept === concept.uri }"
                     :href="getConceptURL(concept.uri)"
-                    @click="loadConcept($event, concept.uri)"
+                    :tabindex="concept.index === conceptInFocus ? 0 : -1"
+                    :ref="'concept' + concept.index"
+                    @click="loadConcept($event, concept.uri, concept.index)"
+                    @keydown="handleKeydownEvent($event)"
                   >
                     <s>{{ concept.prefLabel }}</s>
                     <span class="visually-hidden">{{ toConceptPageAriaMessage }}</span>
@@ -224,7 +277,10 @@ function startChangesApp () {
                   <i class="fa-solid fa-arrow-right"></i>
                   <a :class="{ 'selected': selectedConcept === concept.replacedBy }"
                     :href="getConceptURL(concept.replacedBy)"
-                    @click="loadConcept($event, concept.replacedBy)"
+                    :tabindex="concept.replacedByIndex === conceptInFocus ? 0 : -1"
+                    :ref="'concept' + concept.replacedByIndex"
+                    @click="loadConcept($event, concept.replacedBy, concept.replacedByIndex)"
+                    @keydown="handleKeydownEvent($event)"
                   >
                     {{ concept.replacingLabel }}
                     <span class="visually-hidden">{{ toConceptPageAriaMessage }}</span>
@@ -233,7 +289,10 @@ function startChangesApp () {
                 <template v-else>
                   <a :class="{ 'selected': selectedConcept === concept.uri }"
                     :href="getConceptURL(concept.uri)"
-                    @click="loadConcept($event, concept.uri)"
+                    :tabindex="concept.index === conceptInFocus ? 0 : -1"
+                    :ref="'concept' + concept.index"
+                    @click="loadConcept($event, concept.uri, concept.index)"
+                    @keydown="handleKeydownEvent($event)"
                   >
                     {{ concept.prefLabel }}
                     <span class="visually-hidden">{{ toConceptPageAriaMessage }}</span>

--- a/resource/js/tab-changes.js
+++ b/resource/js/tab-changes.js
@@ -193,11 +193,19 @@ function startChangesApp () {
     props: ['changedConcepts', 'selectedConcept', 'loadingConcepts', 'loadingMoreConcepts', 'loadingMessage', 'toConceptPageAriaMessage', 'listStyle'],
     data () {
       return {
-        conceptInFocus: 0
+        conceptInFocus: 0,
+        changedConceptsLength: 0
       }
     },
-    computed: {
-      indexedConcepts () {
+    inject: ['partialPageLoad', 'getConceptURL'],
+    emits: ['selectConcept'],
+    methods: {
+      loadConcept (event, uri, i) {
+        this.conceptInFocus = i
+        partialPageLoad(event, getConceptURL(uri))
+        this.$emit('selectConcept', uri)
+      },
+      getIndexedConcepts () {
         // Give each uri and replacedBy in changedConcepts a unique index for keyboard navigation
         let counter = 0
 
@@ -211,21 +219,8 @@ function startChangesApp () {
             })
           ])
         )
+        this.changedConceptsLength = counter
         return indexed
-      },
-      changedConceptsLength () {
-        return [...this.changedConcepts.values()]
-          .flat()
-          .reduce((acc, entry) => acc + 1 + (entry.replacedBy ? 1 : 0), 0)
-      }
-    },
-    inject: ['partialPageLoad', 'getConceptURL'],
-    emits: ['selectConcept'],
-    methods: {
-      loadConcept (event, uri, i) {
-        this.conceptInFocus = i
-        partialPageLoad(event, getConceptURL(uri))
-        this.$emit('selectConcept', uri)
       },
       handleKeydownEvent (e) {
         if (e.key === ' ') {
@@ -268,7 +263,7 @@ function startChangesApp () {
         </template>
         <template v-else>
           <ul class="list-group" v-if="changedConcepts.length !== 0">
-            <template v-for="[month, concepts] in indexedConcepts">
+            <template v-for="[month, concepts] in getIndexedConcepts()">
               <li class="list-group-item py-1 px-2">
                 <h2 class="pb-1">{{ month }}</h2>
               </li>

--- a/tests/cypress/template/sidebar-alpha.cy.js
+++ b/tests/cypress/template/sidebar-alpha.cy.js
@@ -145,18 +145,17 @@ describe('Alphabetical index', () => {
     // Check that new concepts are loaded
     cy.get('#tab-alphabetical').find('.sidebar-list li').first().invoke('text').should('contain', 'birch bark manuscripts')
     
-    // Focus on first index letter and press tab
-    cy.get('.letters input').first().focus()
+    // Press tab
     cy.press(Cypress.Keyboard.Keys.TAB)
     // Check that first list item has focus
-    cy.get('#tab-alphabetical').find('.sidebar-list li').eq(0).should('have.focus')
+    cy.get('#tab-alphabetical').find('.sidebar-list li a').eq(0).should('have.focus')
     // Press down arrow key
     cy.press(Cypress.Keyboard.Keys.DOWN)
     // Check that second list item has focus
-    cy.get('#tab-alphabetical').find('.sidebar-list li').eq(1).should('have.focus')
+    cy.get('#tab-alphabetical').find('.sidebar-list li a').eq(1).should('have.focus')
     // Press up arrow key
     cy.press(Cypress.Keyboard.Keys.UP)
     // Check that first list item has focus again
-    cy.get('#tab-alphabetical').find('.sidebar-list li').eq(0).should('have.focus')
+    cy.get('#tab-alphabetical').find('.sidebar-list li a').eq(0).should('have.focus')
   })
 })

--- a/tests/cypress/template/sidebar-alpha.cy.js
+++ b/tests/cypress/template/sidebar-alpha.cy.js
@@ -144,5 +144,19 @@ describe('Alphabetical index', () => {
     cy.get('.aria-live-message').invoke('text').should('equal', 'Concepts loaded for letter B')
     // Check that new concepts are loaded
     cy.get('#tab-alphabetical').find('.sidebar-list li').first().invoke('text').should('contain', 'birch bark manuscripts')
+    
+    // Focus on first index letter and press tab
+    cy.get('.letters input').first().focus()
+    cy.press(Cypress.Keyboard.Keys.TAB)
+    // Check that first list item has focus
+    cy.get('#tab-alphabetical').find('.sidebar-list li').eq(0).should('have.focus')
+    // Press down arrow key
+    cy.press(Cypress.Keyboard.Keys.DOWN)
+    // Check that second list item has focus
+    cy.get('#tab-alphabetical').find('.sidebar-list li').eq(1).should('have.focus')
+    // Press up arrow key
+    cy.press(Cypress.Keyboard.Keys.UP)
+    // Check that first list item has focus again
+    cy.get('#tab-alphabetical').find('.sidebar-list li').eq(0).should('have.focus')
   })
 })

--- a/tests/cypress/template/sidebar-alpha.cy.js
+++ b/tests/cypress/template/sidebar-alpha.cy.js
@@ -157,5 +157,8 @@ describe('Alphabetical index', () => {
     cy.press(Cypress.Keyboard.Keys.UP)
     // Check that first list item has focus again
     cy.get('#tab-alphabetical').find('.sidebar-list li a').eq(0).should('have.focus')
+    // Check that pressing space opens concept page
+    cy.press(Cypress.Keyboard.Keys.SPACE)
+    cy.get('#concept-heading h1', {'timeout': 15000}).invoke('text').should('equal', 'birch bark manuscripts')
   })
 })

--- a/tests/cypress/template/sidebar-changes.cy.js
+++ b/tests/cypress/template/sidebar-changes.cy.js
@@ -129,4 +129,3 @@ describe('New and removed view', () => {
     cy.get('#tab-changes').find('.sidebar-list a').eq(0).should('have.focus')
   })
 })
-

--- a/tests/cypress/template/sidebar-changes.cy.js
+++ b/tests/cypress/template/sidebar-changes.cy.js
@@ -113,8 +113,9 @@ describe('New and removed view', () => {
   it('Keyboard navigation', () => {
     // go to YSO vocab front page in English
     cy.visit('/yso/en/')
-    // Click on changes tab
+    // Click on changes tab and wait until list has loaded
     cy.get('#changes').click()
+    cy.get('#tab-changes').find('.sidebar-list li a span').eq(0)
     // Press tab key
     cy.press(Cypress.Keyboard.Keys.TAB)
     // Check that first list item has focus
@@ -127,5 +128,8 @@ describe('New and removed view', () => {
     cy.press(Cypress.Keyboard.Keys.UP)
     // Check that first list item has focus again
     cy.get('#tab-changes').find('.sidebar-list a').eq(0).should('have.focus')
+    // Check that pressing space opens concept page
+    cy.press(Cypress.Keyboard.Keys.SPACE)
+    cy.get('#concept-heading h1', {'timeout': 15000}).invoke('text').should('equal', 'Bell beaker culture')
   })
 })

--- a/tests/cypress/template/sidebar-changes.cy.js
+++ b/tests/cypress/template/sidebar-changes.cy.js
@@ -109,5 +109,24 @@ describe('New and removed view', () => {
     // Check that concepts have correct Aria labels
     cy.get('#tab-changes').find('.sidebar-list li a span').eq(0).invoke('text').should('contain', 'Gå till begreppssidan')
 
-  })  
+  })
+  it('Keyboard navigation', () => {
+    // go to YSO vocab front page in English
+    cy.visit('/yso/en/')
+    // Click on changes tab
+    cy.get('#changes').click()
+    // Press tab key
+    cy.press(Cypress.Keyboard.Keys.TAB)
+    // Check that first list item has focus
+    cy.get('#tab-changes').find('.sidebar-list a').eq(0).should('have.focus')
+    // Press down arrow key
+    cy.press(Cypress.Keyboard.Keys.DOWN)
+    // Check that second list item has focus
+    cy.get('#tab-changes').find('.sidebar-list a').eq(1).should('have.focus')
+    // Press up arrow key
+    cy.press(Cypress.Keyboard.Keys.UP)
+    // Check that first list item has focus again
+    cy.get('#tab-changes').find('.sidebar-list a').eq(0).should('have.focus')
+  })
 })
+


### PR DESCRIPTION
## Reasons for creating this PR

Concept lists in sidebar are not currently navigable using the keyboard. This PR adds keyboard navigation to alphabetical and changes tabs.

## Link to relevant issue(s), if any

- Part of #1982

## Description of the changes in this PR

- Add keyboard navigation to alphabetical concept list
  - Enter into/out of list using tab
  - Move up/down concept list using arrow keys
  - Move focus to last item with end key and to first with home
  - Open link using space key
- Add keyboard navigation to changes concept list
  - Enter into/out of list using tab
  - Move up/down concept list using arrow keys
  - Move focus to last item with end key and to first with home
  - Open link using space key
- Cypress tests for both

## Known problems or uncertainties in this PR

## Checklist

- [ ] phpUnit tests pass locally with my changes
- [ ] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [ ] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [ ] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
