### PR TITLE
Sidebar hierarchy and groups tab keyboard navigation

### DIFF
--- a/resource/js/tab-groups.js
+++ b/resource/js/tab-groups.js
@@ -194,8 +194,8 @@ function startGroupsApp () {
           for (const node of nodes) {
             // Assign index only if parent is open
             if (parentIsOpen) {
-              counter++
               node.index = counter
+              counter++
             } else {
               delete node.index
             }

--- a/resource/js/tab-groups.js
+++ b/resource/js/tab-groups.js
@@ -9,7 +9,8 @@ function startGroupsApp () {
         selectedGroup: '',
         loadingGroups: true,
         loadingChildren: [],
-        listStyle: {}
+        listStyle: {},
+        visibleConceptCount: 0
       }
     },
     provide () {
@@ -20,9 +21,6 @@ function startGroupsApp () {
       }
     },
     computed: {
-      openAriaMessage () {
-        return $t('Open')
-      },
       toConceptPageAriaMessage () {
         return $t('Go to the concept page')
       }
@@ -110,6 +108,7 @@ function startGroupsApp () {
                     this.setIsOpenAndAddMembers(result, this.selectedGroup, members)
 
                     this.groups = result
+                    this.addIndicesToGroups()
                     this.loadingGroups = false
                   })
               } else {
@@ -117,11 +116,13 @@ function startGroupsApp () {
                 this.setIsOpenAndAddMembers(result, this.selectedGroup, [])
 
                 this.groups = result
+                this.addIndicesToGroups()
                 this.loadingGroups = false
               }
             } else {
               // If we are on vocab home page, simply set groups to result
               this.groups = result
+              this.addIndicesToGroups()
               this.loadingGroups = false
             }
           })
@@ -177,21 +178,44 @@ function startGroupsApp () {
               for (const m of data.members) {
                 group.childGroups.push({ ...m, childGroups: [], isOpen: false, isGroup: false })
               }
+              this.addIndicesToGroups()
               this.loadingChildren = this.loadingChildren.filter(x => x !== group)
             })
+        } else if (group.childGroups.length > 0) {
+          // If the cgroup already has children loaded, update indices in groups
+          this.addIndicesToGroups()
         }
-      }
+      },
+      addIndicesToGroups () {
+        // Adds a unique index to each concept that is visible in DOM after groups is updated
+        let counter = 0
+
+        const traverse = (nodes, parentIsOpen) => {
+          for (const node of nodes) {
+            // Assign index only if parent is open
+            parentIsOpen ? node.index = counter++ : delete node.index
+
+            if (node.childGroups.length > 0) {
+              traverse(node.childGroups, node.isOpen && parentIsOpen)
+            }
+          }
+        }
+
+        traverse(this.groups, true)
+
+        this.visibleConceptCount = counter
+      },
     },
     template: `
       <div v-click-tab-groups="handleClickGroupsEvent" v-click-collapse-btn="setListStyle" v-resize-window="setListStyle">
-        <div id="groups-list" class="sidebar-list p-0" :style="listStyle">
-          <ul v-if="!loadingGroups" class="list-group">
+        <div id="groups-list" class="sidebar-list p-0" tabindex="-1" :style="listStyle">
+          <ul v-if="!loadingGroups" aria-labelledby="groups" role="tree" class="list-group">
             <tab-groups-wrapper
               :groups="groups"
               :selectedGroup="selectedGroup"
               :loadingChildren="loadingChildren"
-              :openAriaMessage="openAriaMessage"
               :toConceptPageAriaMessage="toConceptPageAriaMessage"
+              :visibleConceptCount="visibleConceptCount"
               @load-children="loadChildren($event)"
               @select-group="selectedGroup = $event"
             ></tab-groups-wrapper>
@@ -242,9 +266,12 @@ function startGroupsApp () {
   })
 
   tabGroupsApp.component('tab-groups-wrapper', {
-    props: ['groups', 'selectedGroup', 'loadingChildren', 'openAriaMessage', 'toConceptPageAriaMessage'],
+    props: ['groups', 'selectedGroup', 'loadingChildren', 'toConceptPageAriaMessage', 'visibleConceptCount'],
     emits: ['loadChildren', 'selectGroup'],
-    mounted () {
+    data () {
+      return {
+        conceptInFocus: 0
+      }
     },
     methods: {
       loadChildren (group) {
@@ -252,6 +279,33 @@ function startGroupsApp () {
       },
       selectGroup (group) {
         this.$emit('selectGroup', group)
+      },
+      handleKeydownEvent (e) {
+        if (e.key === ' ') {
+          // Click on link currently in focus
+          e.preventDefault()
+          document.getElementById('groups-concept' + this.conceptInFocus).click()
+        } else if (e.key === 'ArrowDown') {
+          // On last element move focus to first list item, otherwise next list item
+          e.preventDefault()
+          this.moveFocus((this.conceptInFocus + 1) % this.visibleConceptCount)
+        } else if (e.key === 'ArrowUp') {
+          // On first element move focus to last list item, otherwise to previous list item
+          e.preventDefault()
+          this.moveFocus(this.conceptInFocus === 0 ? this.visibleConceptCount - 1 : this.conceptInFocus - 1)
+        } else if (e.key === 'Home') {
+          // Move focus to first list item
+          e.preventDefault()
+          this.moveFocus(0)
+        } else if (e.key === 'End') {
+          // Move focus to last list item
+          e.preventDefault()
+          this.moveFocus(this.visibleConceptCount - 1)
+        }
+      },
+      moveFocus (i) {
+        this.conceptInFocus = i
+        document.getElementById('groups-concept' + this.conceptInFocus).focus()
       }
     },
     template: `
@@ -262,41 +316,78 @@ function startGroupsApp () {
           :isTopGroup="true"
           :isLast="i == groups.length - 1"
           :loadingChildren="loadingChildren"
-          :openAriaMessage="openAriaMessage"
           :toConceptPageAriaMessage="toConceptPageAriaMessage"
+          :conceptInFocus="conceptInFocus"
           @load-children="loadChildren($event)"
           @select-group="selectGroup($event)"
+          @link-keydown="handleKeydownEvent($event)"
+          @move-focus="moveFocus($event)"
         ></tab-groups>
       </template>
     `
   })
 
   tabGroupsApp.component('tab-groups', {
-    props: ['group', 'selectedGroup', 'isTopGroup', 'isLast', 'loadingChildren', 'openAriaMessage', 'toConceptPageAriaMessage'],
-    emits: ['loadChildren', 'selectGroup'],
+    props: ['group', 'selectedGroup', 'isTopGroup', 'isLast', 'loadingChildren', 'toConceptPageAriaMessage', 'conceptInFocus'],
+    emits: ['loadChildren', 'selectGroup', 'linkKeydown', 'closeParent', 'moveFocus'],
     inject: ['partialPageLoad', 'getConceptURL', 'showNotation'],
     methods: {
       handleClickOpenEvent (group) {
         group.isOpen = !group.isOpen
         this.$emit('loadChildren', group)
+        this.$emit('moveFocus', group.index)
       },
       handleClickGroupEvent (event, group) {
         group.isOpen = true
         this.$emit('loadChildren', group)
         this.$emit('selectGroup', group.uri)
+        this.$emit('moveFocus', group.index)
         this.partialPageLoad(event, this.getConceptURL(group.uri))
+      },
+      handleKeydownEvent (e, g) {
+        if (e.key === 'ArrowRight') {
+          if (!g.isOpen && g.hasMembers) {
+            // If right arrow key is pressed on a closed group, open it
+            g.isOpen = true
+            this.$emit('loadChildren', g)
+          } else if (g.childGroups.length > 0) {
+            // If right arrow is pressed on a open group, move focus to first child
+            this.$emit('moveFocus', g.index + 1)
+          }
+        } else if (e.key === 'ArrowLeft' && g.isOpen) {
+          // If left arrow key is pressed on an open group, close it
+          g.isOpen = false
+          this.$emit('loadChildren', g)
+        } else if (e.key === 'ArrowLeft') {
+          // If left arrow key is pressed on a closed group, close its parent
+          this.$emit('closeParent')
+        } else {
+          // Otherwise, deal with other key press types in tab-groups-wrapper
+          this.$emit('linkKeydown', e)
+        }
+      },
+      handleCloseParentEvent () {
+        // Close this group when left arrow key is pressed on a closed child
+        this.group.isOpen = false
+        this.$emit('loadChildren', this.group)
+        this.$emit('moveFocus', this.group.index)
       },
       loadChildrenRecursive (group) {
         this.$emit('loadChildren', group)
       },
       selectGroupRecursive (group) {
         this.$emit('selectGroup', group)
+      },
+      linkKeydownRecursive (event) {
+        this.$emit('linkKeydown', event)
+      },
+      moveFocusRecursive (index) {
+        this.$emit('moveFocus', index)
       }
     },
     template: `
       <li class="list-group-item p-0" :class="{ 'top-concept': isTopGroup }">
-        <button type="button" class="hierarchy-button btn btn-primary"
-          :aria-label="openAriaMessage"
+        <button type="button" class="hierarchy-button btn btn-primary" aria-hidden="true" tabindex="-1"
           :class="{ 'open': group.isOpen }"
           v-if="group.hasMembers"
           @click="handleClickOpenEvent(group)"
@@ -310,16 +401,22 @@ function startGroupsApp () {
           </template>
         </button>
         <span class="concept-label" :class="{ 'last': isLast }">
-          <a :class="{ 'selected': selectedGroup === group.uri, 'group': group.isGroup }"
+          <a role="treeitem"
+            :class="{ 'selected': selectedGroup === group.uri, 'group': group.isGroup }"
             :href="getConceptURL(group.uri)"
+            :tabindex="group.index === conceptInFocus ? 0 : -1"
+            :id="'groups-concept' + group.index"
+            :aria-expanded="group.hasMembers ? group.isOpen : null"
+            :aria-selected="group.uri === selectedGroup"
             @click="handleClickGroupEvent($event, group)"
+            @keydown="handleKeydownEvent($event, group)"
           >
             <span v-if="showNotation && group.notation" class="concept-notation">{{ group.notation }} </span>
             {{ group.prefLabel }}
             <span class="visually-hidden">{{ toConceptPageAriaMessage }}</span>
           </a>
         </span>
-        <ul class="list-group ps-3" v-if="group.childGroups.length !== 0 && group.isOpen">
+        <ul class="list-group ps-3" role="group" v-if="group.childGroups.length !== 0 && group.isOpen">
           <template v-for="(g, i) in group.childGroups">
             <tab-groups
               :group="g"
@@ -327,10 +424,13 @@ function startGroupsApp () {
               :isTopGroup="false"
               :isLast="i == group.childGroups.length - 1"
               :loadingChildren="loadingChildren"
-              :openAriaMessage="openAriaMessage"
               :toConceptPageAriaMessage="toConceptPageAriaMessage"
+              :conceptInFocus="conceptInFocus"
               @load-children="loadChildrenRecursive($event)"
               @select-group="selectGroupRecursive($event)"
+              @link-keydown="linkKeydownRecursive($event)"
+              @close-parent="handleCloseParentEvent()"
+              @move-focus="moveFocusRecursive($event)"
             ></tab-groups>
           </template>
         </ul>

--- a/resource/js/tab-groups.js
+++ b/resource/js/tab-groups.js
@@ -193,7 +193,12 @@ function startGroupsApp () {
         const traverse = (nodes, parentIsOpen) => {
           for (const node of nodes) {
             // Assign index only if parent is open
-            parentIsOpen ? node.index = counter++ : delete node.index
+            if (parentIsOpen) {
+              counter++
+              node.index = counter
+            } else {
+              delete node.index
+            }
 
             if (node.childGroups.length > 0) {
               traverse(node.childGroups, node.isOpen && parentIsOpen)

--- a/resource/js/tab-groups.js
+++ b/resource/js/tab-groups.js
@@ -182,7 +182,7 @@ function startGroupsApp () {
               this.loadingChildren = this.loadingChildren.filter(x => x !== group)
             })
         } else if (group.childGroups.length > 0) {
-          // If the cgroup already has children loaded, update indices in groups
+          // If the group already has children loaded, update indices in groups
           this.addIndicesToGroups()
         }
       },

--- a/resource/js/tab-groups.js
+++ b/resource/js/tab-groups.js
@@ -204,7 +204,7 @@ function startGroupsApp () {
         traverse(this.groups, true)
 
         this.visibleConceptCount = counter
-      },
+      }
     },
     template: `
       <div v-click-tab-groups="handleClickGroupsEvent" v-click-collapse-btn="setListStyle" v-resize-window="setListStyle">

--- a/resource/js/tab-hierarchy.js
+++ b/resource/js/tab-hierarchy.js
@@ -284,8 +284,8 @@ function startHierarchyApp () {
           for (const node of nodes) {
             // Assign index only if parent is open
             if (parentIsOpen) {
-              counter++
               node.index = counter
+              counter++
             } else {
               delete node.index
             }

--- a/resource/js/tab-hierarchy.js
+++ b/resource/js/tab-hierarchy.js
@@ -9,13 +9,11 @@ function startHierarchyApp () {
         loadingHierarchy: true,
         loadingChildren: [],
         selectedConcept: '',
-        listStyle: {}
+        listStyle: {},
+        visibleConceptCount: 0
       }
     },
     computed: {
-      openAriaMessage () {
-        return $t('Open')
-      },
       toConceptPageAriaMessage () {
         return $t('Go to the concept page')
       }
@@ -69,6 +67,7 @@ function startHierarchyApp () {
                 this.hierarchy.push({ uri: c.uri, label: c.title || c.label, hasChildren: true, children: [], isOpen: false, notation: undefined, isScheme: true })
               }
 
+              this.addIndicesToHierarchy()
               this.loadingHierarchy = false
             })
         } else {
@@ -85,6 +84,7 @@ function startHierarchyApp () {
                 this.hierarchy.push(this.createConceptNode(c))
               }
 
+              this.addIndicesToHierarchy()
               this.loadingHierarchy = false
             })
         }
@@ -107,6 +107,7 @@ function startHierarchyApp () {
         }
 
         this.loadingHierarchy = false
+        this.addIndicesToHierarchy()
         this.selectedConcept = window.SKOSMOS.uri
       },
       loadChildren (concept) {
@@ -127,6 +128,7 @@ function startHierarchyApp () {
                 for (const c of data.topconcepts.sort((a, b) => this.compareConcepts(a, b))) {
                   concept.children.push(this.createConceptNode(c))
                 }
+                this.addIndicesToHierarchy()
                 this.loadingChildren = this.loadingChildren.filter(x => x !== concept)
               })
           } else {
@@ -143,9 +145,13 @@ function startHierarchyApp () {
                 for (const c of data.narrower.sort((a, b) => this.compareConcepts(a, b))) {
                   concept.children.push(this.createConceptNode(c))
                 }
+                this.addIndicesToHierarchy()
                 this.loadingChildren = this.loadingChildren.filter(x => x !== concept)
               })
           }
+        } else if (concept.children.length > 0) {
+          // If the concept already has children loaded, update indices in hierarchy
+          this.addIndicesToHierarchy()
         }
       },
       async loadConceptSchemes () {
@@ -270,6 +276,25 @@ function startHierarchyApp () {
           }
         }
       },
+      addIndicesToHierarchy () {
+        // Adds a unique index to each concept that is visible in DOM after hierarchy is updated
+        let counter = 0
+
+        const traverse = (nodes, parentIsOpen) => {
+          for (const node of nodes) {
+            // Assign index only if parent is open
+            parentIsOpen ? node.index = counter++ : delete node.index
+
+            if (node.children.length > 0) {
+              traverse(node.children, node.isOpen && parentIsOpen)
+            }
+          }
+        }
+
+        traverse(this.hierarchy, true)
+
+        this.visibleConceptCount = counter
+      },
       openContainingScheme () {
         const containsConcept = (node) => {
           if (node.uri === window.SKOSMOS.uri) return true
@@ -345,14 +370,14 @@ function startHierarchyApp () {
     },
     template: `
       <div v-click-tab-hierarchy="handleClickHierarchyEvent" v-click-collapse-btn="setListStyle" v-resize-window="setListStyle">
-        <div id="hierarchy-list" class="sidebar-list p-0" :style="listStyle">
-          <ul class="list-group" v-if="!loadingHierarchy">
+        <div id="hierarchy-list" class="sidebar-list p-0" tabindex="-1" :style="listStyle">
+          <ul class="list-group" aria-labelledby="hierarchy" role="tree" v-if="!loadingHierarchy">
             <tab-hier-wrapper
               :hierarchy="hierarchy"
               :selectedConcept="selectedConcept"
               :loadingChildren="loadingChildren"
-              :openAriaMessage="openAriaMessage"
               :toConceptPageAriaMessage="toConceptPageAriaMessage"
+              :visibleConceptCount="visibleConceptCount"
               @load-children="loadChildren($event)"
               @select-concept="selectedConcept = $event"
             ></tab-hier-wrapper>
@@ -405,8 +430,13 @@ function startHierarchyApp () {
   })
 
   tabHierApp.component('tab-hier-wrapper', {
-    props: ['hierarchy', 'selectedConcept', 'loadingChildren', 'openAriaMessage', 'toConceptPageAriaMessage'],
+    props: ['hierarchy', 'selectedConcept', 'loadingChildren', 'toConceptPageAriaMessage', 'visibleConceptCount'],
     emits: ['loadChildren', 'selectConcept'],
+    data () {
+      return {
+        conceptInFocus: 0
+      }
+    },
     mounted () {
       // scroll automatically to selected concept after the whole hierarchy tree has been mounted
       if (this.selectedConcept) {
@@ -434,6 +464,33 @@ function startHierarchyApp () {
       },
       selectConcept (concept) {
         this.$emit('selectConcept', concept)
+      },
+      handleKeydownEvent (e) {
+        if (e.key === ' ') {
+          // Click on link currently in focus
+          e.preventDefault()
+          document.getElementById('hierarchy-concept' + this.conceptInFocus).click()
+        } else if (e.key === 'ArrowDown') {
+          // On last element move focus to first list item, otherwise next list item
+          e.preventDefault()
+          this.moveFocus((this.conceptInFocus + 1) % this.visibleConceptCount)
+        } else if (e.key === 'ArrowUp') {
+          // On first element move focus to last list item, otherwise to previous list item
+          e.preventDefault()
+          this.moveFocus(this.conceptInFocus === 0 ? this.visibleConceptCount - 1 : this.conceptInFocus - 1)
+        } else if (e.key === 'Home') {
+          // Move focus to first list item
+          e.preventDefault()
+          this.moveFocus(0)
+        } else if (e.key === 'End') {
+          // Move focus to last list item
+          e.preventDefault()
+          this.moveFocus(this.visibleConceptCount - 1)
+        }
+      },
+      moveFocus (i) {
+        this.conceptInFocus = i
+        document.getElementById('hierarchy-concept' + this.conceptInFocus).focus()
       }
     },
     template: `
@@ -444,40 +501,86 @@ function startHierarchyApp () {
           :isTopConcept="true"
           :isLast="i == hierarchy.length - 1"
           :loadingChildren="loadingChildren"
-          :openAriaMessage="openAriaMessage"
           :toConceptPageAriaMessage="toConceptPageAriaMessage"
+          :conceptInFocus="conceptInFocus"
           @load-children="loadChildren($event)"
           @select-concept="selectConcept($event)"
+          @link-keydown="handleKeydownEvent($event)"
+          @move-focus="moveFocus($event)"
         ></tab-hier>
       </template>
     `
   })
 
   tabHierApp.component('tab-hier', {
-    props: ['concept', 'selectedConcept', 'isTopConcept', 'isLast', 'loadingChildren', 'openAriaMessage', 'toConceptPageAriaMessage'],
-    emits: ['loadChildren', 'selectConcept'],
+    props: [
+      'concept',
+      'selectedConcept',
+      'isTopConcept',
+      'isLast',
+      'loadingChildren',
+      'toConceptPageAriaMessage',
+      'conceptInFocus'
+    ],
+    emits: ['loadChildren', 'selectConcept', 'linkKeydown', 'closeParent', 'moveFocus'],
     inject: ['partialPageLoad', 'getConceptURL', 'showNotation'],
     methods: {
       handleClickOpenEvent (concept) {
         concept.isOpen = !concept.isOpen
         this.$emit('loadChildren', concept)
+        this.$emit('moveFocus', concept.index)
       },
       handleClickConceptEvent (event, concept) {
         concept.isOpen = true
         this.$emit('loadChildren', concept)
         this.$emit('selectConcept', concept.uri)
+        this.$emit('moveFocus', concept.index)
         this.partialPageLoad(event, this.getConceptURL(concept.uri))
+      },
+      handleKeydownEvent (e, c) {
+        if (e.key === 'ArrowRight') {
+          if (!c.isOpen && c.hasChildren) {
+            // If right arrow key is pressed on a closed concept, open it
+            c.isOpen = true
+            this.$emit('loadChildren', c)
+          } else if (c.hasChildren) {
+            // If right arrow is pressed on a open concept, move focus to first child
+            this.$emit('moveFocus', c.index + 1)
+          }
+        } else if (e.key === 'ArrowLeft' && c.isOpen) {
+          // If left arrow key is pressed on an open concept, close it
+          c.isOpen = false
+          this.$emit('loadChildren', c)
+        } else if (e.key === 'ArrowLeft') {
+          // If left arrow key is pressed on a closed concept, close its parent
+          this.$emit('closeParent')
+        } else {
+          // Otherwise, deal with other key press types in tab-hier-wrapper
+          this.$emit('linkKeydown', e)
+        }
+      },
+      handleCloseParentEvent () {
+        // Close this concept when left arrow key is pressed on a closed child
+        this.concept.isOpen = false
+        this.$emit('loadChildren', this.concept)
+        this.$emit('moveFocus', this.concept.index)
       },
       loadChildrenRecursive (concept) {
         this.$emit('loadChildren', concept)
       },
       selectConceptRecursive (concept) {
         this.$emit('selectConcept', concept)
+      },
+      linkKeydownRecursive (event) {
+        this.$emit('linkKeydown', event)
+      },
+      moveFocusRecursive (index) {
+        this.$emit('moveFocus', index)
       }
     },
     template: `
       <li class="list-group-item p-0" :class="{ 'top-concept': isTopConcept }">
-        <button type="button" class="hierarchy-button btn btn-primary" :aria-label="openAriaMessage" 
+        <button type="button" class="hierarchy-button btn btn-primary" aria-hidden="true" tabindex="-1"
           :class="{ 'open': concept.isOpen }"
           v-if="concept.hasChildren"
           @click="handleClickOpenEvent(concept)"
@@ -491,27 +594,36 @@ function startHierarchyApp () {
           </template>
         </button>
         <span class="concept-label" :class="{ 'last': isLast }">
-          <a :class="{ 'selected': selectedConcept === concept.uri }"
+          <a role="treeitem"
+            :class="{ 'selected': selectedConcept === concept.uri }" 
             :href="getConceptURL(concept.uri)"
+            :tabindex="concept.index === conceptInFocus ? 0 : -1"
+            :id="'hierarchy-concept' + concept.index"
+            :aria-expanded="concept.hasChildren ? concept.isOpen : null"
+            :aria-selected="concept.uri === selectedConcept"
             @click="handleClickConceptEvent($event, concept)"
+            @keydown="handleKeydownEvent($event, concept)"
           >
             <span v-if="showNotation && concept.notation" class="concept-notation">{{ concept.notation }} </span>
             {{ concept.label }}
             <span class="visually-hidden">{{ toConceptPageAriaMessage }}</span>
           </a>
         </span>
-        <ul class="list-group ps-3" v-if="concept.children.length !== 0 && concept.isOpen">
+        <ul class="list-group ps-3" role="group" v-if="concept.children.length !== 0 && concept.isOpen">
           <template v-for="(c, i) in concept.children">
             <tab-hier
               :concept="c"
               :selectedConcept="selectedConcept"
-              :openAriaMessage="openAriaMessage"
               :toConceptPageAriaMessage="toConceptPageAriaMessage"
               :isTopConcept="false"
               :isLast="i == concept.children.length - 1"
               :loadingChildren="loadingChildren"
+              :conceptInFocus="conceptInFocus"
               @load-children="loadChildrenRecursive($event)"
               @select-concept="selectConceptRecursive($event)"
+              @link-keydown="linkKeydownRecursive($event)"
+              @close-parent="handleCloseParentEvent()"
+              @move-focus="moveFocusRecursive($event)"
             ></tab-hier>
           </template>
         </ul>

--- a/resource/js/tab-hierarchy.js
+++ b/resource/js/tab-hierarchy.js
@@ -283,7 +283,12 @@ function startHierarchyApp () {
         const traverse = (nodes, parentIsOpen) => {
           for (const node of nodes) {
             // Assign index only if parent is open
-            parentIsOpen ? node.index = counter++ : delete node.index
+            if (parentIsOpen) {
+              counter++
+              node.index = counter
+            } else {
+              delete node.index
+            }
 
             if (node.children.length > 0) {
               traverse(node.children, node.isOpen && parentIsOpen)

--- a/resource/js/tab-hierarchy.js
+++ b/resource/js/tab-hierarchy.js
@@ -543,7 +543,7 @@ function startHierarchyApp () {
             // If right arrow key is pressed on a closed concept, open it
             c.isOpen = true
             this.$emit('loadChildren', c)
-          } else if (c.hasChildren) {
+          } else if (c.children.length > 0) {
             // If right arrow is pressed on a open concept, move focus to first child
             this.$emit('moveFocus', c.index + 1)
           }

--- a/tests/cypress/template/sidebar-groups.cy.js
+++ b/tests/cypress/template/sidebar-groups.cy.js
@@ -62,8 +62,6 @@ describe('Groups tab', () => {
     cy.visit('/yso/en/')
     // Click on groups tab
     cy.get('#groups').click()
-    // Check that hierarchy button has correct Aria label
-    cy.get('#groups-list').find('ul.list-group button').should('have.attr', 'aria-label', 'Open')
     // Check that concepts have correct Aria labels
     cy.get('.concept-label a span').eq(0).invoke('text').should('contain', 'Go to the concept page')
 
@@ -71,8 +69,6 @@ describe('Groups tab', () => {
     cy.visit('/yso/fi/')
     // Click on groups tab
     cy.get('#groups').click()
-    // Check that hierarchy button has correct Aria label
-    cy.get('#groups-list').find('ul.list-group button').should('have.attr', 'aria-label', 'Avaa')
     // Check that concepts have correct Aria labels
     cy.get('.concept-label a span').eq(0).invoke('text').should('contain', 'Mene käsitesivulle')
 
@@ -80,8 +76,6 @@ describe('Groups tab', () => {
     cy.visit('/yso/sv/')
     // Click on groups tab
     cy.get('#groups').click()
-    // Check that hierarchy button has correct Aria label
-    cy.get('#groups-list').find('ul.list-group button').should('have.attr', 'aria-label', 'Öppna')
     // Check that concepts have correct Aria labels
     cy.get('.concept-label a span').eq(0).invoke('text').should('contain', 'Gå till begreppssidan')
   })

--- a/tests/cypress/template/sidebar-groups.cy.js
+++ b/tests/cypress/template/sidebar-groups.cy.js
@@ -84,6 +84,34 @@ describe('Groups tab', () => {
     cy.get('#groups-list').find('ul.list-group button').should('have.attr', 'aria-label', 'Öppna')
     // Check that concepts have correct Aria labels
     cy.get('.concept-label a span').eq(0).invoke('text').should('contain', 'Gå till begreppssidan')
-
+  })
+  it('Keyboard navigation', () => {
+    // Go to test vocab home page
+    cy.visit('/groups/en/')
+    // Click on groups tab and wait for the group tree to load
+    cy.get('#groups').click()
+    cy.get('#groups-list .list-group-item a')
+    // Press tab key and check that first list item has focus
+    cy.press(Cypress.Keyboard.Keys.TAB)
+    cy.get('#groups-list .list-group-item a').eq(0).should('have.focus')
+    // Press down arrow key and check that focus is moved
+    cy.press(Cypress.Keyboard.Keys.DOWN)
+    cy.get('#groups-list .list-group-item a').eq(1).should('have.focus')
+    // Press right arrow key and check that children are loaded
+    cy.press(Cypress.Keyboard.Keys.RIGHT)
+    cy.get('#groups-list li ul').eq(0).children().should('have.length', 1)
+    // Press right arrow key and check that focus is moved to first child
+    cy.press(Cypress.Keyboard.Keys.RIGHT)
+    cy.get('#groups-list .list-group-item a').eq(2).should('have.focus')
+    // Press right arrow key again and check that nothing happens
+    cy.press(Cypress.Keyboard.Keys.RIGHT)
+    cy.get('#groups-list .list-group-item a').eq(2).should('have.focus')
+    // Press left arrow key and check that children are closed and focus is moved
+    cy.press(Cypress.Keyboard.Keys.LEFT)
+    cy.get('#groups-list .list-group-item').eq(1).find('ul').should('not.exist')
+    cy.get('#groups-list .list-group-item a').eq(1).should('have.focus')
+    // Press down up key and check that focus is moved
+    cy.press(Cypress.Keyboard.Keys.UP)
+    cy.get('#groups-list .list-group-item a').eq(0).should('have.focus')
   })
 })

--- a/tests/cypress/template/sidebar-groups.cy.js
+++ b/tests/cypress/template/sidebar-groups.cy.js
@@ -107,5 +107,8 @@ describe('Groups tab', () => {
     // Press down up key and check that focus is moved
     cy.press(Cypress.Keyboard.Keys.UP)
     cy.get('#groups-list .list-group-item a').eq(0).should('have.focus')
+    // Check that pressing space opens concept page
+    cy.press(Cypress.Keyboard.Keys.SPACE)
+    cy.get('#concept-heading h1', {'timeout': 15000}).invoke('text').should('equal', 'Fish')
   })
 })

--- a/tests/cypress/template/sidebar-hierarchy.cy.js
+++ b/tests/cypress/template/sidebar-hierarchy.cy.js
@@ -171,15 +171,41 @@ describe('Hierarchy', () => {
   it('Aria tags are correct for each language', () => {
     cy.visit('/test-hierarchy/fi/')
     cy.get('#hierarchy').should('not.have.class', 'disabled').click()
-    cy.get('#hierarchy-list').find('ul.list-group button').should('have.attr', 'aria-label', 'Avaa');
     cy.get('.concept-label a span').eq(0).invoke('text').should('contain', 'Mene käsitesivulle')
     cy.visit('/test-hierarchy/en/')
     cy.get('#hierarchy').should('not.have.class', 'disabled').click()
-    cy.get('#hierarchy-list').find('ul.list-group button').should('have.attr', 'aria-label', 'Open');
     cy.get('.concept-label a span').eq(0).invoke('text').should('contain', 'Go to the concept page')
     cy.visit('/test-hierarchy/sv/')
     cy.get('#hierarchy').should('not.have.class', 'disabled').click()
-    cy.get('#hierarchy-list').find('ul.list-group button').should('have.attr', 'aria-label', 'Öppna');
     cy.get('.concept-label a span').eq(0).invoke('text').should('contain', 'Gå till begreppssidan')
+  })
+  it('Keyboard navigation', () => {
+    // Go to test vocab home page
+    cy.visit('/test-hierarchy/en/')
+    // Click on hierarchy tab and wait for the concept tree to load
+    cy.get('#hierarchy').click()
+    cy.get('#hierarchy-list .list-group-item a')
+    // Press tab key and check that first list item has focus
+    cy.press(Cypress.Keyboard.Keys.TAB)
+    cy.get('#hierarchy-list .list-group-item a').eq(0).should('have.focus')
+    // Press right arrow key and check that children are loaded
+    cy.press(Cypress.Keyboard.Keys.RIGHT)
+    cy.get('#hierarchy-list li ul').first().children().should('have.length', 9)
+    // Press right arrow key and check that focus is moved to first child
+    cy.press(Cypress.Keyboard.Keys.RIGHT)
+    cy.get('#hierarchy-list .list-group-item a').eq(1).should('have.focus')
+    // PRess right arrow key again and check that nothing happens
+    cy.press(Cypress.Keyboard.Keys.RIGHT)
+    cy.get('#hierarchy-list .list-group-item a').eq(1).should('have.focus')
+    // Press down arrow key and check that focus is moved
+    cy.press(Cypress.Keyboard.Keys.DOWN)
+    cy.get('#hierarchy-list .list-group-item a').eq(2).should('have.focus')
+    // Press down up key and check that focus is moved
+    cy.press(Cypress.Keyboard.Keys.UP)
+    cy.get('#hierarchy-list .list-group-item a').eq(1).should('have.focus')
+    // Press left arrow key and check that children are closed and focus is moved
+    cy.press(Cypress.Keyboard.Keys.LEFT)
+    cy.get('#hierarchy-list .list-group-item').eq(0).find('ul').should('not.exist')
+    cy.get('#hierarchy-list .list-group-item a').eq(0).should('have.focus')
   })
 })

--- a/tests/cypress/template/sidebar-hierarchy.cy.js
+++ b/tests/cypress/template/sidebar-hierarchy.cy.js
@@ -194,7 +194,7 @@ describe('Hierarchy', () => {
     // Press right arrow key and check that focus is moved to first child
     cy.press(Cypress.Keyboard.Keys.RIGHT)
     cy.get('#hierarchy-list .list-group-item a').eq(1).should('have.focus')
-    // PRess right arrow key again and check that nothing happens
+    // Press right arrow key again and check that nothing happens
     cy.press(Cypress.Keyboard.Keys.RIGHT)
     cy.get('#hierarchy-list .list-group-item a').eq(1).should('have.focus')
     // Press down arrow key and check that focus is moved

--- a/tests/cypress/template/sidebar-hierarchy.cy.js
+++ b/tests/cypress/template/sidebar-hierarchy.cy.js
@@ -207,5 +207,8 @@ describe('Hierarchy', () => {
     cy.press(Cypress.Keyboard.Keys.LEFT)
     cy.get('#hierarchy-list .list-group-item').eq(0).find('ul').should('not.exist')
     cy.get('#hierarchy-list .list-group-item a').eq(0).should('have.focus')
+    // Check that pressing space opens concept page
+    cy.press(Cypress.Keyboard.Keys.SPACE)
+    cy.get('#concept-heading h1', {'timeout': 15000}).invoke('text').should('equal', 'Birds')
   })
 })


### PR DESCRIPTION
## Reasons for creating this PR

Hierarchy and groups tabs in the sidebar are not currently keyboard navigable. This PR adds keyboard navigation and screen reader semantics to both tabs.

## Link to relevant issue(s), if any

- Closes #1982 
- Closes #1981

## Description of the changes in this PR

- Add keyboard navigation to hierarchy and group trees (based on interactions defined [here](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/tree_role))
  - Arrow up/down are used to navigate between visible list items
  - Arrow right on a closed item opens it
  - Arrow right on an open item moves focus to first child
  - Arrow left on an open item closes it
  - Arrow left on a closed item closes its parent and moves focus to the parent
  - Enter/Space opens concept page and moves focus to concept page heading
  - Home/End move focus to first/last item
- Give hierarchy/groups lists role `tree` and links role `treeitem`
- Add aria-selected and aria-expanded attributes to links
- Make hierarchy buttons non-focusable and invisible to screen readers and remove aria-labels
- Cypress tests for both Vue components

## Known problems or uncertainties in this PR

- Not all accessibility features defined [here](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/tree_role) are implemented
  - Selection is only made with Space/Enter and not when moving between items
  - Type-ahead is not implemented
  - No aria-level, aria-setsize and aria-posinset attributes are used
  - Screen reader gets no indication when children are loaded

## Checklist

- [ ] phpUnit tests pass locally with my changes
- [ ] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [ ] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [ ] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
