### PR TITLE
Use FormatJS Intl.Collator polyfill to fix missing locales in Chromium (e.g. "se")

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test-accessibility-cli-vocab-search": "npx cypress run --env cli=true --spec 'tests/cypress/accessibility/axe-vocab-search.cy.js'"
   },
   "dependencies": {
+    "@formatjs/intl-collator": "^0.2.2",
     "@fortawesome/fontawesome-free": "^7.2.0",
     "bootstrap": "^5.3.*",
     "vue": "^3.5.25"

--- a/resource/js/tab-hierarchy.js
+++ b/resource/js/tab-hierarchy.js
@@ -543,11 +543,11 @@ async function initializeHierarchyApp () {
 
 onTranslationReady(function () {
   if (document.getElementById('tab-hierarchy')) {
-    if (typeof window.getIntlCollatorReady !== 'function') {
+    if (typeof window.getIntlCollatorReady === 'function') {
+      initializeHierarchyApp()
+    } else {
       // wait for the polyfill promise to be initialized
       document.addEventListener('intlCollatorPromiseReady', initializeHierarchyApp)
-    } else {
-      initializeHierarchyApp()
     }
   }
 })

--- a/resource/js/tab-hierarchy.js
+++ b/resource/js/tab-hierarchy.js
@@ -514,7 +514,6 @@ function startHierarchyApp () {
 
   if (document.getElementById('tab-hierarchy')) {
     // initialize the collators needed by the app
-    console.log('initializing hierarchy collators')
     tabHierApp.config.globalProperties.$collator = new Intl.Collator(
       window.SKOSMOS.content_lang || window.SKOSMOS.lang,
       {
@@ -534,9 +533,9 @@ function startHierarchyApp () {
   }
 }
 
-function startHierarchyAppWaitForCollator () {
-  console.log('waiting for collator')
-  document.addEventListener('loadIntlCollator', startHierarchyApp)
+async function startHierarchyAppWaitForCollator () {
+  await window.intlCollatorReady
+  startHierarchyApp()
 }
 
 onTranslationReady(startHierarchyAppWaitForCollator)

--- a/resource/js/tab-hierarchy.js
+++ b/resource/js/tab-hierarchy.js
@@ -513,7 +513,11 @@ async function startHierarchyApp () {
   })
 
   if (document.getElementById('tab-hierarchy')) {
-    await window.getIntlCollatorReady()
+    try {
+      await window.getIntlCollatorReady()
+    } catch (e) {
+      console.error('Intl.Collator polyfill failed to load, continuing with native collator:', e)
+    }
 
     // initialize the collators needed by the app
     tabHierApp.config.globalProperties.$collator = new Intl.Collator(

--- a/resource/js/tab-hierarchy.js
+++ b/resource/js/tab-hierarchy.js
@@ -327,19 +327,12 @@ function startHierarchyApp () {
         strA = strA || a.label || a.prefLabel || a.title || ''
         strB = strB || b.label || b.prefLabel || b.title || ''
 
-        // Set language and options
-        const lang = window.SKOSMOS.content_lang || window.SKOSMOS.lang
-        const options = {
-          numeric: window.SKOSMOS.sortByNotation === 'natural', // Set numeric to true if sort should be natural
-          sensitivity: 'variant' // Strings that differ in base letters, diacritic marks, or case compare as unequal
-        }
-
-        const result = strA.localeCompare(strB, lang, options)
+        const result = this.$collator.compare(strA, strB)
         if (result !== 0) {
           return result
         } else {
           // fall back to non-numeric sort to ensure a consistent order
-          return strA.localeCompare(strB, lang, { sensitivity: 'variant' })
+          return this.$fallbackCollator.compare(strA, strB)
         }
       }
     },
@@ -520,8 +513,30 @@ function startHierarchyApp () {
   })
 
   if (document.getElementById('tab-hierarchy')) {
+    // initialize the collators needed by the app
+    console.log('initializing hierarchy collators')
+    tabHierApp.config.globalProperties.$collator = new Intl.Collator(
+      window.SKOSMOS.content_lang || window.SKOSMOS.lang,
+      {
+        sensitivity: 'variant',
+        numeric: window.SKOSMOS.sortByNotation === 'natural'
+      }
+    )
+    tabHierApp.config.globalProperties.$fallbackCollator = new Intl.Collator(
+      window.SKOSMOS.content_lang || window.SKOSMOS.lang,
+      {
+        sensitivity: 'variant',
+        numeric: false
+      }
+    )
+
     tabHierApp.mount('#tab-hierarchy')
   }
 }
 
-onTranslationReady(startHierarchyApp)
+function startHierarchyAppWaitForCollator () {
+  console.log('waiting for collator')
+  document.addEventListener('loadIntlCollator', startHierarchyApp)
+}
+
+onTranslationReady(startHierarchyAppWaitForCollator)

--- a/resource/js/tab-hierarchy.js
+++ b/resource/js/tab-hierarchy.js
@@ -1,7 +1,7 @@
 /* global Vue, $t, onTranslationReady */
 /* global partialPageLoad, getConceptURL */
 
-async function startHierarchyApp () {
+function startHierarchyApp () {
   const tabHierApp = Vue.createApp({
     data () {
       return {
@@ -512,31 +512,42 @@ async function startHierarchyApp () {
     `
   })
 
-  if (document.getElementById('tab-hierarchy')) {
-    try {
-      await window.getIntlCollatorReady()
-    } catch (e) {
-      console.error('Intl.Collator polyfill failed to load, continuing with native collator:', e)
+  // initialize the collators needed by the app
+  tabHierApp.config.globalProperties.$collator = new Intl.Collator(
+    window.SKOSMOS.content_lang || window.SKOSMOS.lang,
+    {
+      sensitivity: 'variant',
+      numeric: window.SKOSMOS.sortByNotation === 'natural'
     }
+  )
+  tabHierApp.config.globalProperties.$fallbackCollator = new Intl.Collator(
+    window.SKOSMOS.content_lang || window.SKOSMOS.lang,
+    {
+      sensitivity: 'variant',
+      numeric: false
+    }
+  )
 
-    // initialize the collators needed by the app
-    tabHierApp.config.globalProperties.$collator = new Intl.Collator(
-      window.SKOSMOS.content_lang || window.SKOSMOS.lang,
-      {
-        sensitivity: 'variant',
-        numeric: window.SKOSMOS.sortByNotation === 'natural'
-      }
-    )
-    tabHierApp.config.globalProperties.$fallbackCollator = new Intl.Collator(
-      window.SKOSMOS.content_lang || window.SKOSMOS.lang,
-      {
-        sensitivity: 'variant',
-        numeric: false
-      }
-    )
-
-    tabHierApp.mount('#tab-hierarchy')
-  }
+  tabHierApp.mount('#tab-hierarchy')
 }
 
-onTranslationReady(startHierarchyApp)
+async function initializeHierarchyApp () {
+  try {
+    await window.getIntlCollatorReady()
+  } catch (e) {
+    console.error('Intl.Collator polyfill failed to load, continuing with native collator:', e)
+  }
+
+  startHierarchyApp()
+}
+
+onTranslationReady(function () {
+  if (document.getElementById('tab-hierarchy')) {
+    if (typeof window.getIntlCollatorReady !== 'function') {
+      // wait for the polyfill promise to be initialized
+      document.addEventListener('intlCollatorPromiseReady', initializeHierarchyApp)
+    } else {
+      initializeHierarchyApp()
+    }
+  }
+})

--- a/resource/js/tab-hierarchy.js
+++ b/resource/js/tab-hierarchy.js
@@ -1,7 +1,7 @@
 /* global Vue, $t, onTranslationReady */
 /* global partialPageLoad, getConceptURL */
 
-function startHierarchyApp () {
+async function startHierarchyApp () {
   const tabHierApp = Vue.createApp({
     data () {
       return {
@@ -513,6 +513,8 @@ function startHierarchyApp () {
   })
 
   if (document.getElementById('tab-hierarchy')) {
+    await window.intlCollatorReady
+
     // initialize the collators needed by the app
     tabHierApp.config.globalProperties.$collator = new Intl.Collator(
       window.SKOSMOS.content_lang || window.SKOSMOS.lang,
@@ -533,9 +535,4 @@ function startHierarchyApp () {
   }
 }
 
-async function startHierarchyAppWaitForCollator () {
-  await window.intlCollatorReady
-  startHierarchyApp()
-}
-
-onTranslationReady(startHierarchyAppWaitForCollator)
+onTranslationReady(startHierarchyApp)

--- a/resource/js/tab-hierarchy.js
+++ b/resource/js/tab-hierarchy.js
@@ -513,7 +513,7 @@ async function startHierarchyApp () {
   })
 
   if (document.getElementById('tab-hierarchy')) {
-    await window.intlCollatorReady
+    await window.getIntlCollatorReady()
 
     // initialize the collators needed by the app
     tabHierApp.config.globalProperties.$collator = new Intl.Collator(

--- a/src/view/scripts.inc.twig
+++ b/src/view/scripts.inc.twig
@@ -95,6 +95,11 @@ window.SKOSMOS = {
     }
     return collatorPromise
   }
+
+  // custom event to signal that the collator promise has been initialized
+  const event = new Event('intlCollatorPromiseReady')
+  document.dispatchEvent(event)
+
 </script>
 
 <!-- Vue.js -->

--- a/src/view/scripts.inc.twig
+++ b/src/view/scripts.inc.twig
@@ -86,7 +86,15 @@ window.SKOSMOS = {
   }
 
   // global Promise for loading the polyfill on-demand
-  window.intlCollatorReady = ensureCollator(window.SKOSMOS.content_lang || window.SKOSMOS.lang)
+  let collatorPromise = null
+
+  window.getIntlCollatorReady = function () {
+    if (!collatorPromise) {
+      const locale = window.SKOSMOS.content_lang || window.SKOSMOS.lang
+      collatorPromise = ensureCollator(locale)
+    }
+    return collatorPromise
+  }
 </script>
 
 <!-- Vue.js -->

--- a/src/view/scripts.inc.twig
+++ b/src/view/scripts.inc.twig
@@ -99,7 +99,6 @@ window.SKOSMOS = {
   // custom event to signal that the collator promise has been initialized
   const event = new Event('intlCollatorPromiseReady')
   document.dispatchEvent(event)
-
 </script>
 
 <!-- Vue.js -->

--- a/src/view/scripts.inc.twig
+++ b/src/view/scripts.inc.twig
@@ -70,12 +70,23 @@ window.SKOSMOS = {
   }
 </script>
 <script type="module">
-  import './node_modules/@formatjs/intl-collator/polyfill-force.js';
-  console.log('Intl.Collator polyfill loaded');
+  function needsCollatorPolyfill(locale) {
+    try {
+      const supported = Intl.Collator.supportedLocalesOf([locale])
+      return supported.length === 0
+    } catch {
+      return true; // fallback for old browsers
+    }
+  }
 
-  // custom event to signal that the polyfill has been loaded
-  const event = new Event('loadIntlCollator')
-  document.dispatchEvent(event)
+  async function ensureCollator(locale) {
+    if (needsCollatorPolyfill(locale)) {
+      await import('./node_modules/@formatjs/intl-collator/polyfill-force.js')
+    }
+  }
+
+  // global Promise for loading the polyfill on-demand
+  window.intlCollatorReady = ensureCollator(window.SKOSMOS.content_lang || window.SKOSMOS.lang)
 </script>
 
 <!-- Vue.js -->

--- a/src/view/scripts.inc.twig
+++ b/src/view/scripts.inc.twig
@@ -60,6 +60,24 @@ window.SKOSMOS = {
 <!-- Bootstrap -->
 <script src="node_modules/bootstrap/dist/js/bootstrap.bundle.js"></script>
 
+<!-- FormatJS Intl.Collator polyfill for expanded locale support -->
+<script type="importmap">
+  {
+    "imports": {
+      "@formatjs/intl-localematcher": "./node_modules/@formatjs/intl-localematcher/index.js",
+      "@formatjs/fast-memoize": "./node_modules/@formatjs/fast-memoize/index.js"
+    }
+  }
+</script>
+<script type="module">
+  import './node_modules/@formatjs/intl-collator/polyfill-force.js';
+  console.log('Intl.Collator polyfill loaded');
+
+  // custom event to signal that the polyfill has been loaded
+  const event = new Event('loadIntlCollator')
+  document.dispatchEvent(event)
+</script>
+
 <!-- Vue.js -->
 {% if GlobalConfig.uiDevMode %}
 <script src="node_modules/vue/dist/vue.global.js"></script>


### PR DESCRIPTION
## Reasons for creating this PR

The hierarchy sidebar does not sort concepts correctly in Northern Sami locale (se) on Chromium based browsers, see #2016. This PR fixes the issue by using the [Intl.Collator polyfill from FormatJS](https://formatjs.github.io/docs/polyfills/intl-collator/) which can be used to retrofit wider locale support to JavaScript environments. The polyfill is quite heavy and it is only loaded when actually needed: in my tests using Chromium, it will be loaded when the content language is set to Northern Sámi and the page includes a hierarchy sidebar (even if it's not the currently active tab). In all other cases (e.g. Firefox browser, a content language other than Northern Sámi, or a page without the hierarchy tab), the polyfill will not be loaded at all!

## Link to relevant issue(s), if any

- Closes #2016

## Description of the changes in this PR

- add `formatjs/intl-collator` as a dependency managed by npm
- change the hierarchy sidebar Vue app to use Intl.Collator for sorting concept labels; the collators are initialized only once, after loading the Promise that loads the FormatJS polyfill (but only if needed)

## Known problems or uncertainties in this PR

- There were many difficulties creating this: FormatJS is heavily oriented towards JS modules, while Skosmos so far uses more traditional script tags and no build step. It's also difficult to get the timing right; the polyfill takes a long time to initialize so the hierarchy app has to wait for it to be ready, which is now handled using a Promise.
- Is it OK to add the polyfill JS code into `src/view/scripts.inc.twig` or would it be better to move it into its own small `.js` file?
- No Cypress test for the polyfill yet - I wonder if this can be easily tested?
- Cypress tests are currently failing due to LCSH mapping issues, unrelated to this PR.

## Checklist

- [ ] phpUnit tests pass locally with my changes
- [ ] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [ ] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [ ] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
