### PR TITLE
adjust deprecated alert box: no bottom margin

### DIFF
--- a/resource/css/skosmos.css
+++ b/resource/css/skosmos.css
@@ -1094,6 +1094,7 @@ h1#vocab-heading {
 #concept-deprecated-alert {
   padding-left: 2.5rem;
   padding-right: 2.5rem;
+  margin-bottom: 0;
 }
 
 #concept-deprecated-alert i {


### PR DESCRIPTION
## Reasons for creating this PR

We agreed today (at the Finto weekly meeting) that alert boxes for deprecated concepts and vocab messages look better when the box is directly adjacent to the main content box. This PR implements the minor CSS adjustment for deprecated concept warnings.

## Link to relevant issue(s), if any

- follow-up to #1918 and #2001

## Description of the changes in this PR

Remove the margin-bottom of the deprecated alert so it looks like this (notice no grey border between red and white areas):

<img width="1002" height="311" alt="image" src="https://github.com/user-attachments/assets/f6b890ee-be40-41d1-acdd-3f77f54c3153" />

## Known problems or uncertainties in this PR

Bloats the CSS by one more line. I couldn't think of a cleaner solution...

## Checklist

- [ ] phpUnit tests pass locally with my changes
- [ ] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [ ] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [ ] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
