### PR TITLE
Fix switching between sidebar tabs using the keybaord

### DIFF
--- a/resource/js/tab-alpha.js
+++ b/resource/js/tab-alpha.js
@@ -182,10 +182,10 @@ function startAlphaApp () {
       el.clickTabEvent = event => {
         binding.value() // calling the method given as the attribute value (loadLetters)
       }
-      document.querySelector('#alphabetical').addEventListener('click', el.clickTabEvent) // registering an event listener on clicks on the alphabetical nav-item element
+      document.querySelector('#alphabetical').addEventListener('shown.bs.tab', el.clickTabEvent) // registering an event listener on bootstrap's tab shown event on the alphabetical nav-item element
     },
     unmounted: el => {
-      document.querySelector('#alphabetical').removeEventListener('click', el.clickTabEvent)
+      document.querySelector('#alphabetical').removeEventListener('shown.bs.tab', el.clickTabEvent)
     }
   })
 

--- a/resource/js/tab-changes.js
+++ b/resource/js/tab-changes.js
@@ -156,10 +156,10 @@ function startChangesApp () {
       el.clickTabEvent = event => {
         binding.value() // calling the method given as the attribute value (loadChanges)
       }
-      document.querySelector('#changes').addEventListener('click', el.clickTabEvent) // registering an event listener on clicks on the changes nav-item element
+      document.querySelector('#changes').addEventListener('shown.bs.tab', el.clickTabEvent) // registering an event listener on bootstrap's tab shown event on the changes nav-item element
     },
     unmounted: el => {
-      document.querySelector('#changes').removeEventListener('click', el.clickTabEvent)
+      document.querySelector('#changes').removeEventListener('shown.bs.tab', el.clickTabEvent)
     }
   })
 

--- a/resource/js/tab-groups.js
+++ b/resource/js/tab-groups.js
@@ -237,10 +237,10 @@ function startGroupsApp () {
       el.clickTabEvent = event => {
         binding.value() // calling the method given as the attribute value (handleClickGroupsEvent)
       }
-      document.querySelector('#groups').addEventListener('click', el.clickTabEvent) // registering an event listener on clicks on the groups nav-item element
+      document.querySelector('#groups').addEventListener('shown.bs.tab', el.clickTabEvent) // registering an event listener on bootstrap's tab shown event on the groups nav-item element
     },
     unmounted: el => {
-      document.querySelector('#groups').removeEventListener('click', el.clickTabEvent)
+      document.querySelector('#groups').removeEventListener('shown.bs.tab', el.clickTabEvent)
     }
   })
 

--- a/resource/js/tab-hierarchy.js
+++ b/resource/js/tab-hierarchy.js
@@ -394,10 +394,10 @@ function startHierarchyApp () {
       el.clickTabEvent = event => {
         binding.value() // calling the method given as the attribute value (handleClickHierarchyEvent)
       }
-      document.querySelector('#hierarchy').addEventListener('click', el.clickTabEvent) // registering an event listener on clicks on the hierarchy nav-item element
+      document.querySelector('#hierarchy').addEventListener('shown.bs.tab', el.clickTabEvent) // registering an event listener on bootstrap's tab shown event on the hierarchy nav-item element
     },
     unmounted: el => {
-      document.querySelector('#hierarchy').removeEventListener('click', el.clickTabEvent)
+      document.querySelector('#hierarchy').removeEventListener('shown.bs.tab', el.clickTabEvent)
     }
   })
 

--- a/tests/cypress/template/sidebar.cy.js
+++ b/tests/cypress/template/sidebar.cy.js
@@ -36,4 +36,17 @@ describe('Sidebar', () => {
     cy.get('#sidebar-collapse-btn').invoke('text').should('contain', 'Selaa käsitteitä')
     cy.get('#sidebar-col').should('not.be.visible')
   })
+
+  it('Keyboard navigation', () => {
+    // Go to YSO home page
+    cy.visit('/yso/fi/')
+    // Focus on first tab
+    cy.get('#sidebar-tabs').find('.nav-link').first().focus()
+    // Check that alphabetical list is shown
+    cy.get('.tab-content').find('#tab-alphabetical').should('exist')
+    // Press right arrow key
+    cy.press(Cypress.Keyboard.Keys.RIGHT)
+    // Check that hierarchy is loaded
+    cy.get('#hierarchy-list ul').should('exist')
+  })
 })


### PR DESCRIPTION
## Reasons for creating this PR

Switching between sidebar tabs using the arrow keys does not currently load the contents of the tabs. This PR fixes the way tab contents are loaded. Contents should now be loaded when tabs are clicked and when switching between them with arrow keys.

## Description of the changes in this PR

- Listen to [bootstrap's tab shown event](https://getbootstrap.com/docs/5.3/components/navs-tabs/#events) instead of click events in sidebar tabs to load tab content
- Add cypress test

## Known problems or uncertainties in this PR

## Checklist

- [ ] phpUnit tests pass locally with my changes
- [ ] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [ ] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [ ] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
