### PR TITLE
Added Vue i18n dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "@formatjs/intl-collator": "^0.2.2",
     "@fortawesome/fontawesome-free": "^7.2.0",
     "bootstrap": "^5.3.*",
-    "vue": "^3.5.25"
+    "vue": "^3.5.25",
+    "vue-i18n": "^11.2.8"
   },
   "devDependencies": {
     "axe-core": "^4.11.*",

--- a/src/view/scripts.inc.twig
+++ b/src/view/scripts.inc.twig
@@ -104,8 +104,10 @@ window.SKOSMOS = {
 <!-- Vue.js -->
 {% if GlobalConfig.uiDevMode %}
 <script src="node_modules/vue/dist/vue.global.js"></script>
+<script src="node_modules/vue-i18n/dist/vue-i18n.global.js"></script>
 {% else %}
 <script src="node_modules/vue/dist/vue.global.prod.js"></script>
+<script src="node_modules/vue-i18n/dist/vue-i18n.global.prod.js"></script>
 {% endif %}
 
 <!-- Plugin JS sources -->


### PR DESCRIPTION
## Reasons for creating this PR

## Link to relevant issue(s), if any

- Closes #2030 

## Description of the changes in this PR

- Vue i18n dependency can be loaded from Skosmos instead loading it for each plugin separately. Dependencies from two plugins can be removed:
https://github.com/NatLibFi/Skosmos-widget-finna
https://github.com/NatLibFi/Skosmos-widget-suggestions/

## Checklist

- [X] phpUnit tests pass locally with my changes
- [ ] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [X] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [X] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
