### PR TITLE
Fix target URLs for external links on concept page

### DIFF
--- a/src/view/concept-card.inc.twig
+++ b/src/view/concept-card.inc.twig
@@ -23,8 +23,12 @@
       <div class="main-content-section py-4{% if concept.deprecated %} concept-deprecated{% endif %}">
 
         {# Macro for rendering concept links with notation #}
-        {% macro concept_link(item, vocab, lang, contentLang) %}
-          <a href="{{ item.uri | link_url(vocab, lang, 'page', contentLang) }}">
+        {% macro concept_link(item, current_vocab, lang, contentLang) %}
+          {%- if current_vocab == item.vocab and item.isExternal %}
+            <a href="{{ item.uri }}">
+          {%- else -%}
+            <a href="{{ item.uri | link_url(item.vocab, lang, 'page', contentLang) }}">
+          {%- endif -%}
           {%- if item.notation -%}
             <span class="property-value-notation">{{ item.notation }} </span>
           {%- endif -%}
@@ -127,7 +131,7 @@
                   {# Display as an ordered list #}
                   <ol class="rdf-list">
                   {% for listItem in propval.rdfListItems %}
-                    <li>{{ _self.concept_link(listItem, listItem.vocab, request.lang, request.contentLang) }}</li>
+                    <li>{{ _self.concept_link(listItem, vocab, request.lang, request.contentLang) }}</li>
                   {% endfor %}
                   {% if propval.isRdfListTruncated %}
                     <li class="rdf-list-truncated">
@@ -138,11 +142,11 @@
                   
                 {% else %}
                   {# Regular resource display #}
-                  {{ _self.concept_link(propval, propval.vocab, request.lang, request.contentLang) }}
+                  {{ _self.concept_link(propval, vocab, request.lang, request.contentLang) }}
                   {% if propval.submembers %}
                   <ul class="property-value-submembers">
                   {% for submember in propval.submembers %}
-                    <li>{{ _self.concept_link(submember, propval.vocab, request.lang, request.contentLang) }}</li>
+                    <li>{{ _self.concept_link(submember, vocab, request.lang, request.contentLang) }}</li>
                   {% endfor %}
                   </ul>
                   {% endif %}

--- a/tests/cypress/template/concept.cy.js
+++ b/tests/cypress/template/concept.cy.js
@@ -268,6 +268,21 @@ describe('Concept page', () => {
     // check that we have the correct number of related concepts
     cy.get('.prop-skos_related .property-value').find('li').should('have.length', 3)
   })
+  it('contains external links', () => {
+    cy.visit('/test/en/page/ta126') // go to "Europa" concept page
+
+    // check the property name
+    cy.get('.prop-foaf_homepage .property-label h2').invoke('text').should('equal', 'Homepage')
+
+    // check that we have the correct number of related concepts
+    cy.get('.prop-foaf_homepage .property-value').find('li').should('have.length', 1)
+
+    // check that the link has the correct text (the URL itself)
+    cy.get('.prop-foaf_homepage .property-value a').invoke('text').should('equal', 'https://en.wikipedia.org/wiki/Europe')
+
+    // check that the link has the correct href URL
+    cy.get('.prop-foaf_homepage .property-value a').should('have.attr', 'href', 'https://en.wikipedia.org/wiki/Europe')
+  })
   it('contains altLabels (entry terms)', () => {
     cy.visit('/yso/en/page/p21685') // go to "music research" concept page
 

--- a/tests/test-vocab-data/test.ttl
+++ b/tests/test-vocab-data/test.ttl
@@ -1,6 +1,7 @@
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dc11: <http://purl.org/dc/elements/1.1/> .
 @prefix dct: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix test: <http://www.skosmos.skos/test/> .
 @prefix meta: <http://www.skosmos.skos/test-meta/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
@@ -143,6 +144,7 @@ test:ta125
 test:ta126
   a mads:Geographic, skos:Concept ;
   skos:notation "12.34" ;
+  foaf:homepage <https://en.wikipedia.org/wiki/Europe> ;
   skos:prefLabel "Europa"@nb .
 
 test:ta127


### PR DESCRIPTION
## Reasons for creating this PR

See #1927. Links to external URLs (not other vocabularies on the same server, but totally external services like Wikipedia, ISNI, whatever...) as the values of regular concept properties (not mapping properties like closeMatch) did not have the correct href URL. Instead the URL pointed to another Skosmos "page" that didn't show anything interesting.

This PR fixes the behavior by making the href URL simply the external URL itself without any manipulation. Comes with a Cypress test to verify.

## Example cases / how to test and verify:

* YSE concepts like [adaptaatio](https://test.dev.finto.fi/yse/fi/page?uri=http%3A%2F%2Fwww.yso.fi%2Fonto%2Fyso%2FY510783) : with the fix in this PR, the "Homepage" links properly to the GitHub issue
* KANTO agents like [this one](https://test.dev.finto.fi/finaf/fi/page?uri=http%3A%2F%2Furn.fi%2FURN%3ANBN%3Afi%3Aau%3Afinaf%3A000184443): with the fix in this PR, the identifier links to ISNI, VIAF and ORCID point to the correct URLs

## Link to relevant issue(s), if any

- Closes #1927

## Description of the changes in this PR

* adjust `concept_link` macro in concept-card Twig template: it now takes a current_vocab parameter and based on that, plus the isExternal information for the target resource, determines whether to use a plain href URL or not
* add Cypress test
* add small adjustment to test.ttl vocabulary needed by the Cypress test

## Known problems or uncertainties in this PR

I hope I didn't break anything :crossed_fingers: 

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
