### PR TITLE
Refactor copy to clipboard events using a single event handler

### DIFF
--- a/resource/js/copy-to-clipboard.js
+++ b/resource/js/copy-to-clipboard.js
@@ -11,25 +11,19 @@ function copyToClipboard (id) {
     console.error('Failed to copy text to clipboard: ', err))
 }
 
-function registerCopyToClipboardEvents () {
-  const copyPrefElem = document.getElementById('copy-preflabel')
-  if (copyPrefElem) {
-    copyPrefElem.addEventListener('click', () => copyToClipboard('concept-preflabel'))
-  }
-
-  const copyNotationElem = document.getElementById('copy-notation')
-  if (copyNotationElem) {
-    copyNotationElem.addEventListener('click', () => copyToClipboard('concept-notation'))
-  }
-
-  const copyUriElem = document.getElementById('copy-uri')
-  if (copyUriElem) {
-    copyUriElem.addEventListener('click', () => copyToClipboard('concept-uri'))
-  }
+function registerCopyToClipboardEvent () {
+  const mainElement = document.getElementById('main-container')
+  mainElement.addEventListener('click', function(event) {
+    const target = event.target.closest('.copy-clipboard')
+    if (target) {
+      event.preventDefault()
+      const targetId = target.getAttribute('data-target-id')
+      if (targetId) {
+        copyToClipboard(targetId)
+      }
+    }
+  })
 }
 
 // register the copyToClipboard function as event an handler for the copy buttons
-registerCopyToClipboardEvents()
-
-// re-register the event handlers after partial page loads
-document.addEventListener('loadConceptPage', registerCopyToClipboardEvents)
+registerCopyToClipboardEvent()

--- a/resource/js/copy-to-clipboard.js
+++ b/resource/js/copy-to-clipboard.js
@@ -17,7 +17,7 @@ function registerCopyToClipboardEvent () {
     const target = event.target.closest('.copy-clipboard')
     if (target) {
       event.preventDefault()
-      const targetId = target.getAttribute('data-target-id')
+      const targetId = target.dataset.targetId
       if (targetId) {
         copyToClipboard(targetId)
       }

--- a/resource/js/copy-to-clipboard.js
+++ b/resource/js/copy-to-clipboard.js
@@ -13,7 +13,7 @@ function copyToClipboard (id) {
 
 function registerCopyToClipboardEvent () {
   const mainElement = document.getElementById('main-container')
-  mainElement.addEventListener('click', function(event) {
+  mainElement.addEventListener('click', function (event) {
     const target = event.target.closest('.copy-clipboard')
     if (target) {
       event.preventDefault()

--- a/src/view/concept-card.inc.twig
+++ b/src/view/concept-card.inc.twig
@@ -78,7 +78,7 @@
                 {% if descriptionId %}aria-describedby="{{ descriptionId }}"{% endif %}
                 class="mb-0">
               <span class="notation user-select-all" id="concept-notation">{{ concept.notation }}</span> {{ concept.label }}</h1><button
-                  class="btn btn-default copy-clipboard px-1" type="button" id="copy-notation"
+                  class="btn btn-default copy-clipboard px-1" type="button" id="copy-notation" data-target-id="concept-notation"
                   data-bs-toggle="tooltip" data-bs-placement="button" title="{{ 'Copy to clipboard' | trans }}">
                 <i class="fa-regular fa-copy"></i>
               </button>
@@ -86,7 +86,7 @@
             <h1 id="concept-preflabel" tabindex="-1"
                 {% if descriptionId %}aria-describedby="{{ descriptionId }}"{% endif %}
                 class="mb-0 user-select-all">{{ concept.label }}</h1><button
-                    class="btn btn-default copy-clipboard px-1" type="button" id="copy-preflabel"
+                    class="btn btn-default copy-clipboard px-1" type="button" id="copy-preflabel" data-target-id="concept-preflabel"
                     data-bs-toggle="tooltip" data-bs-placement="button" title="{{ 'Copy to clipboard' | trans }}">
               <i class="fa-regular fa-copy"></i>
             </button>
@@ -209,7 +209,7 @@
           <div class="col-lg-8 gx-0 gx-lg-4 property-value">
             <span id="concept-uri"
                   class="user-select-all">{{ concept.uri }}</span><button
-                    class="btn btn-default copy-clipboard px-1" type="button" id="copy-uri"
+                    class="btn btn-default copy-clipboard px-1" type="button" id="copy-uri" data-target-id="concept-uri"
                     data-bs-toggle="tooltip" data-bs-placement="button" title="{{ 'Copy to clipboard' | trans }}">
               <i class="fa-regular fa-copy"></i>
             </button>


### PR DESCRIPTION
## Reasons for creating this PR

I need to implement some concept page tweaks in the KANTO/finaf plugin that include adding new copy to clipboard buttons for identifiers like ISNI and ORCID. The existing Skosmos copy to clipboard code attaches separate event handlers for each copy button (preflabel, notation, URI). This is brittle and repetitive, and makes it hard to copy the same approach in the finaf plugin.

This PR refactors the copy to clipboard event handling to use just a single event handler attached to `#main-container`. It responds to events from every copy button on the page (event delegation). The value to copy is indicated using `data-target-id` attributes on each copy button. This makes it easy to copy the same HTML structure in the finaf plugin without having to adjust event handler. Also, this single global event handler survives partial page loads so event handlers no longer have to be reinitialized after partial page loads.

## Link to relevant issue(s), if any

n/a

## Description of the changes in this PR

* switch to single event handler for all copy to clipboard buttons
* add `data-target-id` attributes on individual copy buttons to indicate which element value should be copied

## Known problems or uncertainties in this PR

none

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
