### PR TITLE
Simplify DOM structure on landing page, remove Bootstrap columns

### DIFF
--- a/src/view/landing.twig
+++ b/src/view/landing.twig
@@ -9,7 +9,11 @@
   {{ include('custom-templates.inc.twig', {slotName: 'landing-top'}) }}
 </div>
 
-<div class="col-lg-7 mb-gutterwidth mb-lg-0" id="landing-start-slot">
+<div id="landing-main">
+  <div id="landing-start-slot">
+    {{ include('custom-templates.inc.twig', {slotName: 'landing-start', showPlaceholder: true}) }}
+  </div>
+
   <div class="px-3 py-4" id="vocabulary-list">
     {% if request.vocabList|length == 0 %}
     <h2 class="fs-3 fw-bold">{{ "No vocabularies on the server!" | trans }}</h2>
@@ -31,10 +35,10 @@
       {% endfor %}
     {% endif %}
   </div>
-  {{ include('custom-templates.inc.twig', {slotName: 'landing-start'}) }}
-</div>
-<div class="col-lg-5 d-flex flex-column" id="landing-end-slot">
-  {{ include('custom-templates.inc.twig', {slotName: 'landing-end', showPlaceholder: true}) }}
+
+  <div id="landing-end-slot">
+    {{ include('custom-templates.inc.twig', {slotName: 'landing-end', showPlaceholder: true}) }}
+  </div>
 </div>
 
 <div id="landing-bottom-slot">


### PR DESCRIPTION
## Reasons for creating this PR

The hardcoded Bootstrap column layout on the landing page was causing accessibility problems for mobile and screen reader users (#1976). The DOM structure didn't match logical reading order in the way Finto was set up. The logical reading order is 1. welcome-box 2. vocabulary-list 3. news-box, but the DOM order was 1. vocabulary-list 2. welcome-box 3. news-box. The welcome and news boxes were both placed in the custom template slot `landing-end`.

This PR simplifies the landing page structure and removes Bootstrap column formatting. The DIV structure is now as follows:

- div#landing-top
  - div#landing-top-slot (with custom templates from `landing-top`)
- div#landing-main
  - div#landing-start-slot (with custom templates from `landing-start`; in Finto, `welcome-box` goes here)
  - div#vocabulary-list (vocabulary list rendered by Skosmos itself)
  - div#landing-end-slot (with custom templates from `landing-end`; in Finto, `news-box` goes here)
- div#landing-bottom-slot (with custom templates from `landing-bottom`)

## How to test

In Finto custom CSS, use these CSS Grid rules to render the two-column layout on wider screens:

```
@media (min-width: 992px) {
  #landing-main {
    display: grid;
    grid-template-columns: 7fr 5fr;
    grid-auto-rows: min-content 1fr;
    column-gap: 2rem;
  }

  #vocabulary-list {
    grid-row: 1 / 3;
    grid-column: 1;
  }

  #landing-start-slot {
    grid-row: 1;
    grid-column: 2;
  }

  #landing-end-slot {
    grid-row: 2;
    grid-column: 2;
  }
}
```

In addition, the `welcome-box` twig template needs to be moved from `landing-end` to `landing-start` under `custom-templates`.

The end result looks like this on a wide screen, i.e. pretty much the same as before:

<img width="1920" height="958" alt="image" src="https://github.com/user-attachments/assets/4b7cc791-dc87-4cf3-97da-a3d3ce38ae35" />

On a narrow screen, the welcome box comes above the vocabulary list and the newsfeed after.

## Link to relevant issue(s), if any

- Closes #1976

## Description of the changes in this PR

* remove Bootstrap column classes from landing page divs
* add new `landing-main` wrapper div
* move the `landing-start-slot` and `landing-end-slot` around a little bit
* show the placeholder message for `landing-start-slot` and not `landing-end-slot` because it is more logical and visible there

## Known problems or uncertainties in this PR

The narrow/mobile view is probably still not optimal.

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
