### PR TITLE
Fix navigating session history on concept pages

### DIFF
--- a/resource/js/partial-page-load.js
+++ b/resource/js/partial-page-load.js
@@ -89,7 +89,7 @@ const moveFocus = () => {
 
 /* eslint-disable no-unused-vars */
 const partialPageLoad = (event, pageUri) => {
-  event.preventDefault()
+  event.type != 'popstate' && event.preventDefault()
 
   // fetching html content of the concept page
   fetchWithAbort(pageUri, 'concept')
@@ -97,9 +97,9 @@ const partialPageLoad = (event, pageUri) => {
       return data.text()
     })
     .then(data => {
-      // updating url and history
-      if (window.history.pushState) { window.history.pushState({ url: pageUri }, '', pageUri) }
-
+      // updating url and history when clicking on concept links
+      if (event.type != 'popstate' && window.history.pushState) { window.history.pushState({ url: pageUri }, '', pageUri) }
+      
       // removing disabled class from hierarchy tab
       if (document.querySelector('#hierarchy > a')) {
         document.querySelector('#hierarchy').classList.remove('disabled')
@@ -118,8 +118,8 @@ const partialPageLoad = (event, pageUri) => {
       moveFocus()
 
       // custom event to signal that a new concept page was loaded
-      const event = new Event('loadConceptPage')
-      document.dispatchEvent(event)
+      const e = new Event('loadConceptPage')
+      document.dispatchEvent(e)
     })
     .catch(error => {
       if (error.name !== 'AbortError') {
@@ -128,3 +128,17 @@ const partialPageLoad = (event, pageUri) => {
     })
 }
 /* eslint-disable no-unused-vars */
+
+// Event listener for handling browser's back and forward navigation
+window.addEventListener("popstate", (e) => {
+  // Do a partial page load when moving to a concept page, otherwise load new page fully
+  if (window.location.href.includes(`${window.SKOSMOS.vocab}/${window.SKOSMOS.lang}/page/`)) {
+    if (e.state && e.state.url) {
+      partialPageLoad(e, e.state.url)
+    } else {
+      partialPageLoad(e, window.location.href)
+    }
+  } else {
+    open(window.location.href, '_self')
+  }
+})

--- a/resource/js/partial-page-load.js
+++ b/resource/js/partial-page-load.js
@@ -133,7 +133,7 @@ const partialPageLoad = (event, pageUri) => {
 window.addEventListener('popstate', (e) => {
   // Do a partial page load when moving to a concept page, otherwise load new page fully
   if (window.location.href.includes(`${window.SKOSMOS.vocab}/${window.SKOSMOS.lang}/page/`)) {
-    if (e.state && e.state.url) {
+    if (e.state?.url) {
       partialPageLoad(e, e.state.url)
     } else {
       partialPageLoad(e, window.location.href)

--- a/resource/js/partial-page-load.js
+++ b/resource/js/partial-page-load.js
@@ -139,6 +139,6 @@ window.addEventListener('popstate', (e) => {
       partialPageLoad(e, window.location.href)
     }
   } else {
-    window.open(window.location.href, '_self')
+    window.location.reload()
   }
 })

--- a/resource/js/partial-page-load.js
+++ b/resource/js/partial-page-load.js
@@ -89,7 +89,7 @@ const moveFocus = () => {
 
 /* eslint-disable no-unused-vars */
 const partialPageLoad = (event, pageUri) => {
-  event.type != 'popstate' && event.preventDefault()
+  event.type !== 'popstate' && event.preventDefault()
 
   // fetching html content of the concept page
   fetchWithAbort(pageUri, 'concept')
@@ -98,8 +98,8 @@ const partialPageLoad = (event, pageUri) => {
     })
     .then(data => {
       // updating url and history when clicking on concept links
-      if (event.type != 'popstate' && window.history.pushState) { window.history.pushState({ url: pageUri }, '', pageUri) }
-      
+      if (event.type !== 'popstate' && window.history.pushState) { window.history.pushState({ url: pageUri }, '', pageUri) }
+
       // removing disabled class from hierarchy tab
       if (document.querySelector('#hierarchy > a')) {
         document.querySelector('#hierarchy').classList.remove('disabled')
@@ -130,7 +130,7 @@ const partialPageLoad = (event, pageUri) => {
 /* eslint-disable no-unused-vars */
 
 // Event listener for handling browser's back and forward navigation
-window.addEventListener("popstate", (e) => {
+window.addEventListener('popstate', (e) => {
   // Do a partial page load when moving to a concept page, otherwise load new page fully
   if (window.location.href.includes(`${window.SKOSMOS.vocab}/${window.SKOSMOS.lang}/page/`)) {
     if (e.state && e.state.url) {
@@ -139,6 +139,6 @@ window.addEventListener("popstate", (e) => {
       partialPageLoad(e, window.location.href)
     }
   } else {
-    open(window.location.href, '_self')
+    window.open(window.location.href, '_self')
   }
 })

--- a/resource/js/tab-alpha.js
+++ b/resource/js/tab-alpha.js
@@ -154,7 +154,12 @@ function startAlphaApp () {
       }
     },
     template: `
-      <div v-click-tab-alphabetical="handleClickAlphabeticalEvent" v-click-collapse-btn="setListStyle" v-resize-window="setListStyle">
+      <div
+        v-click-tab-alphabetical="handleClickAlphabeticalEvent"
+        v-click-collapse-btn="setListStyle"
+        v-resize-window="setListStyle"
+        v-window-popstate="() => selectedConcept = ''"
+      >
         <tab-alpha
           :index-letters="indexLetters"
           :index-concepts="indexConcepts"
@@ -212,6 +217,19 @@ function startAlphaApp () {
     },
     unmounted: el => {
       window.removeEventListener('resize', el.resizeWindowEvent)
+    }
+  })
+
+  /* Custom directive used to add an event listener on popstate events */
+  tabAlphaApp.directive('window-popstate', {
+    beforeMount: (el, binding) => {
+      el.windowPopstateEvent = event => {
+        binding.value() // calling the method given as the attribute value
+      }
+      window.addEventListener('popstate', el.windowPopstateEvent) // registering an event listener on popstate events
+    },
+    unmounted: el => {
+      window.removeEventListener('popstate', el.windowPopstateEvent)
     }
   })
 

--- a/resource/js/tab-changes.js
+++ b/resource/js/tab-changes.js
@@ -134,7 +134,12 @@ function startChangesApp () {
       }
     },
     template: `
-      <div v-click-tab-changes="handleClickChangesEvent" v-click-collapse-btn="setListStyle" v-resize-window="setListStyle">
+      <div
+        v-click-tab-changes="handleClickChangesEvent"
+        v-click-collapse-btn="setListStyle"
+        v-resize-window="setListStyle"
+        v-window-popstate="() => selectedConcept = ''"
+      >
         <tab-changes
           :changed-concepts="changedConcepts"
           :selected-concept="selectedConcept"
@@ -186,6 +191,19 @@ function startChangesApp () {
     },
     unmounted: el => {
       window.removeEventListener('resize', el.resizeWindowEvent)
+    }
+  })
+
+  /* Custom directive used to add an event listener on popstate events */
+  tabChangesApp.directive('window-popstate', {
+    beforeMount: (el, binding) => {
+      el.windowPopstateEvent = event => {
+        binding.value() // calling the method given as the attribute value
+      }
+      window.addEventListener('popstate', el.windowPopstateEvent) // registering an event listener on popstate events
+    },
+    unmounted: el => {
+      window.removeEventListener('popstate', el.windowPopstateEvent)
     }
   })
 

--- a/resource/js/tab-groups.js
+++ b/resource/js/tab-groups.js
@@ -212,7 +212,12 @@ function startGroupsApp () {
       }
     },
     template: `
-      <div v-click-tab-groups="handleClickGroupsEvent" v-click-collapse-btn="setListStyle" v-resize-window="setListStyle">
+      <div
+        v-click-tab-groups="handleClickGroupsEvent"
+        v-click-collapse-btn="setListStyle" 
+        v-resize-window="setListStyle"
+        v-window-popstate="() => selectedGroup = ''"
+      >
         <div id="groups-list" class="sidebar-list p-0" tabindex="-1" :style="listStyle">
           <ul v-if="!loadingGroups" aria-labelledby="groups" role="tree" class="list-group">
             <tab-groups-wrapper
@@ -267,6 +272,19 @@ function startGroupsApp () {
     },
     unmounted: el => {
       window.removeEventListener('resize', el.resizeWindowEvent)
+    }
+  })
+
+  /* Custom directive used to add an event listener on popstate events */
+  tabGroupsApp.directive('window-popstate', {
+    beforeMount: (el, binding) => {
+      el.windowPopstateEvent = event => {
+        binding.value() // calling the method given as the attribute value
+      }
+      window.addEventListener('popstate', el.windowPopstateEvent) // registering an event listener on popstate events
+    },
+    unmounted: el => {
+      window.removeEventListener('popstate', el.windowPopstateEvent)
     }
   })
 

--- a/resource/js/tab-hierarchy.js
+++ b/resource/js/tab-hierarchy.js
@@ -367,7 +367,12 @@ function startHierarchyApp () {
       }
     },
     template: `
-      <div v-click-tab-hierarchy="handleClickHierarchyEvent" v-click-collapse-btn="setListStyle" v-resize-window="setListStyle">
+      <div
+        v-click-tab-hierarchy="handleClickHierarchyEvent"
+        v-click-collapse-btn="setListStyle"
+        v-resize-window="setListStyle"
+        v-window-popstate="() => selectedConcept = ''"
+      >
         <div id="hierarchy-list" class="sidebar-list p-0" tabindex="-1" :style="listStyle">
           <ul class="list-group" aria-labelledby="hierarchy" role="tree" v-if="!loadingHierarchy">
             <tab-hier-wrapper
@@ -424,6 +429,19 @@ function startHierarchyApp () {
     },
     unmounted: el => {
       window.removeEventListener('resize', el.resizeWindowEvent)
+    }
+  })
+
+  /* Custom directive used to add an event listener on popstate events */
+  tabHierApp.directive('window-popstate', {
+    beforeMount: (el, binding) => {
+      el.windowPopstateEvent = event => {
+        binding.value() // calling the method given as the attribute value
+      }
+      window.addEventListener('popstate', el.windowPopstateEvent) // registering an event listener on popstate events
+    },
+    unmounted: el => {
+      window.removeEventListener('popstate', el.windowPopstateEvent)
     }
   })
 

--- a/tests/cypress/template/concept.cy.js
+++ b/tests/cypress/template/concept.cy.js
@@ -430,4 +430,30 @@ describe('Concept page', () => {
         })
       })
   })
+  it('handles navigating back and forward in browser\'s history', () => {
+    // Go to YSO home page
+    cy.visit('/yso/en/')
+    // Click on the link to "abstract objects" to trigger partial page load
+    cy.get('#tab-alphabetical').contains('a', 'abstract objects').click()
+    // Check that partial page load was successful
+    cy.get('#concept-heading h1', {timeout: 10000}).should('contain', 'abstract objects')
+    // Click on the link to "acid" to trigger partial page load
+    cy.get('#tab-alphabetical').contains('a', 'acids').click()
+    // Check that partial page load was successful
+    cy.get('#concept-heading h1', {timeout: 10000}).should('contain', 'acids')
+    // Trigger browser's back button
+    cy.go('back')
+    // Check that partial page load was successful
+    cy.get('#concept-heading h1', {timeout: 10000}).should('contain', 'abstract objects')
+    // Check that selected concept highlight is removed from alphabetical list
+    cy.get('#tab-alphabetical .sidebar-list .selected').should('not.exist')
+    // Trigger browser's forward button
+    cy.go('forward')
+    // Check that partial page load was successful
+    cy.get('#concept-heading h1', {timeout: 10000}).should('contain', 'acids')
+    // Go back two pages in history
+    cy.go(-2)
+    // Check that vocab home page is loaded
+    cy.get('#vocab-heading', {timeout: 10000}).should('exist')
+  })
 })


### PR DESCRIPTION
## Reasons for creating this PR

Clicking on browser's back and forward buttons currently does nothing on concept pages. This PR adds functionality to move between concept pages using the buttons.

## Description of the changes in this PR

- Add event listener to partial-page-load.js that listens to popstate events originating from browser's history navigation
  - Perform a partial page load when moving to a concept page
  - Load the new page fully when moving to any other type of page
- Add event listeners for popstate events to sidebar Vue components to remove selected concept highlighting
- Add cypress tests for navigating in history

## Known problems or uncertainties in this PR

I'm not sure if `${window.SKOSMOS.vocab}/${window.SKOSMOS.lang}/page/` (used to detect if the page being opened is a concept page) will work with all concepts/vocabs possible in Skosmos.

Highlighting for selected concept in sidebar is now removed when navigating between pages. Skosmos 2 works this way as well so no regression is introduced but ideally highlight should move as well.

## Checklist

- [ ] phpUnit tests pass locally with my changes
- [ ] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [ ] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [ ] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
