### PR TITLE
Fix flaky cypress search page tests: 

### DIFF
--- a/tests/cypress/template/global-search-page.cy.js
+++ b/tests/cypress/template/global-search-page.cy.js
@@ -57,6 +57,13 @@ describe('Global search page', () => {
     cy.visit(`/en/search?clang=en&q=g&vocabs=yso`)
     // Check that there are 5 search results
     cy.get('#search-results').find('.search-result').should('have.length', 5)
+    // The scroll handler attaches via onTranslationReady(), which runs after the
+    // async translation fetch resolves. Wait for translations to be ready first so
+    // the listener is attached before we scroll; otherwise scrollTo happens with no
+    // listener present and never dispatches a 'scroll' event, so no request fires.
+    cy.window().then(win => new Promise(resolve => {
+      win.onTranslationReady(() => resolve())
+    }))
     // Scroll to bottom of page
     cy.scrollTo('bottom')
     // Check that there are 9 search results

--- a/tests/cypress/template/vocab-search-page.cy.js
+++ b/tests/cypress/template/vocab-search-page.cy.js
@@ -74,6 +74,14 @@ describe('Vocabulary search page', () => {
     // Listen to the API call
     cy.intercept('GET', '/yso/en/search?clang=en&q=an*').as('search')
 
+    // The scroll handler attaches via onTranslationReady(), which runs after the
+    // async translation fetch resolves. Wait for translations to be ready first so
+    // the listener is attached before we scroll; otherwise scrollTo happens with no
+    // listener present and never dispatches a 'scroll' event, so no request fires.
+    cy.window().then(win => new Promise(resolve => {
+      win.onTranslationReady(() => resolve())
+    }))
+
     cy.scrollTo('bottom')
 
     // Wait for the API call to finish


### PR DESCRIPTION
## Reasons for creating this PR

The Cypress tests in vocab-search-page.cy.js that checks for "More results are loaded on scroll" was flaky and failing often especially under CI. This PR fixes a race condition in the test: now the test waits for translations to be initialized before scrolling. The similar test global-search-page.cy.js is also fixed in the same way although it is written in a different way so is not as sensitive to this flakiness.

Root cause analysis by my AI agent (Zoo Code with Tiel-Coder-35B-A3B): 

> A test-side timing race in vocab-search-page.cy.js. The scroll handler attaches only inside an onTranslationReady() callback, which fires after the async translation fetch resolves. cy.scrollTo('bottom') ran unconditionally right after cy.visit, before translations loaded — so it scrolled with no listener attached, dispatched no 'scroll' event, and never issued the search request → 20s timeout.

## Link to relevant issue(s), if any

- n/a

## Description of the changes in this PR

* wait for translation service to be initialized before scrolling in vocab-search-page.cy.js and global-search-page.cy.js

## Known problems or uncertainties in this PR

:crossed_fingers: I hope it actually works. I have run the tests many times locally and twice under CI without failures.

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
