### PR TITLE
Fix PluginRegister callback handling when there are none or multiple callbacks per plugin

### DIFF
--- a/src/model/PluginRegister.php
+++ b/src/model/PluginRegister.php
@@ -74,13 +74,14 @@ class PluginRegister
     /**
      * Returns the plugin configurations found from plugin folders
      * inside the plugins folder filtered by plugin name (the folder name).
-     * @param string $type filetype e.g. 'css' or 'js'
+     * @param string $type filetype e.g. 'css', 'js', or 'callback'
      * @param array $names the plugin name strings (foldernames) in an array
+     * @param bool $raw if true, returns raw values without prefixing file paths
      * @return array
      */
-    private function filterPluginsByName($type, $names)
+    private function filterPluginsByName($type, $names, $raw = false)
     {
-        $files = $this->filterPlugins($type);
+        $files = $this->filterPlugins($type, $raw);
         foreach ($files as $plugin => $filelist) {
             if (!in_array($plugin, $names)) {
                 unset($files[$plugin]);
@@ -126,9 +127,9 @@ class PluginRegister
     {
         if ($names) {
             $names = array_merge($this->requestedPlugins, $names);
-            return $this->filterPluginsByName('callback', $names);
+            return $this->filterPluginsByName('callback', $names, true);
         }
-        return $this->filterPluginsByName('callback', $this->requestedPlugins);
+        return $this->filterPluginsByName('callback', $this->requestedPlugins, true);
     }
 
     /**
@@ -139,17 +140,14 @@ class PluginRegister
     public function getCallbacks()
     {
         $ret = array();
-        $sortedCallbacks = array();
         $plugins = $this->getPluginCallbacks($this->requestedPlugins);
-        foreach ($plugins as $callbacks) {
-            foreach ($callbacks as $callback) {
-                $split = explode('/', $callback);
-                $sortedCallbacks[$split[1]] = $split[2];
+        // Collect callbacks in plugin order, preserving all callbacks per plugin
+        foreach ($this->requestedPlugins as $pluginName) {
+            if (isset($plugins[$pluginName])) {
+                foreach ($plugins[$pluginName] as $callback) {
+                    $ret[] = $callback;
+                }
             }
-        }
-        $sortedCallbacks = array_replace($this->pluginOrder, $sortedCallbacks);
-        foreach ($sortedCallbacks as $callback) {
-            $ret[] = $callback;
         }
         return $ret;
     }

--- a/tests/PluginRegisterTest.php
+++ b/tests/PluginRegisterTest.php
@@ -26,11 +26,11 @@ class PluginRegisterTest extends PHPUnit\Framework\TestCase
                             ),
                             'test-plugin1' => array( 'js' => array( 0 => 'plugin1.js', 1 => 'second.min.js'),
                                                      'css' => array( 0 => 'stylesheet.css', ),
-                                                     'callback' => array( 0 => 'callplugin1')
+                                                     'callback' => array( 0 => 'callplugin1', 1 => 'secondplugin')  // multiple callbacks to test overwrite bug
                             ),
                             'test-plugin2' => array( 'js' => array( 0 => 'plugin2.js', ),
-                                                     'css' => array( 0 => 'stylesheet.css', ),
-                                                     'callback' => array( 0 => 'callplugin2')
+                                                     'css' => array( 0 => 'stylesheet.css', )
+                                                     // NO callback entry to test numeric index leak bug
                             ),
                             'test-plugin3' => array( 'js' => array( 0 => 'plugin3.js', ),
                                                      'css' => array( 0 => 'stylesheet.css', ),
@@ -151,10 +151,13 @@ class PluginRegisterTest extends PHPUnit\Framework\TestCase
     public function testGetPluginCallbacks()
     {
         $plugins = new PluginRegister();
+        // test-plugin1 now has TWO callbacks - verify both are returned
         $this->assertEquals(
-            array('plugins/test-plugin1/callplugin1'),
+            array('plugins/test-plugin1/callplugin1', 'plugins/test-plugin1/secondplugin'),
             $this->mockpr->getPluginCallbacks()['test-plugin1']
         );
+        // test-plugin2 has NO callback entry - should be absent from results
+        $this->assertArrayNotHasKey('test-plugin2', $this->mockpr->getPluginCallbacks());
     }
 
     /**
@@ -162,10 +165,37 @@ class PluginRegisterTest extends PHPUnit\Framework\TestCase
      */
     public function testGetCallbacks()
     {
+        // test-plugin2 has NO callback entry, so it should NOT appear in callbacks
+        // test-plugin1 has TWO callbacks, both should be preserved
         $this->assertEquals(
-            array('callplugin2', 'bravo', 'imaginaryPlugin', 'callplugin1', 'alpha', 'charlie', 'callplugin3'),
+            array('bravo', 'imaginaryPlugin', 'callplugin1', 'secondplugin', 'alpha', 'charlie', 'callplugin3'),
             $this->mockpr->getCallbacks()
         );
+    }
+
+    /**
+     * @covers PluginRegister::getCallbacks
+     * Tests that multiple callbacks per plugin are all preserved, not overwritten
+     */
+    public function testGetCallbacksMultiplePerPlugin()
+    {
+        // Verify that test-plugin1's second callback 'secondplugin' is included
+        $callbacks = $this->mockpr->getCallbacks();
+        $this->assertContains('callplugin1', $callbacks, 'First callback for test-plugin1 should be present');
+        $this->assertContains('secondplugin', $callbacks, 'Second callback for test-plugin1 should be present (not overwritten)');
+    }
+
+    /**
+     * @covers PluginRegister::getCallbacks
+     * Tests that plugins without callback entry don't cause numeric indices to leak
+     */
+    public function testGetCallbacksNoNumericLeak()
+    {
+        $callbacks = $this->mockpr->getCallbacks();
+        // Verify no numeric values leak into the result
+        foreach ($callbacks as $callback) {
+            $this->assertIsString($callback, "Callback value should be a string, got: " . var_export($callback, true));
+        }
     }
 
 }

--- a/tests/PluginRegisterTest.php
+++ b/tests/PluginRegisterTest.php
@@ -153,7 +153,7 @@ class PluginRegisterTest extends PHPUnit\Framework\TestCase
         $plugins = new PluginRegister();
         // test-plugin1 now has TWO callbacks - verify both are returned
         $this->assertEquals(
-            array('plugins/test-plugin1/callplugin1', 'plugins/test-plugin1/secondplugin'),
+            array('callplugin1', 'secondplugin'),
             $this->mockpr->getPluginCallbacks()['test-plugin1']
         );
         // test-plugin2 has NO callback entry - should be absent from results


### PR DESCRIPTION
## Reasons for creating this PR

The newly updated `finaf` plugin didn't work properly. It registers two callbacks (one to handle the identifiers and another to create a widget with bibliographic titles related to the person/organization) and only one of them was called by Skosmos. I traced the bug to PluginRegister, which didn't properly handle cases when a plugin defined either zero callbacks or more than one callback. If there were >1 callbacks per plugin, it would leave just one and drop the others. It could also return numbers instead of callback function names.

Analysis from the AI agent:

>The PluginRegister::getCallbacks() method had three compounding bugs:
>
>Wrong data format: Callbacks were treated as file paths. The filterPlugins() method prefixed them with plugins/{pluginName}/, so a callback like callplugin1 became plugins/test-plugin1/callplugin1.
>
>Key collision (overwrite): The code used explode('/', $callback) and stored $split[2] (the function name) keyed by $split[1] (the plugin name). When a plugin had multiple callbacks, each one overwrote the previous — only the last one survived.
>
>Numeric index leak: The code used array_replace($this->pluginOrder, $sortedCallbacks) to maintain sort order. When a plugin had no callbacks, its numeric index (0, 1, 2...) from $this->pluginOrder leaked into the final result array instead of a function name.
>
>The fix: Pass $raw=true to skip file path prefixing, and rewrite getCallbacks() to iterate plugins in order and collect all their callbacks directly without using string splitting or associative array keying.


After this fix, both finaf callbacks are called:

<img width="947" height="1237" alt="image" src="https://github.com/user-attachments/assets/a664bbf8-c100-4a84-973d-4335c2d22c06" />

## Link to relevant issue(s), if any

- n/a

## Description of the changes in this PR

* fix special case handling in PluginRegister.php
* update PHPUnit tests to verify

## Known problems or uncertainties in this PR

I used an AI agent (Zoo Code with Qwen3.6-35B-A3B) to trace the bug, prepare unit tests that catch it, then implement the fix. I did my best to verify the code and I have tested that it works.

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
