### PR TITLE
Fix sidebar and hierarchy bugs

### DIFF
--- a/resource/js/partial-page-load.js
+++ b/resource/js/partial-page-load.js
@@ -117,20 +117,12 @@ const partialPageLoad = (event, pageUri) => {
         if (window.SKOSMOS.isGroup) { // Add disabled class if opening a group page
           document.querySelector('#hierarchy').classList.add('disabled')
           document.querySelector('#hierarchy > a').classList.add('disabled')
-
-          const setTooltip = () => {
+          onTranslationReady(() => {
             // Prevent a race condition
-            if (!document.querySelector('#hierarchy').classList.contains('disabled')) return
-
-            document.querySelector('#hierarchy').dataset.title = $t('hierarchy-disabled-help')
-          }
-
-          // Add tooltip text
-          if (typeof $t !== 'undefined') {
-            document.querySelector('#hierarchy').dataset.title = $t('hierarchy-disabled-help')
-          } else {
-            onTranslationReady(setTooltip)
-          }
+            if (document.querySelector('#hierarchy').classList.contains('disabled')) {
+              document.querySelector('#hierarchy').dataset.title = $t('hierarchy-disabled-help')
+            }
+          })
         } else { // Otherwise remove disabled class and tooltip text
           document.querySelector('#hierarchy').classList.remove('disabled')
           document.querySelector('#hierarchy > a').classList.remove('disabled')

--- a/resource/js/partial-page-load.js
+++ b/resource/js/partial-page-load.js
@@ -130,14 +130,12 @@ const partialPageLoad = (event, pageUri) => {
             document.querySelector('#hierarchy').setAttribute('data-title', $t('hierarchy-disabled-help'))
           } else {
             onTranslationReady(setTooltip)
-          }
-          
-        } else { // Otherwise remove disabled class and tooltip text
+          }  
+        } else {// Otherwise remove disabled class and tooltip text
           document.querySelector('#hierarchy').classList.remove('disabled')
           document.querySelector('#hierarchy > a').classList.remove('disabled')
           document.querySelector('#hierarchy').removeAttribute('data-title')
         }
-        
       }
 
       // custom event to signal that a new concept page was loaded

--- a/resource/js/partial-page-load.js
+++ b/resource/js/partial-page-load.js
@@ -122,19 +122,19 @@ const partialPageLoad = (event, pageUri) => {
             // Prevent a race condition
             if (!document.querySelector('#hierarchy').classList.contains('disabled')) return
 
-            document.querySelector('#hierarchy').setAttribute('data-title', $t('hierarchy-disabled-help'))
+            document.querySelector('#hierarchy').dataset.title = $t('hierarchy-disabled-help')
           }
 
           // Add tooltip text
           if (typeof $t !== 'undefined') {
-            document.querySelector('#hierarchy').setAttribute('data-title', $t('hierarchy-disabled-help'))
+            document.querySelector('#hierarchy').dataset.title = $t('hierarchy-disabled-help')
           } else {
             onTranslationReady(setTooltip)
           }
         } else { // Otherwise remove disabled class and tooltip text
           document.querySelector('#hierarchy').classList.remove('disabled')
           document.querySelector('#hierarchy > a').classList.remove('disabled')
-          document.querySelector('#hierarchy').removeAttribute('data-title')
+          delete document.querySelector('#hierarchy').dataset.title
         }
       }
 

--- a/resource/js/partial-page-load.js
+++ b/resource/js/partial-page-load.js
@@ -130,8 +130,8 @@ const partialPageLoad = (event, pageUri) => {
             document.querySelector('#hierarchy').setAttribute('data-title', $t('hierarchy-disabled-help'))
           } else {
             onTranslationReady(setTooltip)
-          }  
-        } else {// Otherwise remove disabled class and tooltip text
+          }
+        } else { // Otherwise remove disabled class and tooltip text
           document.querySelector('#hierarchy').classList.remove('disabled')
           document.querySelector('#hierarchy > a').classList.remove('disabled')
           document.querySelector('#hierarchy').removeAttribute('data-title')

--- a/resource/js/partial-page-load.js
+++ b/resource/js/partial-page-load.js
@@ -1,3 +1,5 @@
+/* global $t, onTranslationReady */
+
 const fetchWithAbort = (function () {
   const controllers = {}
 
@@ -87,7 +89,6 @@ const moveFocus = () => {
   document.getElementById('concept-preflabel').focus()
 }
 
-/* eslint-disable no-unused-vars */
 const partialPageLoad = (event, pageUri) => {
   event.type !== 'popstate' && event.preventDefault()
 
@@ -100,12 +101,6 @@ const partialPageLoad = (event, pageUri) => {
       // updating url and history when clicking on concept links
       if (event.type !== 'popstate' && window.history.pushState) { window.history.pushState({ url: pageUri }, '', pageUri) }
 
-      // removing disabled class from hierarchy tab
-      if (document.querySelector('#hierarchy > a')) {
-        document.querySelector('#hierarchy').classList.remove('disabled')
-        document.querySelector('#hierarchy > a').classList.remove('disabled')
-      }
-
       // concept page HTML
       const conceptHTML = document.createElement('div')
       conceptHTML.innerHTML = data.trim()
@@ -117,6 +112,34 @@ const partialPageLoad = (event, pageUri) => {
       updateSKOSMOS(conceptHTML)
       moveFocus()
 
+      // removing/adding disabled class from hierarchy tab
+      if (document.querySelector('#hierarchy > a')) {
+        if (window.SKOSMOS.isGroup) { // Add disabled class if opening a group page
+          document.querySelector('#hierarchy').classList.add('disabled')
+          document.querySelector('#hierarchy > a').classList.add('disabled')
+
+          const setTooltip = () => {
+            // Prevent a race condition
+            if (!document.querySelector('#hierarchy').classList.contains('disabled')) return
+
+            document.querySelector('#hierarchy').setAttribute('data-title', $t('hierarchy-disabled-help'))
+          }
+
+          // Add tooltip text
+          if (typeof $t !== 'undefined') {
+            document.querySelector('#hierarchy').setAttribute('data-title', $t('hierarchy-disabled-help'))
+          } else {
+            onTranslationReady(setTooltip)
+          }
+          
+        } else { // Otherwise remove disabled class and tooltip text
+          document.querySelector('#hierarchy').classList.remove('disabled')
+          document.querySelector('#hierarchy > a').classList.remove('disabled')
+          document.querySelector('#hierarchy').removeAttribute('data-title')
+        }
+        
+      }
+
       // custom event to signal that a new concept page was loaded
       const e = new Event('loadConceptPage')
       document.dispatchEvent(e)
@@ -127,7 +150,6 @@ const partialPageLoad = (event, pageUri) => {
       }
     })
 }
-/* eslint-disable no-unused-vars */
 
 // Event listener for handling browser's back and forward navigation
 window.addEventListener('popstate', (e) => {

--- a/resource/js/tab-hierarchy.js
+++ b/resource/js/tab-hierarchy.js
@@ -51,42 +51,50 @@ function startHierarchyApp () {
           this.loadTopConcepts()
         }
       },
-      loadTopConcepts () {
+      async loadTopConcepts () {
         this.loadingHierarchy = true
         if (window.SKOSMOS.showConceptSchemesInHierarchy) {
           // if concept schemes are shown in hierarchy, fetch them from API and set them as top concepts in hierarchy
           const params = new URLSearchParams({ lang: window.SKOSMOS.content_lang })
-          fetch(`rest/v1/${window.SKOSMOS.vocab}/?${params}`)
-            .then(data => {
-              return data.json()
-            })
-            .then(data => {
-              this.hierarchy = []
-
-              for (const c of data.conceptschemes.sort((a, b) => this.compareConcepts(a, b))) {
-                this.hierarchy.push({ uri: c.uri, label: c.title || c.label, hasChildren: true, children: [], isOpen: false, notation: undefined, isScheme: true })
-              }
-
-              this.addIndicesToHierarchy()
+          try {
+            const res = await fetch(`rest/v1/${window.SKOSMOS.vocab}/?${params}`)
+            if (!res.ok) {
               this.loadingHierarchy = false
-            })
+              return
+            }
+            const data = await res.json()
+            this.hierarchy = []
+
+            for (const c of data.conceptschemes.sort((a, b) => this.compareConcepts(a, b))) {
+              this.hierarchy.push({ uri: c.uri, label: c.title || c.label, hasChildren: true, children: [], isOpen: false, notation: undefined, isScheme: true })
+            }
+
+            this.addIndicesToHierarchy()
+            this.loadingHierarchy = false
+          } catch (e) {
+            this.loadingHierarchy = false
+          }
         } else {
           // otherwise, fetch top concepts
           const params = new URLSearchParams({ lang: window.SKOSMOS.content_lang })
-          fetch(`rest/v1/${window.SKOSMOS.vocab}/topConcepts/?${params}`)
-            .then(data => {
-              return data.json()
-            })
-            .then(data => {
-              this.hierarchy = []
-
-              for (const c of data.topconcepts.sort((a, b) => this.compareConcepts(a, b))) {
-                this.hierarchy.push(this.createConceptNode(c))
-              }
-
-              this.addIndicesToHierarchy()
+          try {
+            const res = await fetch(`rest/v1/${window.SKOSMOS.vocab}/topConcepts/?${params}`)
+            if (!res.ok) {
               this.loadingHierarchy = false
-            })
+              return
+            }
+            const data = await res.json()
+            this.hierarchy = []
+
+            for (const c of data.topconcepts.sort((a, b) => this.compareConcepts(a, b))) {
+              this.hierarchy.push(this.createConceptNode(c))
+            }
+
+            this.addIndicesToHierarchy()
+            this.loadingHierarchy = false
+          } catch (e) {
+            this.loadingHierarchy = false
+          }
         }
       },
       async loadConceptHierarchy () {
@@ -156,12 +164,20 @@ function startHierarchyApp () {
       },
       async loadConceptSchemes () {
         const params = new URLSearchParams({ lang: window.SKOSMOS.content_lang })
-        const res = await fetch(`rest/v1/${window.SKOSMOS.vocab}/?${params}`)
-        const data = await res.json()
+        try {
+          const res = await fetch(`rest/v1/${window.SKOSMOS.vocab}/?${params}`)
+          if (!res.ok) {
+            this.loadingHierarchy = false
+            return
+          }
+          const data = await res.json()
 
-        for (const s of data.conceptschemes.sort((a, b) => this.compareConcepts(a, b))) {
-          const schemeNode = { uri: s.uri, label: s.title || s.label, hasChildren: true, children: [], isOpen: s.uri === window.SKOSMOS.uri, notation: undefined, isScheme: true }
-          this.hierarchy.push(schemeNode)
+          for (const s of data.conceptschemes.sort((a, b) => this.compareConcepts(a, b))) {
+            const schemeNode = { uri: s.uri, label: s.title || s.label, hasChildren: true, children: [], isOpen: s.uri === window.SKOSMOS.uri, notation: undefined, isScheme: true }
+            this.hierarchy.push(schemeNode)
+          }
+        } catch (e) {
+          this.loadingHierarchy = false
         }
       },
       async loadTopConceptsForConceptScheme () {
@@ -169,41 +185,57 @@ function startHierarchyApp () {
           scheme: window.SKOSMOS.uri,
           lang: window.SKOSMOS.content_lang
         })
-        const res = await fetch(`rest/v1/${window.SKOSMOS.vocab}/topConcepts?${params}`)
-        const data = await res.json()
+        try {
+          const res = await fetch(`rest/v1/${window.SKOSMOS.vocab}/topConcepts?${params}`)
+          if (!res.ok) {
+            this.loadingHierarchy = false
+            return
+          }
+          const data = await res.json()
 
-        // find selected scheme in hierarchy
-        const scheme = this.hierarchy.find(s => s.uri === window.SKOSMOS.uri)
-        // add top concepts to hierarchy as the scheme's children
-        scheme.children = data.topconcepts
-          .sort((a, b) => this.compareConcepts(a, b))
-          .map(c => this.createConceptNode(c))
+          // find selected scheme in hierarchy
+          const scheme = this.hierarchy.find(s => s.uri === window.SKOSMOS.uri)
+          // add top concepts to hierarchy as the scheme's children
+          scheme.children = data.topconcepts
+            .sort((a, b) => this.compareConcepts(a, b))
+            .map(c => this.createConceptNode(c))
+        } catch (e) {
+          this.loadingHierarchy = false
+        }
       },
       async loadHierarchyForConcept () {
         const params = new URLSearchParams({
           uri: window.SKOSMOS.uri,
           lang: window.SKOSMOS.content_lang
         })
-        const res = await fetch(`rest/v1/${window.SKOSMOS.vocab}/hierarchy/?${params}`)
-        const data = await res.json()
-
-        // transform broaderTransitive to an array and sort it
-        const bt = Object.values(data.broaderTransitive).sort((a, b) => this.compareConcepts(a, b))
-        const parents = [] // queue of nodes in hierarchy tree with potential missing child nodes
-
-        // add top concepts to hierarchy tree
-        for (const concept of bt) {
-          if (concept.top || !concept.broader) {
-            this.addTopConceptsToHierarchy(concept, parents)
+        try {
+          const res = await fetch(`rest/v1/${window.SKOSMOS.vocab}/hierarchy/?${params}`)
+          if (!res.ok) {
+            this.loadingHierarchy = false
+            return
           }
-        }
+          const data = await res.json()
+        
+          // transform broaderTransitive to an array and sort it
+          const bt = Object.values(data.broaderTransitive).sort((a, b) => this.compareConcepts(a, b))
+          const parents = [] // queue of nodes in hierarchy tree with potential missing child nodes
 
-        // add other concepts to hierarchy tree
-        this.addChildConceptsToHierarchy(bt, parents)
+          // add top concepts to hierarchy tree
+          for (const concept of bt) {
+            if (concept.top || !concept.broader) {
+              this.addTopConceptsToHierarchy(concept, parents)
+            }
+          }
 
-        // if concept schemes are in shown hierarchy, open the concept scheme that contains selected concept
-        if (window.SKOSMOS.showConceptSchemesInHierarchy) {
-          this.openContainingScheme()
+          // add other concepts to hierarchy tree
+          this.addChildConceptsToHierarchy(bt, parents)
+
+          // if concept schemes are in shown hierarchy, open the concept scheme that contains selected concept
+          if (window.SKOSMOS.showConceptSchemesInHierarchy) {
+            this.openContainingScheme()
+          }
+        } catch (e) {
+          this.loadingHierarchy = false
         }
       },
       addTopConceptsToHierarchy (concept, parents) {

--- a/resource/js/tab-hierarchy.js
+++ b/resource/js/tab-hierarchy.js
@@ -68,10 +68,10 @@ function startHierarchyApp () {
             for (const c of data.conceptschemes.sort((a, b) => this.compareConcepts(a, b))) {
               this.hierarchy.push({ uri: c.uri, label: c.title || c.label, hasChildren: true, children: [], isOpen: false, notation: undefined, isScheme: true })
             }
-
-            this.addIndicesToHierarchy()
-            this.loadingHierarchy = false
           } catch (e) {
+            console.error(e)
+          } finally {
+            this.addIndicesToHierarchy()
             this.loadingHierarchy = false
           }
         } else {
@@ -89,10 +89,10 @@ function startHierarchyApp () {
             for (const c of data.topconcepts.sort((a, b) => this.compareConcepts(a, b))) {
               this.hierarchy.push(this.createConceptNode(c))
             }
-
-            this.addIndicesToHierarchy()
-            this.loadingHierarchy = false
           } catch (e) {
+            console.error(e)
+          } finally {
+            this.addIndicesToHierarchy()
             this.loadingHierarchy = false
           }
         }
@@ -101,22 +101,26 @@ function startHierarchyApp () {
         this.loadingHierarchy = true
         this.hierarchy = []
 
-        // if concept schemes are shown in hierarchy, add them to the root of the hierarchy tree
-        if (window.SKOSMOS.showConceptSchemesInHierarchy) {
-          await this.loadConceptSchemes()
-        }
+        try {
+          // if concept schemes are shown in hierarchy, add them to the root of the hierarchy tree
+          if (window.SKOSMOS.showConceptSchemesInHierarchy) {
+            await this.loadConceptSchemes()
+          }
 
-        if (this.hierarchy.some(s => s.uri === window.SKOSMOS.uri)) {
-          // if we are on a page for a concept scheme, fetch its top concepts
-          await this.loadTopConceptsForConceptScheme()
-        } else {
-          // otherwise, fetch hierarchy tree for selected concept
-          await this.loadHierarchyForConcept()
+          if (this.hierarchy.some(s => s.uri === window.SKOSMOS.uri)) {
+            // if we are on a page for a concept scheme, fetch its top concepts
+            await this.loadTopConceptsForConceptScheme()
+          } else {
+            // otherwise, fetch hierarchy tree for selected concept
+            await this.loadHierarchyForConcept()
+          }
+        } catch (e) {
+          console.error(e)
+        } finally {
+          this.loadingHierarchy = false
+          this.addIndicesToHierarchy()
+          this.selectedConcept = window.SKOSMOS.uri
         }
-
-        this.loadingHierarchy = false
-        this.addIndicesToHierarchy()
-        this.selectedConcept = window.SKOSMOS.uri
       },
       loadChildren (concept) {
         // load children only if concept has children but they have not been loaded yet
@@ -164,20 +168,15 @@ function startHierarchyApp () {
       },
       async loadConceptSchemes () {
         const params = new URLSearchParams({ lang: window.SKOSMOS.content_lang })
-        try {
-          const res = await fetch(`rest/v1/${window.SKOSMOS.vocab}/?${params}`)
-          if (!res.ok) {
-            this.loadingHierarchy = false
-            return
-          }
-          const data = await res.json()
+        const res = await fetch(`rest/v1/${window.SKOSMOS.vocab}/?${params}`)
+        if (!res.ok) {
+          return
+        }
+        const data = await res.json()
 
-          for (const s of data.conceptschemes.sort((a, b) => this.compareConcepts(a, b))) {
-            const schemeNode = { uri: s.uri, label: s.title || s.label, hasChildren: true, children: [], isOpen: s.uri === window.SKOSMOS.uri, notation: undefined, isScheme: true }
-            this.hierarchy.push(schemeNode)
-          }
-        } catch (e) {
-          this.loadingHierarchy = false
+        for (const s of data.conceptschemes.sort((a, b) => this.compareConcepts(a, b))) {
+          const schemeNode = { uri: s.uri, label: s.title || s.label, hasChildren: true, children: [], isOpen: s.uri === window.SKOSMOS.uri, notation: undefined, isScheme: true }
+          this.hierarchy.push(schemeNode)
         }
       },
       async loadTopConceptsForConceptScheme () {
@@ -185,57 +184,47 @@ function startHierarchyApp () {
           scheme: window.SKOSMOS.uri,
           lang: window.SKOSMOS.content_lang
         })
-        try {
-          const res = await fetch(`rest/v1/${window.SKOSMOS.vocab}/topConcepts?${params}`)
-          if (!res.ok) {
-            this.loadingHierarchy = false
-            return
-          }
-          const data = await res.json()
-
-          // find selected scheme in hierarchy
-          const scheme = this.hierarchy.find(s => s.uri === window.SKOSMOS.uri)
-          // add top concepts to hierarchy as the scheme's children
-          scheme.children = data.topconcepts
-            .sort((a, b) => this.compareConcepts(a, b))
-            .map(c => this.createConceptNode(c))
-        } catch (e) {
-          this.loadingHierarchy = false
+        const res = await fetch(`rest/v1/${window.SKOSMOS.vocab}/topConcepts?${params}`)
+        if (!res.ok) {
+          return
         }
+        const data = await res.json()
+
+        // find selected scheme in hierarchy
+        const scheme = this.hierarchy.find(s => s.uri === window.SKOSMOS.uri)
+        // add top concepts to hierarchy as the scheme's children
+        scheme.children = data.topconcepts
+          .sort((a, b) => this.compareConcepts(a, b))
+          .map(c => this.createConceptNode(c))
       },
       async loadHierarchyForConcept () {
         const params = new URLSearchParams({
           uri: window.SKOSMOS.uri,
           lang: window.SKOSMOS.content_lang
         })
-        try {
-          const res = await fetch(`rest/v1/${window.SKOSMOS.vocab}/hierarchy/?${params}`)
-          if (!res.ok) {
-            this.loadingHierarchy = false
-            return
+        const res = await fetch(`rest/v1/${window.SKOSMOS.vocab}/hierarchy/?${params}`)
+        if (!res.ok) {
+          return
+        }
+        const data = await res.json()
+
+        // transform broaderTransitive to an array and sort it
+        const bt = Object.values(data.broaderTransitive).sort((a, b) => this.compareConcepts(a, b))
+        const parents = [] // queue of nodes in hierarchy tree with potential missing child nodes
+
+        // add top concepts to hierarchy tree
+        for (const concept of bt) {
+          if (concept.top || !concept.broader) {
+            this.addTopConceptsToHierarchy(concept, parents)
           }
-          const data = await res.json()
+        }
 
-          // transform broaderTransitive to an array and sort it
-          const bt = Object.values(data.broaderTransitive).sort((a, b) => this.compareConcepts(a, b))
-          const parents = [] // queue of nodes in hierarchy tree with potential missing child nodes
+        // add other concepts to hierarchy tree
+        this.addChildConceptsToHierarchy(bt, parents)
 
-          // add top concepts to hierarchy tree
-          for (const concept of bt) {
-            if (concept.top || !concept.broader) {
-              this.addTopConceptsToHierarchy(concept, parents)
-            }
-          }
-
-          // add other concepts to hierarchy tree
-          this.addChildConceptsToHierarchy(bt, parents)
-
-          // if concept schemes are in shown hierarchy, open the concept scheme that contains selected concept
-          if (window.SKOSMOS.showConceptSchemesInHierarchy) {
-            this.openContainingScheme()
-          }
-        } catch (e) {
-          this.loadingHierarchy = false
+        // if concept schemes are in shown hierarchy, open the concept scheme that contains selected concept
+        if (window.SKOSMOS.showConceptSchemesInHierarchy) {
+          this.openContainingScheme()
         }
       },
       addTopConceptsToHierarchy (concept, parents) {
@@ -492,7 +481,7 @@ function startHierarchyApp () {
         const list = document.querySelector('#hierarchy-list')
 
         // distances to the top of the page
-        const selectedTop = selected.getBoundingClientRect().top
+        const selectedTop = selected?.getBoundingClientRect().top
         const listTop = list.getBoundingClientRect().top
 
         // height of the visible portion of the list element

--- a/resource/js/tab-hierarchy.js
+++ b/resource/js/tab-hierarchy.js
@@ -215,7 +215,7 @@ function startHierarchyApp () {
             return
           }
           const data = await res.json()
-        
+
           // transform broaderTransitive to an array and sort it
           const bt = Object.values(data.broaderTransitive).sort((a, b) => this.compareConcepts(a, b))
           const parents = [] // queue of nodes in hierarchy tree with potential missing child nodes

--- a/src/view/scripts.inc.twig
+++ b/src/view/scripts.inc.twig
@@ -18,6 +18,7 @@ window.SKOSMOS = {
   {% if request.page == "page" and concept -%}
   "prefLabels": [{"lang": "{{ concept.label.lang }}", "label": "{{ concept.label }}"}{% for data in concept.foreignLabels %}{% for literal in data.prefLabel %}, {"lang": "{{ literal.lang }}", "label": "{{ literal.label }}"}{% endfor %}{% endfor %}],
   "uri": "{{ concept.uri }}",
+  "isGroup": {{ concept.isGroup ? "true" : "false" }},
   {% endif %}
   {%- if request.vocab ~%}
   "showNotation": {{ request.vocab.config.showNotation ? "true" : "false" }},

--- a/src/view/sidebar.inc.twig
+++ b/src/view/sidebar.inc.twig
@@ -10,18 +10,19 @@
     <div class="sidebar-buttons">
       <h2 class="visually-hidden">{{'Sidebar listing: list and traverse vocabulary contents by a criterion' | trans}}</h2>
       <ul class="nav nav-tabs-no-style nav-justified{% if vocab.config.sidebarViews | length >= 4 and vocab.config.showDeprecatedChanges %} wide{% endif %}" id="sidebar-tabs" role="tablist">
+        {# active_view is used to set initial active tab #}
+        {# On vocab page active tab is set to defaultSidebarView, on group page active tab is set to groups if it exists, otherwise active tab is set to defaultConceptSidebarView #}
+        {% set active_view = request.page == 'vocab' ? vocab.config.defaultSidebarView : (concept.isGroup and ('groups' in vocab.config.sidebarViews) ? 'groups' : vocab.config.defaultConceptSidebarView) %}
         {% for view in vocab.config.sidebarViews %}
           {% if view == 'alphabetical' %} {% set view_trans_text = (vocab.config.sidebarViews | length >= 4) ? 'A-Z' : 'Alpha-nav' %}
           {% elseif view == 'hierarchy' %} {% set view_trans_text = 'Hier-nav' %}
           {% elseif view == 'groups' %} {% set view_trans_text = 'Group-nav' %}
           {% else %} {% set view_trans_text = vocab.config.showDeprecatedChanges ? 'Changes-and-deprecations-nav' : 'Changes-nav' %}{% endif %}
-          {# active_class is used to set initial active tab and disabled_class is used to disable hierarchy tab #}
-          {# On vocab page active tab is set to defaultSidebarView, on concept page active tab is set to defaultConceptSidebarView #}
-          {% set active_class = (request.page == 'vocab' and view == vocab.config.defaultSidebarView) or (request.page == 'page' and view == vocab.config.defaultConceptSidebarView) %}
-          {# Hierarchy tab is disabled on vocab page if showTopConcepts is set to false #}
-          {% set disabled_class = request.page == 'vocab' and view == 'hierarchy' and not (vocab.config.showTopConcepts) %}
+          {# disabled_class is used to disable hierarchy tab #}
+          {# Hierarchy tab is disabled on vocab page if showTopConcepts is set to false and on group pages if groups tab exists #}
+          {% set disabled_class = (view == 'hierarchy' and request.page == 'vocab' and not vocab.config.showTopConcepts) or (view == 'hierarchy' and request.page == 'page' and concept.isGroup and 'groups' in vocab.config.sidebarViews) %}
           <li id="{{ view }}" class="nav-item{% if disabled_class %} disabled{% endif %}" {% if disabled_class %}data-title="{{ 'hierarchy-disabled-help' | trans }}"{% endif %}>
-            <a class="nav-link p-2{% if active_class %} active{% elseif disabled_class %} disabled{% endif %}" 
+            <a class="nav-link p-2{% if view == active_view %} active{% elseif disabled_class %} disabled{% endif %}" 
               role="tab" data-bs-toggle="tab" href="#tab-{{ view }}" aria-controls="tab-{{ view }}">
               {{ view_trans_text | trans }}
             </a>
@@ -33,10 +34,7 @@
 
     <div class="tab-content">
       {% for view in vocab.config.sidebarViews %}
-        {# active_class is used to set initial active tab #}
-        {# On vocab page active tab is set to defaultSidebarView, on concept page active tab is set to defaultConceptSidebarView #}
-        {% set active_class = (request.page == 'vocab' and view == vocab.config.defaultSidebarView) or (request.page == 'page' and view == vocab.config.defaultConceptSidebarView) %}
-        <div class="tab-pane{% if active_class %} active{% endif %}" id="tab-{{ view }}" role="tabpanel"></div>
+        <div class="tab-pane{% if view == active_view %} active{% endif %}" id="tab-{{ view }}" role="tabpanel"></div>
       {% endfor %}
     </div>
 

--- a/tests/cypress/template/sidebar-groups.cy.js
+++ b/tests/cypress/template/sidebar-groups.cy.js
@@ -13,6 +13,8 @@ describe('Groups tab', () => {
   it('Loads groups and expands hierarchy on group page', () => {
     // Go to "Freshwater fish" group page
     cy.visit('groups/en/page/?uri=http%3A%2F%2Fwww.skosmos.skos%2Fgroups%2Ffresh')
+    // Check that groups tab is opened
+    cy.get('#groups a').should('have.class', 'active')
     // Check that selected element is "Freshwater fish"
     cy.get('#groups-list .selected').should('have.length', 1).invoke('text').should('contain', 'Freshwater fish')
     // Check that "Freshwater fish" has 1 child "Carp"

--- a/tests/cypress/template/sidebar-hierarchy.cy.js
+++ b/tests/cypress/template/sidebar-hierarchy.cy.js
@@ -211,4 +211,23 @@ describe('Hierarchy', () => {
     cy.press(Cypress.Keyboard.Keys.SPACE)
     cy.get('#concept-heading h1', {'timeout': 15000}).invoke('text').should('equal', 'Birds')
   })
+  it('Disables and enables the hierarchy tab correctly when opening group and concept pages', () => {
+    // Go to test vocab home page
+    cy.visit('/yso/en/')
+    // Check that hierarchy tab is available and no tooltip is available
+    cy.get('#hierarchy').should('not.have.class', 'disabled')
+    cy.get('#hierarchy').should('not.have.attr', 'data-title')
+    // Open groups tab
+    cy.get('#groups').click()
+    // Click first group link
+    cy.get('#groups-list li a').eq(0).click()
+    // Check that hierarchy tab is disabled and tooltip is available
+    cy.get('#hierarchy').should('have.class', 'disabled')
+    cy.get('#hierarchy').should('have.attr', 'data-title', 'The top level hierarchy can\'t be shown in this vocabulary.')
+    // Click first concept link
+    cy.get('#groups-list li a').eq(1).click()
+    // Check that hierarchy tab is not disabled and no tooltip is available
+    cy.get('#hierarchy').should('not.have.class', 'disabled')
+    cy.get('#hierarchy').should('not.have.attr', 'data-title')
+  })
 })


### PR DESCRIPTION
## Reasons for creating this PR

There are a few bugs in the way active/disabled classes are added to sidebar tabs and how hierarchy tab is shown on different pages:

- If opening a page for a group or an array (e.g. `/mts/fi/page/m4849` or `/koko/fi/page/?uri=http%3A%2F%2Fwww.yso.fi%2Fonto%2Fyso%2Fp6386`) hierarchy tab is seemingly left loading forever because groups and arrays are not part of the hierarchy
- If clicking to a group page through the groups tab, hierarchy is enabled and the contents don't load if the tab is clicked

This PR fixes both of these issues by fixing the way hierarchy is disabled/enabled and by adding error handling to hierarchy tab so it does not load forever if no hierarchy exists. Group tab is now always opened initially on group pages if it exists and opening a group page always disables the hierarchy tab.

## Description of the changes in this PR

- Fix the way hierarchy is enabled/disabled in `partialPageLoad`
- Remove/add hierarchy tooltip text in `partialPageLoad`
- Add error handling to hierarchy tab so that it is not left loading forever if no hierarchy exists
- Fix the way active and disabled tabs are set initially in `sidebar.twig`
- Add `isGroup` to `SKOSMOS` object
- Cypress tests

## Known problems or uncertainties in this PR

The behavior of the sidebar now matches that of Skosmos 2, i.e. on a group page, hierarchy is always inaccessible. It could, however, be useful to be able to browse the hierarchy from group pages in vocabs with `showTopConcepts` set to true (e.g. `/yso/en/page/p26556`). The current tooltip message is also not very accurate in these cases.

## Checklist

- [ ] phpUnit tests pass locally with my changes
- [ ] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [ ] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [ ] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
