### PR TITLE
Add custom template slot to feedback page

### DIFF
--- a/custom-templates/feedback/README.txt
+++ b/custom-templates/feedback/README.txt
@@ -1,0 +1,1 @@
+Any *.twig files placed here will be included into the about page in alphabetical order.

--- a/src/view/feedback.twig
+++ b/src/view/feedback.twig
@@ -16,7 +16,7 @@
     <h1 class="mb-5">{{ 'Contact us!' | trans}}</h1>
     <div class="fs-5 mb-5">
       <p>{{ 'feedback_enter_name_email' | trans }}</p>
-      {{ include('custom-templates.inc.twig', {slotName: 'feedback', showPlaceholder: true}) }}
+      {{ include('custom-templates.inc.twig', {slotName: 'feedback'}) }}
     </div>
     
     <form id="feedback-form" method="post" action="{% if request.vocab %}{{request.vocab.id}}/{% endif %}{{ request.lang }}/feedback">

--- a/src/view/feedback.twig
+++ b/src/view/feedback.twig
@@ -14,7 +14,10 @@
   {% else %}
 
     <h1 class="mb-5">{{ 'Contact us!' | trans}}</h1>
-    <p class="fs-5 mb-5">{{ 'feedback_enter_name_email' | trans }}</p>
+    <div class="fs-5 mb-5">
+      <p>{{ 'feedback_enter_name_email' | trans }}</p>
+      {{ include('custom-templates.inc.twig', {slotName: 'feedback', showPlaceholder: true}) }}
+    </div>
     
     <form id="feedback-form" method="post" action="{% if request.vocab %}{{request.vocab.id}}/{% endif %}{{ request.lang }}/feedback">
       <div class="mb-4">


### PR DESCRIPTION
s## Reasons for creating this PR

Finto.fi needs to have custom content on the feedback page. This PR adds a custom template slot under the info paragraph.

## Description of the changes in this PR

- Add a directory to custom_templates for feedback page
- Add template slot to feedback.twig

## Known problems or uncertainties in this PR

## Checklist

- [ ] phpUnit tests pass locally with my changes
- [ ] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [ ] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [ ] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
