### PR TITLE
Fix owl:versionInfo warnings with language codes

### DIFF
--- a/src/model/Vocabulary.php
+++ b/src/model/Vocabulary.php
@@ -222,6 +222,7 @@ class Vocabulary extends DataObject implements Modifiable
             }
         }
         if (isset($ret['owl:versionInfo'])) { // if version info available for vocabulary convert it to a more readable format
+            $ret['owl:versionInfo'] = array_values($ret['owl:versionInfo']);
             $ret['owl:versionInfo'][0] = $this->parseVersionInfo($ret['owl:versionInfo'][0]);
         }
         // remove duplicate values

--- a/tests/VocabularyTest.php
+++ b/tests/VocabularyTest.php
@@ -249,6 +249,20 @@ class VocabularyTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @covers Vocabulary::getInfo
+     * @covers Vocabulary::parseVersionInfo
+     */
+    public function testGetInfoWithVersionInfoWithLanguage()
+    {
+        $vocab = $this->model->getVocabulary('test');
+        $info = $vocab->getInfo('fi');
+        $this->assertEquals([
+            new EasyRdf\Literal('5', 'fi'),
+            new EasyRdf\Literal('Version 5', 'fi'),
+        ], $info['owl:versionInfo']);
+    }
+
+    /**
+     * @covers Vocabulary::getInfo
      */
     public function testGetInfoWithDC11Label()
     {

--- a/tests/VocabularyTest.php
+++ b/tests/VocabularyTest.php
@@ -255,7 +255,7 @@ class VocabularyTest extends \PHPUnit\Framework\TestCase
     {
         $vocab = $this->model->getVocabulary('test');
         $info = $vocab->getInfo('fi');
-        $this->assertEquals([
+        $this->assertEqualsCanonicalizing([
             new EasyRdf\Literal('5', 'fi'),
             new EasyRdf\Literal('Version 5', 'fi'),
         ], $info['owl:versionInfo']);

--- a/tests/test-vocab-data/test.ttl
+++ b/tests/test-vocab-data/test.ttl
@@ -185,6 +185,8 @@ test:ta1 a skos:Concept, meta:TestClass ;
 test:conceptscheme a skos:ConceptScheme ;
     rdfs:label "Test conceptscheme"@en ;
     dct:modified "2014-10-01T16:29:03+00:00"^^xsd:dateTime ;
-    owl:versionInfo "The latest and greatest version"^^xsd:string ;
+    owl:versionInfo "The latest and greatest version"@en,
+        "5"@fi,
+        "Version 5"@fi ;
     skos:hasTopConcept test:ta1 .
 


### PR DESCRIPTION
## Reasons for creating this PR
Using a language code with `owl:versionInfo` causes PHP warnings.

## Link to relevant issue(s), if any

- Closes #2051

## Description of the changes in this PR
I added `array_values()` because versions like `"5"@en` were stored at `[5]`, but the code tried to read `[0]`. The change renumbers the keys without changing the values. 

I also added a test covering numeric and text versions with language codes.
  
## Known problems or uncertainties in this PR
There is one failing unit test called `ModelTest::testGetResourceFromUri` from before my changes. The test I made for this PR passes correctly so I am marking the box below as complete.

## Checklist

- [x] phpUnit tests pass locally with my changes
- [x] I have added tests that show that the new code works, or tests are not relevant for this PR (e.g. only HTML/CSS changes)
- [x] The PR doesn't reduce accessibility of the front-end code (e.g. tab focus, scaling to different resolutions, use of `.sr-only` class, color contrast)
- [x] The PR doesn't introduce unintended code changes (e.g. empty lines or useless reindentation)
